### PR TITLE
Harden PSPF policy parsing and trust enforcement

### DIFF
--- a/.github/workflows/05-code-quality.yml
+++ b/.github/workflows/05-code-quality.yml
@@ -703,13 +703,14 @@ jobs:
           echo "- Commands: \`make quality-python-fast\`, \`make quality-python-deep\`" >> $GITHUB_STEP_SUMMARY
           echo "- Intent categories: Unit / Integration / Cross-Language / Security / Adversarial / Property / Fuzz / Mutation / Smoke" >> $GITHUB_STEP_SUMMARY
           if [ -f coverage.json ]; then
-            python3 -c "
-import json
-from pathlib import Path
-data = json.loads(Path('coverage.json').read_text())
-totals = data.get('totals', {})
-print(f'- Coverage: {totals.get(\"percent_covered_display\", \"unknown\")}%')
-" >> $GITHUB_STEP_SUMMARY
+            python3 - <<'PY' >> $GITHUB_STEP_SUMMARY
+            import json
+            from pathlib import Path
+
+            data = json.loads(Path("coverage.json").read_text())
+            totals = data.get("totals", {})
+            print(f'- Coverage: {totals.get("percent_covered_display", "unknown")}%')
+            PY
           fi
 
       - name: 📤 Upload Python observability artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,7 +432,6 @@ jobs:
       - name: 🚀 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
           verbose: true
 

--- a/src/flavor-go/go.mod
+++ b/src/flavor-go/go.mod
@@ -3,6 +3,7 @@ module github.com/provide-io/flavor/go/flavor
 go 1.26.1
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/dsnet/compress v0.0.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/spf13/cobra v1.10.2

--- a/src/flavor-go/go.sum
+++ b/src/flavor-go/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/src/flavor-go/pkg/psp/format_2025/builder.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder.go
@@ -234,6 +234,12 @@ func doBuild(logger hclog.Logger, manifestPath, outputPath, launcherBin, private
 		logger.Debug("🎲 Using random key generation")
 	}
 	copy(index.PublicKey[:], publicKey[:32])
+	if fingerprint, err := ComputeKeyFingerprint(publicKey); err != nil {
+		logger.Error("❌ Failed to compute signing key fingerprint", "error", err)
+		os.Exit(1)
+	} else {
+		copy(index.AttestationKeyFp[:], fingerprint)
+	}
 
 	// Build metadata
 	var buildTimestamp string
@@ -791,7 +797,7 @@ func convertToResourceEmbedding(filePath string, launcherSize int64, logger hclo
 
 // getFileSize returns the size of a file
 func getFileSize(path string) (int64, error) {
-	info, err := os.Stat(path)
+	info, err := statValidated(path)
 	if err != nil {
 		return 0, err
 	}

--- a/src/flavor-go/pkg/psp/format_2025/builder_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -350,6 +351,13 @@ func TestDoBuildLoadsKeyFilesAndCarriesRuntimeMetadata(t *testing.T) {
 	}
 	if !bytes.Equal(index.PublicKey[:32], publicKey[:32]) {
 		t.Fatalf("expected index public key to match loaded key")
+	}
+	expectedFP, err := ComputeKeyFingerprint(publicKey)
+	if err != nil {
+		t.Fatalf("ComputeKeyFingerprint() error = %v", err)
+	}
+	if got := strings.TrimRight(string(index.AttestationKeyFp[:]), "\x00"); got != expectedFP {
+		t.Fatalf("expected attestation fingerprint %q, got %q", expectedFP, got)
 	}
 	if metadata.Execution == nil || metadata.Execution.Environment["APP_MODE"] != "test" {
 		t.Fatalf("expected execution environment metadata, got %#v", metadata.Execution)

--- a/src/flavor-go/pkg/psp/format_2025/execution.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution.go
@@ -155,21 +155,42 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 		return nil, fmt.Errorf("failed to read index: %w", err)
 	}
 
-	// Check signing key trust status.
-	// keyTrusted is false only when the trusted store exists AND the key is explicitly absent.
-	// It stays true when: no attestation fingerprint, store missing (nil), or key is trusted.
-	keyTrusted := true
-	if fp := strings.TrimRight(string(index.AttestationKeyFp[:]), "\x00"); fp != "" {
-		trusted, err := IsKeyTrusted(fp, true)
-		if err != nil {
-			logger.Warn("⚠️ Failed to check trusted key store", "error", err)
-		} else if trusted != nil && !*trusted {
-			keyTrusted = false
-			fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package signing key is not in the trusted store\n")
-			fmt.Fprintf(os.Stderr, "⚠️ Key fingerprint: %s\n", fp)
-			fmt.Fprintf(os.Stderr, "⚠️ Use 'flavor trust add <key-file>' to trust this key\n")
-			logger.Warn("⚠️ Package signing key not in trusted store", "fingerprint", fp)
+	// Check signing key trust status from the embedded public key.
+	// The attestation fingerprint, when present, must match the derived public-key fingerprint.
+	keyTrusted := false
+	hasPublicKey := false
+	for _, b := range index.PublicKey {
+		if b != 0 {
+			hasPublicKey = true
+			break
 		}
+	}
+	attestationFP := strings.TrimRight(string(index.AttestationKeyFp[:]), "\x00")
+	if hasPublicKey {
+		fp, err := ComputeKeyFingerprint(index.PublicKey[:])
+		if err != nil {
+			logger.Warn("⚠️ Failed to derive signing key fingerprint", "error", err)
+		} else {
+			if attestationFP != "" && attestationFP != fp {
+				return nil, fmt.Errorf("attestation key fingerprint does not match embedded public key")
+			}
+
+			trusted, err := IsKeyTrusted(fp, true)
+			if err != nil {
+				logger.Warn("⚠️ Failed to check trusted key store", "error", err)
+			} else if trusted == nil {
+				logger.Warn("⚠️ No trusted-keys store found; requiring a trusted key will fail closed", "fingerprint", fp)
+			} else if *trusted {
+				keyTrusted = true
+			} else {
+				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package signing key is not in the trusted store\n")
+				fmt.Fprintf(os.Stderr, "⚠️ Key fingerprint: %s\n", fp)
+				fmt.Fprintf(os.Stderr, "⚠️ Use 'flavor trust add <key-file>' to trust this key\n")
+				logger.Warn("⚠️ Package signing key not in trusted store", "fingerprint", fp)
+			}
+		}
+	} else if attestationFP != "" {
+		return nil, fmt.Errorf("attestation key fingerprint is present but public key is missing")
 	}
 
 	validationLevel := getValidationLevel()
@@ -262,8 +283,8 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 	// Policy enforcement
 	opPolicy, policyErr := LoadOperatorPolicy()
 	if policyErr != nil {
-		fmt.Fprintf(os.Stderr, "WARN: failed to load operator policy: %v\n", policyErr)
-		opPolicy = OperatorPolicy{}
+		logger.Error("❌ Failed to load operator policy", "error", policyErr)
+		return nil, fmt.Errorf("failed to load operator policy: %w", policyErr)
 	}
 
 	var pkgPolicy PackagePolicy
@@ -281,7 +302,12 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 		}
 	}
 
-	if enforceErr := EnforcePolicy(effective, int64(index.BuildTimestamp), hasSBOM, keyTrusted); enforceErr != nil {
+	buildTimestamp, tsErr := uint64ToInt64Checked(index.BuildTimestamp, "build timestamp")
+	if tsErr != nil {
+		logger.Error("❌ Invalid build timestamp", "error", tsErr)
+		return nil, fmt.Errorf("invalid build timestamp: %w", tsErr)
+	}
+	if enforceErr := EnforcePolicy(effective, buildTimestamp, hasSBOM, keyTrusted); enforceErr != nil {
 		logger.Error("❌ Policy violation", "error", enforceErr)
 		return nil, fmt.Errorf("policy violation: %w", enforceErr)
 	}
@@ -306,7 +332,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 	// Convert to forward slashes for command string substitution on Windows
 	// This prevents backslashes from being treated as escape characters by the shell parser
 	workenvDirForCmd := filepath.ToSlash(workenvDir)
-	if err := os.MkdirAll(workenvDir, os.FileMode(DirPerms)); err != nil {
+	if err := mkdirAllValidated(workenvDir, os.FileMode(DirPerms)); err != nil {
 		logger.Error("❌ Failed to create work environment directory", "error", err)
 		return nil, fmt.Errorf("failed to create work environment directory: %w", err)
 	}
@@ -322,7 +348,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 				return nil, fmt.Errorf("directory path %q escapes work environment directory", dirSpec.Path)
 			}
 			logger.Debug("📁 Creating directory", "path", dirPath)
-			if err := os.MkdirAll(dirPath, os.FileMode(DirPerms)); err != nil {
+			if err := mkdirAllValidated(dirPath, os.FileMode(DirPerms)); err != nil {
 				logger.Error("❌ Failed to create directory", "path", dirPath, "error", err)
 				return nil, fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 			}
@@ -332,7 +358,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 				// Parse octal mode string (e.g., "0700")
 				mode, err := strconv.ParseUint(strings.TrimPrefix(dirSpec.Mode, "0"), 8, 32)
 				if err == nil {
-					if err := os.Chmod(dirPath, os.FileMode(mode)); err != nil {
+					if err := chmodValidated(dirPath, os.FileMode(mode)); err != nil {
 						logger.Debug("Failed to set permissions", "path", dirPath, "mode", dirSpec.Mode, "error", err)
 					} else {
 						logger.Debug("🔒 Set permissions", "path", dirPath, "mode", dirSpec.Mode)
@@ -416,7 +442,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 	if !workenvValid && len(metadata.SetupCommands) > 0 {
 		logger.Info("🔧 Running setup commands", "count", len(metadata.SetupCommands))
 		metadataDir := filepath.Join(workenvDir, "metadata")
-		if err := os.MkdirAll(metadataDir, os.FileMode(DirPerms)); err != nil {
+		if err := mkdirAllValidated(metadataDir, os.FileMode(DirPerms)); err != nil {
 			logger.Error("❌ Failed to create metadata directory", "error", err)
 			return nil, fmt.Errorf("failed to create metadata directory: %w", err)
 		}
@@ -466,12 +492,12 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 					content, _ := cmd["content"].(string)
 
 					path = strings.ReplaceAll(path, "{workenv}", workenvDir)
+					path = strings.ReplaceAll(path, "{package_name}", metadata.Package.Name)
+					path = strings.ReplaceAll(path, "{version}", metadata.Package.Version)
 					if err := ensurePathWithinWorkenv(path, workenvDir, path); err != nil {
 						logger.Error("❌ Write-file path escapes work environment directory", "path", path, "error", err)
 						return nil, err
 					}
-					path = strings.ReplaceAll(path, "{package_name}", metadata.Package.Name)
-					path = strings.ReplaceAll(path, "{version}", metadata.Package.Version)
 
 					content = strings.ReplaceAll(content, "{workenv}", workenvDirForCmd)
 					content = strings.ReplaceAll(content, "{package_name}", metadata.Package.Name)
@@ -479,10 +505,15 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 
 					mode := os.FileMode(0644)
 					if modeFloat, ok := cmd["mode"].(float64); ok {
-						mode = os.FileMode(int(modeFloat))
+						modeChecked, modeErr := float64ToFileModeChecked(modeFloat, "setup command mode")
+						if modeErr != nil {
+							logger.Error("❌ Invalid setup file mode", "mode", modeFloat, "error", modeErr)
+							return nil, modeErr
+						}
+						mode = modeChecked
 					}
 
-					if err := os.WriteFile(path, []byte(content+"\n"), mode); err != nil {
+					if err := writeFileValidated(path, []byte(content+"\n"), mode); err != nil {
 						logger.Error("❌ Failed to write file", "path", path, "error", err)
 						return nil, fmt.Errorf("failed to write file %s: %w", path, err)
 					}
@@ -507,7 +538,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 				if len(cmdArgs) > 0 {
 					// Resolve executable for cross-platform compatibility
 					resolvedCmd := resolveExecutable(cmdToRun, logger)
-					setupExec = exec.Command(resolvedCmd, cmdArgs...)
+					setupExec = execCommandValidated(resolvedCmd, cmdArgs...)
 				} else {
 					// Use shell-aware parser to handle quoted arguments
 					parts, err := shellparse.Split(cmdToRun)
@@ -520,7 +551,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 					}
 					// Resolve executable for cross-platform compatibility
 					resolvedExec := resolveExecutable(parts[0], logger)
-					setupExec = exec.Command(resolvedExec, parts[1:]...)
+					setupExec = execCommandValidated(resolvedExec, parts[1:]...)
 				}
 
 				setupExec.Dir = userCwd
@@ -595,7 +626,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger hclo
 
 	// Resolve executable for cross-platform compatibility
 	resolvedExec := resolveExecutable(parts[0], logger)
-	cmd := exec.Command(resolvedExec, cmdArgs...)
+	cmd := execCommandValidated(resolvedExec, cmdArgs...)
 
 	originalCmd := os.Args[0]
 	binaryName := filepath.Base(originalCmd)

--- a/src/flavor-go/pkg/psp/format_2025/execution_policy.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_policy.go
@@ -9,8 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
+
+	toml "github.com/BurntSushi/toml"
+)
+
+var (
+	getSystemPolicyFileImpl = getSystemPolicyFile
+	getUserPolicyFileImpl   = getUserPolicyFile
 )
 
 // PackagePolicy mirrors the Python PackagePolicy struct.
@@ -38,31 +44,34 @@ type EffectivePolicy struct {
 	MaxAgeDays        *int
 	RequireEnv        []string
 	RequireTrustedKey bool
+	UseOsKeychain     bool
 	RequireSBOM       bool
 }
 
 // LoadOperatorPolicy reads system and user policy.toml files.
-// Returns permissive defaults if the files do not exist.
+// Missing files are allowed; unreadable or invalid files are errors.
 func LoadOperatorPolicy() (OperatorPolicy, error) {
 	policy := OperatorPolicy{}
 
 	paths := []string{
-		getSystemPolicyFile(),
-		getUserPolicyFile(),
+		getSystemPolicyFileImpl(),
+		getUserPolicyFileImpl(),
 	}
 
 	for _, path := range paths {
 		if path == "" {
 			continue
 		}
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) // #nosec G304 -- policy files come from fixed config locations
 		if os.IsNotExist(err) {
 			continue
 		}
 		if err != nil {
 			return policy, fmt.Errorf("reading policy %s: %w", path, err)
 		}
-		parseMinimalTOML(data, &policy)
+		if err := applyOperatorPolicyTOML(data, &policy); err != nil {
+			return policy, fmt.Errorf("parsing policy %s: %w", path, err)
+		}
 	}
 	return policy, nil
 }
@@ -90,67 +99,207 @@ func getUserPolicyFile() string {
 	return ""
 }
 
-// parseMinimalTOML is a line-by-line parser for the small subset of TOML used
-// in policy.toml: [section] headers and key = value bool/int/string-list lines.
-func parseMinimalTOML(data []byte, policy *OperatorPolicy) {
-	section := ""
-	for _, rawLine := range strings.Split(string(data), "\n") {
-		line := strings.TrimSpace(rawLine)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section = strings.ToLower(line[1 : len(line)-1])
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		val := strings.TrimSpace(parts[1])
-		// Strip inline comments
-		if idx := strings.Index(val, "#"); idx != -1 {
-			val = strings.TrimSpace(val[:idx])
-		}
+func applyOperatorPolicyTOML(data []byte, policy *OperatorPolicy) error {
+	var raw map[string]any
+	if _, err := toml.Decode(string(data), &raw); err != nil {
+		return err
+	}
 
-		switch section + "." + key {
-		case "trust.require_trusted_key":
-			policy.RequireTrustedKey = val == "true"
-		case "trust.use_os_keychain":
-			policy.UseOsKeychain = val == "true"
-		case "execution.refuse_root":
-			policy.RefuseRoot = val == "true"
-		case "execution.max_age_days":
-			var n int
-			if _, err := fmt.Sscanf(val, "%d", &n); err == nil {
-				policy.MaxAgeDays = &n
-			}
-		case "execution.allow_platforms":
-			// Parse a TOML string list: ["linux_amd64", "linux_arm64"]
-			policy.AllowPlatforms = parseTOMLStringList(val)
-		case "attestation.require_sbom":
-			policy.RequireSBOM = val == "true"
+	for key := range raw {
+		switch key {
+		case "trust", "execution", "attestation":
+		default:
+			return fmt.Errorf("unknown policy section %q", key)
 		}
+	}
+
+	if section, ok := raw["trust"]; ok {
+		if err := applyTrustPolicySection(section, policy); err != nil {
+			return err
+		}
+	}
+	if section, ok := raw["execution"]; ok {
+		if err := applyExecutionPolicySection(section, policy); err != nil {
+			return err
+		}
+	}
+	if section, ok := raw["attestation"]; ok {
+		if err := applyAttestationPolicySection(section, policy); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func applyTrustPolicySection(raw any, policy *OperatorPolicy) error {
+	section, err := mustPolicySection("trust", raw)
+	if err != nil {
+		return err
+	}
+	for key := range section {
+		switch key {
+		case "require_trusted_key", "use_os_keychain":
+		default:
+			return fmt.Errorf("unknown key %q in [trust]", key)
+		}
+	}
+
+	if value, ok := section["require_trusted_key"]; ok {
+		b, err := mustBool("trust.require_trusted_key", value)
+		if err != nil {
+			return err
+		}
+		policy.RequireTrustedKey = b
+	}
+	if value, ok := section["use_os_keychain"]; ok {
+		b, err := mustBool("trust.use_os_keychain", value)
+		if err != nil {
+			return err
+		}
+		policy.UseOsKeychain = b
+	}
+
+	return nil
+}
+
+func applyExecutionPolicySection(raw any, policy *OperatorPolicy) error {
+	section, err := mustPolicySection("execution", raw)
+	if err != nil {
+		return err
+	}
+	for key := range section {
+		switch key {
+		case "refuse_root", "max_age_days", "allow_platforms":
+		default:
+			return fmt.Errorf("unknown key %q in [execution]", key)
+		}
+	}
+
+	if value, ok := section["refuse_root"]; ok {
+		b, err := mustBool("execution.refuse_root", value)
+		if err != nil {
+			return err
+		}
+		policy.RefuseRoot = b
+	}
+	if value, ok := section["max_age_days"]; ok {
+		n, err := mustInt("execution.max_age_days", value)
+		if err != nil {
+			return err
+		}
+		policy.MaxAgeDays = &n
+	}
+	if value, ok := section["allow_platforms"]; ok {
+		platforms, err := mustStringList("execution.allow_platforms", value)
+		if err != nil {
+			return err
+		}
+		policy.AllowPlatforms = platforms
+	}
+
+	return nil
+}
+
+func applyAttestationPolicySection(raw any, policy *OperatorPolicy) error {
+	section, err := mustPolicySection("attestation", raw)
+	if err != nil {
+		return err
+	}
+	for key := range section {
+		switch key {
+		case "require_sbom":
+		default:
+			return fmt.Errorf("unknown key %q in [attestation]", key)
+		}
+	}
+
+	if value, ok := section["require_sbom"]; ok {
+		b, err := mustBool("attestation.require_sbom", value)
+		if err != nil {
+			return err
+		}
+		policy.RequireSBOM = b
+	}
+
+	return nil
+}
+
+func mustPolicySection(sectionName string, raw any) (map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	section, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("policy section %q must be a table, got %T", sectionName, raw)
+	}
+	return section, nil
+}
+
+func mustBool(fieldName string, raw any) (bool, error) {
+	value, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("policy field %s must be a boolean, got %T", fieldName, raw)
+	}
+	return value, nil
+}
+
+func mustInt(fieldName string, raw any) (int, error) {
+	maxInt := int(^uint(0) >> 1)
+	switch value := raw.(type) {
+	case int:
+		return value, nil
+	case int8:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case int16:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case int32:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case int64:
+		if value > int64(maxInt) || value < -int64(maxInt)-1 {
+			return 0, fmt.Errorf("policy field %s is out of range for int", fieldName)
+		}
+		return int(value), nil // #nosec G115 -- range checked above
+	case uint:
+		if value > uint(maxInt) {
+			return 0, fmt.Errorf("policy field %s is out of range for int", fieldName)
+		}
+		return int(value), nil // #nosec G115 -- range checked above
+	case uint8:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case uint16:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case uint32:
+		return int(value), nil // #nosec G115 -- bounded integer conversion
+	case uint64:
+		if value > uint64(maxInt) {
+			return 0, fmt.Errorf("policy field %s is out of range for int", fieldName)
+		}
+		return int(value), nil // #nosec G115 -- range checked above
+	default:
+		return 0, fmt.Errorf("policy field %s must be an integer, got %T", fieldName, raw)
 	}
 }
 
-// parseTOMLStringList parses a TOML array like ["a", "b"] or ['a', 'b'].
-func parseTOMLStringList(val string) []string {
-	val = strings.TrimSpace(val)
-	if !strings.HasPrefix(val, "[") || !strings.HasSuffix(val, "]") {
-		return nil
-	}
-	inner := val[1 : len(val)-1]
-	var result []string
-	for _, item := range strings.Split(inner, ",") {
-		item = strings.TrimSpace(item)
-		item = strings.Trim(item, `"'`)
-		if item != "" {
-			result = append(result, item)
+func mustStringList(fieldName string, raw any) ([]string, error) {
+	switch value := raw.(type) {
+	case []string:
+		result := make([]string, len(value))
+		copy(result, value)
+		return result, nil
+	case []any:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("policy field %s must contain only strings, got %T", fieldName, item)
+			}
+			result = append(result, s)
 		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("policy field %s must be a string list, got %T", fieldName, raw)
 	}
-	return result
 }
 
 // MergePolicy produces an EffectivePolicy where stricter always wins.
@@ -192,6 +341,7 @@ func MergePolicy(pkg PackagePolicy, op OperatorPolicy) EffectivePolicy {
 
 	effective.RequireEnv = pkg.RequireEnv
 	effective.RequireTrustedKey = op.RequireTrustedKey
+	effective.UseOsKeychain = op.UseOsKeychain
 	effective.RequireSBOM = op.RequireSBOM
 
 	return effective
@@ -215,6 +365,10 @@ func EnforcePolicy(policy EffectivePolicy, buildTimestamp int64, hasSBOM bool, k
 		if !found {
 			return fmt.Errorf("platform not permitted: %s not in %v", currentPlatform, policy.Platforms)
 		}
+	}
+
+	if policy.UseOsKeychain {
+		return fmt.Errorf("use_os_keychain is not supported by this launcher")
 	}
 
 	// 2. Root / Administrator check

--- a/src/flavor-go/pkg/psp/format_2025/execution_policy_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_policy_test.go
@@ -43,6 +43,21 @@ func TestMergePolicy_MaxAgeDays(t *testing.T) {
 	}
 }
 
+func TestMergePolicy_OperatorFlagsPropagated(t *testing.T) {
+	pkg := PackagePolicy{}
+	op := OperatorPolicy{RequireTrustedKey: true, UseOsKeychain: true, RequireSBOM: true}
+	eff := MergePolicy(pkg, op)
+	if !eff.RequireTrustedKey {
+		t.Fatal("expected require_trusted_key to propagate")
+	}
+	if !eff.UseOsKeychain {
+		t.Fatal("expected use_os_keychain to propagate")
+	}
+	if !eff.RequireSBOM {
+		t.Fatal("expected require_sbom to propagate")
+	}
+}
+
 func TestMergePolicy_Platforms_Intersection(t *testing.T) {
 	pkg := PackagePolicy{Platforms: []string{"linux_amd64", "darwin_arm64"}}
 	op := OperatorPolicy{AllowPlatforms: []string{"linux_amd64", "linux_arm64"}}
@@ -74,6 +89,13 @@ func TestEnforcePolicy_Permissive(t *testing.T) {
 	eff := EffectivePolicy{}
 	if err := EnforcePolicy(eff, 0, false, true); err != nil {
 		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestEnforcePolicy_UseOsKeychainUnsupported(t *testing.T) {
+	eff := EffectivePolicy{UseOsKeychain: true}
+	if err := EnforcePolicy(eff, 0, false, true); err == nil {
+		t.Fatal("expected use_os_keychain to be rejected")
 	}
 }
 
@@ -195,33 +217,6 @@ func TestLoadOperatorPolicy_WithFile(t *testing.T) {
 	}
 }
 
-func TestParseMinimalTOML_MaxAgeDays(t *testing.T) {
-	content := "[execution]\nmax_age_days = 90\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
-	if policy.MaxAgeDays == nil || *policy.MaxAgeDays != 90 {
-		t.Errorf("expected max_age_days=90, got %v", policy.MaxAgeDays)
-	}
-}
-
-func TestParseMinimalTOML_RequireSBOM(t *testing.T) {
-	content := "[attestation]\nrequire_sbom = true\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
-	if !policy.RequireSBOM {
-		t.Error("expected require_sbom=true")
-	}
-}
-
-func TestParseMinimalTOML_IgnoresComments(t *testing.T) {
-	content := "# comment\n[trust]\n# another comment\nrequire_trusted_key = true\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
-	if !policy.RequireTrustedKey {
-		t.Error("expected require_trusted_key=true after ignoring comments")
-	}
-}
-
 func TestGetUserPolicyFile_XDG(t *testing.T) {
 	t.Setenv(EnvConfigDir, "")
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg")
@@ -252,27 +247,6 @@ func TestGetUserPolicyFile_NoEnv(t *testing.T) {
 	_ = getUserPolicyFile()
 }
 
-func TestParseMinimalTOML_InlineComment(t *testing.T) {
-	content := "[execution]\nrefuse_root = true # disable if needed\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
-	if !policy.RefuseRoot {
-		t.Error("expected refuse_root=true after stripping inline comment")
-	}
-}
-
-func TestParseMinimalTOML_AllowPlatforms(t *testing.T) {
-	content := "[execution]\nallow_platforms = [\"linux_amd64\", \"linux_arm64\"]\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
-	if len(policy.AllowPlatforms) != 2 {
-		t.Errorf("expected 2 platforms, got %d: %v", len(policy.AllowPlatforms), policy.AllowPlatforms)
-	}
-	if policy.AllowPlatforms[0] != "linux_amd64" {
-		t.Errorf("expected linux_amd64, got %s", policy.AllowPlatforms[0])
-	}
-}
-
 func TestLoadOperatorPolicyReturnsErrorWhenPolicyPathIsDirectory(t *testing.T) {
 	dir := t.TempDir()
 	policyDir := filepath.Join(dir, "policy.toml")
@@ -287,25 +261,54 @@ func TestLoadOperatorPolicyReturnsErrorWhenPolicyPathIsDirectory(t *testing.T) {
 	}
 }
 
-func TestParseMinimalTOMLParsesExtendedFieldsAndListFallback(t *testing.T) {
-	content := "[trust]\nuse_os_keychain = true\n[execution]\nmax_age_days = not-a-number\nallow_platforms = ['linux_amd64', \"linux_arm64\"]\n[attestation]\nrequire_sbom = true\n"
-	policy := OperatorPolicy{}
-	parseMinimalTOML([]byte(content), &policy)
+func TestLoadOperatorPolicyRejectsMalformedUserPolicy(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.toml")
+	if err := os.WriteFile(policyPath, []byte("[broken toml\nnot valid ===\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
+	}
 
-	if !policy.UseOsKeychain {
-		t.Fatal("expected use_os_keychain=true")
+	t.Setenv(EnvConfigDir, dir)
+	_, err := LoadOperatorPolicy()
+	if err == nil {
+		t.Fatal("expected malformed user policy to fail closed")
 	}
-	if policy.MaxAgeDays != nil {
-		t.Fatalf("expected invalid max_age_days to be ignored, got %v", policy.MaxAgeDays)
+}
+
+func TestLoadOperatorPolicyRejectsMalformedSystemPolicy(t *testing.T) {
+	dir := t.TempDir()
+	systemPath := filepath.Join(dir, "system-policy.toml")
+	if err := os.WriteFile(systemPath, []byte("[broken toml\nnot valid ===\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(system policy) error = %v", err)
 	}
-	if !policy.RequireSBOM {
-		t.Fatal("expected require_sbom=true")
+
+	oldSystem := getSystemPolicyFileImpl
+	oldUser := getUserPolicyFileImpl
+	t.Cleanup(func() {
+		getSystemPolicyFileImpl = oldSystem
+		getUserPolicyFileImpl = oldUser
+	})
+
+	getSystemPolicyFileImpl = func() string { return systemPath }
+	getUserPolicyFileImpl = func() string { return filepath.Join(dir, "missing-user-policy.toml") }
+
+	_, err := LoadOperatorPolicy()
+	if err == nil {
+		t.Fatal("expected malformed system policy to fail closed")
 	}
-	if len(policy.AllowPlatforms) != 2 || policy.AllowPlatforms[0] != "linux_amd64" || policy.AllowPlatforms[1] != "linux_arm64" {
-		t.Fatalf("unexpected allow_platforms: %v", policy.AllowPlatforms)
+}
+
+func TestLoadOperatorPolicyRejectsUnknownUserPolicyKey(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.toml")
+	if err := os.WriteFile(policyPath, []byte("[trust]\nrequire_trusted_key = true\nunexpected = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
 	}
-	if got := parseTOMLStringList("not-a-list"); got != nil {
-		t.Fatalf("parseTOMLStringList() = %v, want nil for invalid input", got)
+
+	t.Setenv(EnvConfigDir, dir)
+	_, err := LoadOperatorPolicy()
+	if err == nil {
+		t.Fatal("expected unknown user policy key to fail closed")
 	}
 }
 

--- a/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
@@ -4,10 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -240,6 +245,79 @@ func buildRawBundleForTests(t *testing.T, slotDescriptors []SlotDescriptor, meta
 	}
 
 	return bundlePath
+}
+
+func buildSignedBundleForPolicyTests(t *testing.T, manifest BuildOptions) string {
+	t.Helper()
+
+	if manifest.Package.Name == "" {
+		manifest.Package.Name = "demo"
+	}
+	if manifest.Package.Version == "" {
+		manifest.Package.Version = "1.0.0"
+	}
+	if manifest.Execution.Command == "" {
+		manifest.Execution.Command = "/bin/true"
+	}
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	outputPath := filepath.Join(dir, "bundle.psp")
+	launcherPath := filepath.Join(dir, "launcher.sh")
+	privateKeyPath := filepath.Join(dir, "private.pem")
+	publicKeyPath := filepath.Join(dir, "public.pem")
+
+	if err := os.WriteFile(launcherPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(launcher) error = %v", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error = %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey() error = %v", err)
+	}
+	if err := os.WriteFile(privateKeyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}), 0o600); err != nil {
+		t.Fatalf("WriteFile(private key) error = %v", err)
+	}
+	if err := os.WriteFile(publicKeyPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}), 0o600); err != nil {
+		t.Fatalf("WriteFile(public key) error = %v", err)
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("json.Marshal(manifest) error = %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestJSON, 0o600); err != nil {
+		t.Fatalf("WriteFile(manifest) error = %v", err)
+	}
+
+	doBuild(hclog.NewNullLogger(), manifestPath, outputPath, launcherPath, privateKeyPath, publicKeyPath, "")
+	return outputPath
+}
+
+func patchBundleBuildTimestamp(t *testing.T, bundlePath string, buildTimestamp uint64) {
+	t.Helper()
+
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatalf("ReadFile(bundle) error = %v", err)
+	}
+	if len(data) < MagicTrailerSize {
+		t.Fatalf("bundle too small to patch build timestamp: %d", len(data))
+	}
+
+	trailerStart := len(data) - MagicTrailerSize
+	binary.LittleEndian.PutUint64(data[trailerStart+4+704:trailerStart+4+712], buildTimestamp)
+	if err := os.WriteFile(bundlePath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(bundle) error = %v", err)
+	}
 }
 
 // This test only proves the non-Windows/appended-EOF path. The PE-resource
@@ -1153,6 +1231,221 @@ func TestRunBundleWithCwdRejectsPolicyViolation(t *testing.T) {
 	logger := hclog.NewNullLogger()
 	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), logger); err == nil || !strings.Contains(err.Error(), "policy violation") {
 		t.Fatalf("runBundleWithCwd() error = %v, want policy violation", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsUnsignedBundleWhenTrustedKeyRequired(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+	t.Setenv(EnvTrustedKeysDir, filepath.Join(t.TempDir(), "missing-trusted-keys"))
+
+	policyDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.toml"), []byte("[trust]\nrequire_trusted_key = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
+	}
+	t.Setenv(EnvConfigDir, policyDir)
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta: SlotMetadata{
+				ID:     "policy-slot",
+				Target: "{workenv}",
+			},
+			storedData:   []byte("payload"),
+			originalData: []byte("payload"),
+			permissions:  0o644,
+		},
+	}, Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "demo", Version: "1.0.0"},
+		Execution:     &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:         &BuildInfo{Tool: "flavor-go"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "policy violation") {
+		t.Fatalf("runBundleWithCwd() error = %v, want require_trusted_key failure", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsSignedBundleWhenTrustedKeyStoreMissing(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+	t.Setenv(EnvTrustedKeysDir, filepath.Join(t.TempDir(), "missing-trusted-keys"))
+
+	policyDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.toml"), []byte("[trust]\nrequire_trusted_key = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
+	}
+	t.Setenv(EnvConfigDir, policyDir)
+
+	bundle := buildSignedBundleForPolicyTests(t, BuildOptions{
+		Package:   PackageConfig{Name: "signed-demo", Version: "1.0.0"},
+		Execution: ExecutionConfig{Command: "/bin/true"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "policy violation") {
+		t.Fatalf("runBundleWithCwd() error = %v, want missing trust-store failure", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsUnsupportedOsKeychainPolicy(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+
+	policyDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.toml"), []byte("[trust]\nuse_os_keychain = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
+	}
+	t.Setenv(EnvConfigDir, policyDir)
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta: SlotMetadata{
+				ID:     "policy-slot",
+				Target: "{workenv}",
+			},
+			storedData:   []byte("payload"),
+			originalData: []byte("payload"),
+			permissions:  0o644,
+		},
+	}, Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "demo", Version: "1.0.0"},
+		Execution:     &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:         &BuildInfo{Tool: "flavor-go"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "policy violation") {
+		t.Fatalf("runBundleWithCwd() error = %v, want unsupported keychain policy failure", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsInvalidOperatorPolicyFile(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+
+	policyDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.toml"), []byte("[trust\nrequire_trusted_key = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(policy) error = %v", err)
+	}
+	t.Setenv(EnvConfigDir, policyDir)
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta: SlotMetadata{
+				ID:     "policy-slot",
+				Target: "{workenv}",
+			},
+			storedData:   []byte("payload"),
+			originalData: []byte("payload"),
+			permissions:  0o644,
+		},
+	}, Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "demo", Version: "1.0.0"},
+		Execution:     &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:         &BuildInfo{Tool: "flavor-go"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "failed to load operator policy") {
+		t.Fatalf("runBundleWithCwd() error = %v, want invalid policy failure", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsWriteFilePathEscapeViaPackageNamePlaceholder(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta: SlotMetadata{
+				ID:     "dir-slot",
+				Target: "{workenv}",
+			},
+			storedData:   []byte("payload"),
+			originalData: []byte("payload"),
+			permissions:  0o644,
+		},
+	}, Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "../escape", Version: "1.0.0"},
+		SetupCommands: []interface{}{map[string]interface{}{
+			"type":    "write_file",
+			"path":    "{workenv}/{package_name}.txt",
+			"content": "hello",
+		}},
+		Execution: &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:     &BuildInfo{Tool: "flavor-go"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "escapes work environment directory") {
+		t.Fatalf("runBundleWithCwd() error = %v, want write_file path escape failure", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsBuildTimestampOverflow(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+
+	bundle := buildSignedBundleForPolicyTests(t, BuildOptions{
+		Package:   PackageConfig{Name: "signed-demo", Version: "1.0.0"},
+		Execution: ExecutionConfig{Command: "/bin/true"},
+	})
+	patchBundleBuildTimestamp(t, bundle, math.MaxInt64+1)
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "invalid build timestamp") {
+		t.Fatalf("runBundleWithCwd() error = %v, want invalid build timestamp", err)
+	}
+}
+
+func TestRunBundleWithCwdRejectsOutOfRangeWriteFileMode(t *testing.T) {
+	t.Setenv(EnvCacheDir, t.TempDir())
+	t.Setenv(EnvValidation, "none")
+	t.Setenv(EnvWorkenvCache, "false")
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta: SlotMetadata{
+				ID:     "policy-slot",
+				Target: "{workenv}",
+			},
+			storedData:   []byte("payload"),
+			originalData: []byte("payload"),
+			permissions:  0o644,
+		},
+	}, Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "demo", Version: "1.0.0"},
+		Workenv: &WorkenvInfo{
+			Directories: []DirectorySpec{
+				{Path: "{workenv}/metadata", Mode: "0700"},
+			},
+		},
+		SetupCommands: []interface{}{
+			map[string]interface{}{
+				"type":    "write_file",
+				"path":    "{workenv}/metadata/generated.txt",
+				"content": "hello",
+				"mode":    float64(math.MaxUint32) + 1,
+			},
+		},
+		Execution: &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:     &BuildInfo{Tool: "flavor-go"},
+	})
+
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), hclog.NewNullLogger()); err == nil || !strings.Contains(err.Error(), "setup command mode") {
+		t.Fatalf("runBundleWithCwd() error = %v, want setup command mode range failure", err)
 	}
 }
 

--- a/src/flavor-go/pkg/psp/format_2025/pe_resources.go
+++ b/src/flavor-go/pkg/psp/format_2025/pe_resources.go
@@ -6,11 +6,9 @@ package format_2025
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/tc-hib/winres"
-	"golang.org/x/sys/windows"
 )
 
 const (
@@ -138,6 +136,9 @@ func EmbedPSPFAsResource(exePath string, pspfData []byte, logger hclog.Logger) e
 // This is used by the launcher to read embedded PSPF data instead of reading
 // from the end of the file.
 //
+// Uses the winres library (pure-Go PE parser) to avoid any unsafe.Pointer conversions
+// that would be required by the Windows LoadLibraryEx/LockResource API path.
+//
 // Parameters:
 //
 //	exePath: Path to the PE executable (usually os.Args[0])
@@ -147,67 +148,28 @@ func EmbedPSPFAsResource(exePath string, pspfData []byte, logger hclog.Logger) e
 func ReadPSPFFromResource(exePath string, logger hclog.Logger) ([]byte, error) {
 	logger.Debug("Reading PSPF from PE resources", "exe", exePath)
 
-	// Load the EXE as a data file (read-only, no code execution)
-	handle, err := windows.LoadLibraryEx(
-		exePath,
-		0,
-		windows.LOAD_LIBRARY_AS_DATAFILE,
-	)
+	f, err := os.Open(exePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load EXE as data file: %w", err)
+		return nil, fmt.Errorf("failed to open EXE for resource read: %w", err)
 	}
-	defer windows.FreeLibrary(handle)
+	defer f.Close()
 
-	logger.Debug("Loaded EXE as data file", "handle", handle)
-
-	// Find the PSPF resource by name (string) and type (ResourceID)
-	resInfo, err := windows.FindResource(
-		handle,
-		PSPF_RESOURCE_NAME,
-		windows.RT_RCDATA,
-	)
+	// Load only the PSPF resource type to avoid parsing all resources.
+	rs, err := winres.LoadFromEXESingleType(f, PSPF_RESOURCE_TYPE)
 	if err != nil {
-		return nil, fmt.Errorf("PSPF resource not found (type=%d, name=%s): %w",
+		return nil, fmt.Errorf("PSPF resource not found in PE (type=%d, name=%s): %w",
 			PSPF_RESOURCE_TYPE, PSPF_RESOURCE_NAME, err)
 	}
 
-	logger.Debug("Found PSPF resource", "info", resInfo)
-
-	// Load the resource data
-	resData, err := windows.LoadResource(handle, resInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load resource data: %w", err)
+	// Get returns nil when the resource does not exist.
+	data := rs.Get(PSPF_RESOURCE_TYPE, winres.Name(PSPF_RESOURCE_NAME), PSPF_RESOURCE_LANG)
+	if data == nil {
+		return nil, fmt.Errorf("PSPF resource not found (type=%d, name=%s)", PSPF_RESOURCE_TYPE, PSPF_RESOURCE_NAME)
 	}
-
-	// Get resource size
-	size, err := windows.SizeofResource(handle, resInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resource size: %w", err)
-	}
-	if size == 0 {
-		return nil, fmt.Errorf("resource has zero size")
-	}
-
-	logger.Debug("Resource loaded", "size", size)
-
-	// Lock the resource and get pointer to data
-	ptr, err := windows.LockResource(resData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to lock resource: %w", err)
-	}
-	if ptr == 0 {
-		return nil, fmt.Errorf("lock resource returned null pointer")
-	}
-
-	// Copy the data (Windows resource data is read-only)
-	// We create a slice backed by the resource memory, then copy it
-	resourceSlice := (*[1 << 30]byte)(unsafe.Pointer(ptr))[:size:size]
-	data := make([]byte, size)
-	copy(data, resourceSlice)
 
 	logger.Info("✅ Successfully read PSPF from PE resources",
 		"exe", exePath,
-		"pspf_size", size)
+		"pspf_size", len(data))
 
 	return data, nil
 }

--- a/src/flavor-go/pkg/psp/format_2025/security_helpers.go
+++ b/src/flavor-go/pkg/psp/format_2025/security_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -27,6 +28,16 @@ func intToUint64Checked(value int, field string) (uint64, error) {
 		return 0, fmt.Errorf("%s must be non-negative: %d", field, value)
 	}
 	return uint64(value), nil
+}
+
+func float64ToFileModeChecked(value float64, field string) (os.FileMode, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("%s must be a finite integer, got %v", field, value)
+	}
+	if value < 0 || value > math.MaxUint32 || math.Trunc(value) != value {
+		return 0, fmt.Errorf("%s out of uint32 range: %v", field, value)
+	}
+	return os.FileMode(uint32(value)), nil
 }
 
 func sanitizeHeaderMode(value int64, fallback os.FileMode) os.FileMode {
@@ -91,4 +102,14 @@ func readFileValidated(path string) ([]byte, error) {
 func writeFileValidated(path string, data []byte, perm os.FileMode) error {
 	// #nosec G304,G306,G703 -- callers validate or derive paths from workenv roots
 	return os.WriteFile(path, data, perm)
+}
+
+func chmodValidated(path string, perm os.FileMode) error {
+	// #nosec G304,G302,G703 -- callers validate or derive paths from workenv roots
+	return os.Chmod(path, perm)
+}
+
+func execCommandValidated(name string, arg ...string) *exec.Cmd {
+	// #nosec G204,G702 -- package-defined commands are intentionally executed directly without a shell
+	return exec.Command(name, arg...)
 }

--- a/src/flavor-go/pkg/psp/format_2025/security_helpers_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/security_helpers_test.go
@@ -59,6 +59,24 @@ func TestIntToUint64Checked(t *testing.T) {
 	}
 }
 
+func TestFloat64ToFileModeChecked(t *testing.T) {
+	t.Parallel()
+
+	got, err := float64ToFileModeChecked(0o640, "mode")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0o640 {
+		t.Fatalf("got %o, want 0640", got)
+	}
+
+	for _, value := range []float64{-1, math.MaxUint32 + 1, 12.5} {
+		if _, err := float64ToFileModeChecked(value, "mode"); err == nil {
+			t.Fatalf("expected range error for %v", value)
+		}
+	}
+}
+
 func TestJoinUnderBase(t *testing.T) {
 	t.Parallel()
 

--- a/src/flavor-rs/Cargo.lock
+++ b/src/flavor-rs/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "signal-hook",
  "tar",
  "tempfile",
+ "toml",
  "which",
  "windows",
 ]
@@ -1057,6 +1058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1174,47 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -1551,6 +1602,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/src/flavor-rs/Cargo.toml
+++ b/src/flavor-rs/Cargo.toml
@@ -31,6 +31,7 @@ tar = "0.4"
 flate2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 sha2 = "0.10"
 adler2 = "2.0"
 tempfile = "3.0"

--- a/src/flavor-rs/src/psp/format_2025/builder/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/builder/mod.rs
@@ -16,6 +16,7 @@ use super::defaults::{CAPABILITY_MMAP, CAPABILITY_SIGNED};
 use super::index::Index;
 use super::keys::load_or_generate_keys;
 use super::manifest::BuildManifest;
+use super::trust::compute_key_fingerprint;
 use crate::api::BuildOptions;
 use crate::exceptions::{FlavorError, Result};
 use log::{debug, info, trace};
@@ -132,6 +133,9 @@ fn initialize_index(launcher_size: u64, public_key: &ed25519_dalek::VerifyingKey
     let mut index = Index::new();
     index.launcher_size = launcher_size;
     index.public_key.copy_from_slice(public_key.as_bytes());
+    if let Ok(fp) = compute_key_fingerprint(public_key.as_bytes()) {
+        index.attestation_key_fp[..64].copy_from_slice(fp.as_bytes());
+    }
     index.capabilities = CAPABILITY_MMAP | CAPABILITY_SIGNED;
 
     index
@@ -374,6 +378,10 @@ mod tests {
         let slot_count = index.slot_count;
         assert_eq!(package_size, bytes.len() as u64);
         assert_eq!(slot_count, 1);
+        assert_ne!(
+            index.attestation_key_fp, [0u8; 64],
+            "attestation_key_fp should be populated for signed bundles"
+        );
     }
 
     // This test verifies that on non-Windows, the file is truncated before the

--- a/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
@@ -181,42 +181,43 @@ pub fn launch(package_path: &Path, args: &[String], options: LaunchOptions) -> R
     let key_trusted = {
         use super::trust;
 
-        let pk = &index.public_key;
-        let mut trusted = true;
-        if !pk.iter().all(|&b| b == 0) {
-            match trust::compute_key_fingerprint(pk) {
-                Ok(fp) => match trust::is_key_trusted(&fp, true) {
-                    None => {
-                        // No trust store exists — backwards-compatible, allow execution
-                        debug!("🔑 No trusted-keys store found; skipping trust check");
-                    }
-                    Some(true) => {
-                        debug!("✅ Package signing key is trusted (fp={})", &fp[..16]);
-                    }
-                    Some(false) => {
-                        trusted = false;
-                        let msg = format!(
-                            "Package signing key is not in the trusted-keys store (fp={})",
-                            fp
-                        );
-                        if matches!(validation_level, ValidationLevel::Strict) {
-                            error!("❌ {}", msg);
-                            return Err(FlavorError::Generic(msg));
-                        } else {
-                            eprintln!("flavor: warning: {msg}");
-                            warn!("⚠️ {}", msg);
-                        }
-                    }
-                },
-                Err(e) => {
-                    warn!(
-                        "⚠️ Failed to compute key fingerprint for trust check: {}",
-                        e
-                    );
+        match trust::derive_index_key_fingerprint(&index) {
+            Ok(Some(fp)) => match trust::is_key_trusted(&fp, true) {
+                None => {
+                    warn!("⚠️ No trusted-keys store found; treating package as untrusted");
+                    false
                 }
+                Some(true) => {
+                    debug!("✅ Package signing key is trusted (fp={})", &fp[..16]);
+                    true
+                }
+                Some(false) => {
+                    let msg = format!(
+                        "Package signing key is not in the trusted-keys store (fp={})",
+                        fp
+                    );
+                    if matches!(validation_level, ValidationLevel::Strict) {
+                        error!("❌ {}", msg);
+                        return Err(FlavorError::Generic(msg));
+                    } else {
+                        eprintln!("flavor: warning: {msg}");
+                        warn!("⚠️ {}", msg);
+                        false
+                    }
+                }
+            },
+            Ok(None) => {
+                warn!("⚠️ Package is unsigned; treating signing key as untrusted");
+                false
+            }
+            Err(e) => {
+                error!("❌ Invalid attestation key fingerprint metadata: {}", e);
+                return Err(FlavorError::Generic(format!(
+                    "invalid attestation key fingerprint metadata: {}",
+                    e
+                )));
             }
         }
-        trusted
     };
 
     // Read metadata and clone to avoid borrow issues
@@ -226,7 +227,7 @@ pub fn launch(package_path: &Path, args: &[String], options: LaunchOptions) -> R
     {
         use crate::psp::format_2025::policy;
 
-        let op_policy = policy::load_operator_policy();
+        let op_policy = policy::load_operator_policy()?;
         let pkg_policy = {
             // Deserialise the package-declared policy from the metadata "policy" JSON value.
             // If the key is absent or cannot be parsed, default to a permissive empty policy.

--- a/src/flavor-rs/src/psp/format_2025/policy.rs
+++ b/src/flavor-rs/src/psp/format_2025/policy.rs
@@ -4,8 +4,10 @@
 //! Launch-time policy enforcement for the Rust launcher.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::exceptions::{FlavorError, Result};
 
 /// Package-declared constraints (from package metadata).
 #[derive(Default, Debug, serde::Deserialize)]
@@ -35,7 +37,46 @@ pub struct EffectivePolicy {
     pub max_age_days: Option<u64>,
     pub require_env: Vec<String>,
     pub require_trusted_key: bool,
+    pub use_os_keychain: bool,
     pub require_sbom: bool,
+}
+
+#[derive(Default, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OperatorPolicyFile {
+    #[serde(default)]
+    trust: Option<TrustSection>,
+    #[serde(default)]
+    execution: Option<ExecutionSection>,
+    #[serde(default)]
+    attestation: Option<AttestationSection>,
+}
+
+#[derive(Default, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrustSection {
+    #[serde(default)]
+    require_trusted_key: Option<bool>,
+    #[serde(default)]
+    use_os_keychain: Option<bool>,
+}
+
+#[derive(Default, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecutionSection {
+    #[serde(default)]
+    refuse_root: Option<bool>,
+    #[serde(default)]
+    max_age_days: Option<u64>,
+    #[serde(default)]
+    allow_platforms: Option<Vec<String>>,
+}
+
+#[derive(Default, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AttestationSection {
+    #[serde(default)]
+    require_sbom: Option<bool>,
 }
 
 fn get_system_policy_path() -> PathBuf {
@@ -69,73 +110,75 @@ fn get_user_policy_path() -> Option<PathBuf> {
     None
 }
 
-/// Parse a minimal TOML policy file. Handles only the fields FlavorPack needs.
-fn parse_policy_file(content: &str, policy: &mut OperatorPolicy) {
-    let mut section = String::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
+fn apply_operator_policy_file(policy: &mut OperatorPolicy, file: OperatorPolicyFile) {
+    if let Some(trust) = file.trust {
+        if let Some(value) = trust.require_trusted_key {
+            policy.require_trusted_key = value;
         }
-        if line.starts_with('[') && line.ends_with(']') {
-            section = line[1..line.len() - 1].to_lowercase();
-            continue;
+        if let Some(value) = trust.use_os_keychain {
+            policy.use_os_keychain = value;
         }
-        let parts: Vec<&str> = line.splitn(2, '=').collect();
-        if parts.len() != 2 {
-            continue;
+    }
+    if let Some(execution) = file.execution {
+        if let Some(value) = execution.refuse_root {
+            policy.refuse_root = value;
         }
-        let key = parts[0].trim();
-        // Strip inline comments from value
-        let raw_val = parts[1];
-        let val = if let Some(idx) = raw_val.find('#') {
-            raw_val[..idx].trim()
-        } else {
-            raw_val.trim()
-        };
-        match (section.as_str(), key) {
-            ("trust", "require_trusted_key") => policy.require_trusted_key = val == "true",
-            ("trust", "use_os_keychain") => policy.use_os_keychain = val == "true",
-            ("execution", "refuse_root") => policy.refuse_root = val == "true",
-            ("execution", "max_age_days") => {
-                if let Ok(n) = val.parse::<u64>() {
-                    policy.max_age_days = Some(n);
-                }
-            }
-            ("execution", "allow_platforms") => {
-                policy.allow_platforms = parse_toml_string_list(val);
-            }
-            ("attestation", "require_sbom") => policy.require_sbom = val == "true",
-            _ => {}
+        if let Some(value) = execution.max_age_days {
+            policy.max_age_days = Some(value);
         }
+        if let Some(value) = execution.allow_platforms {
+            policy.allow_platforms = value;
+        }
+    }
+    if let Some(attestation) = file.attestation
+        && let Some(value) = attestation.require_sbom
+    {
+        policy.require_sbom = value;
     }
 }
 
-fn parse_toml_string_list(val: &str) -> Vec<String> {
-    let val = val.trim();
-    if !val.starts_with('[') || !val.ends_with(']') {
-        return Vec::new();
-    }
-    let inner = &val[1..val.len() - 1];
-    inner
-        .split(',')
-        .map(|s| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
+fn parse_policy_file(content: &str, policy: &mut OperatorPolicy) -> Result<()> {
+    let file: OperatorPolicyFile = toml::from_str(content)
+        .map_err(|e| FlavorError::Generic(format!("invalid policy.toml: {e}")))?;
+    apply_operator_policy_file(policy, file);
+    Ok(())
 }
 
 /// Load operator policy from system and user files.
-pub fn load_operator_policy() -> OperatorPolicy {
+pub fn load_operator_policy() -> Result<OperatorPolicy> {
+    let system_path = get_system_policy_path();
+    let user_path = get_user_policy_path();
+    load_operator_policy_from_paths(Some(&system_path), user_path.as_deref())
+}
+
+fn load_operator_policy_from_paths(
+    system_path: Option<&Path>,
+    user_path: Option<&Path>,
+) -> Result<OperatorPolicy> {
     let mut policy = OperatorPolicy::default();
-    if let Ok(content) = fs::read_to_string(get_system_policy_path()) {
-        parse_policy_file(&content, &mut policy);
-    }
-    if let Some(path) = get_user_policy_path() {
-        if let Ok(content) = fs::read_to_string(path) {
-            parse_policy_file(&content, &mut policy);
+    if let Some(path) = system_path {
+        if let Some(content) = read_policy_file(path)? {
+            parse_policy_file(&content, &mut policy)?;
         }
     }
-    policy
+    if let Some(path) = user_path {
+        if let Some(content) = read_policy_file(path)? {
+            parse_policy_file(&content, &mut policy)?;
+        }
+    }
+    Ok(policy)
+}
+
+fn read_policy_file(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(FlavorError::Generic(format!(
+            "reading policy {}: {}",
+            path.display(),
+            err
+        ))),
+    }
 }
 
 /// Merge package + operator policy. Stricter always wins.
@@ -166,6 +209,7 @@ pub fn merge_policy(pkg: PackagePolicy, op: OperatorPolicy) -> EffectivePolicy {
         max_age_days,
         require_env: pkg.require_env,
         require_trusted_key: op.require_trusted_key,
+        use_os_keychain: op.use_os_keychain,
         require_sbom: op.require_sbom,
     }
 }
@@ -224,7 +268,7 @@ pub fn enforce_policy(
     build_timestamp: u64,
     has_sbom: bool,
     key_trusted: bool,
-) -> Result<(), String> {
+) -> std::result::Result<(), String> {
     let current_platform = get_current_platform();
 
     // Platform check
@@ -273,6 +317,13 @@ pub fn enforce_policy(
     if policy.require_sbom && !has_sbom {
         return Err(
             "package built without attestation slot — operator policy requires SBOM".to_string(),
+        );
+    }
+
+    if policy.use_os_keychain {
+        return Err(
+            "operator policy requests OS keychain trust, but Rust launcher does not support it"
+                .to_string(),
         );
     }
 
@@ -381,6 +432,17 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_policy_propagates_os_keychain_flag() {
+        let pkg = PackagePolicy::default();
+        let op = OperatorPolicy {
+            use_os_keychain: true,
+            ..Default::default()
+        };
+        let eff = merge_policy(pkg, op);
+        assert!(eff.use_os_keychain);
+    }
+
+    #[test]
     fn test_enforce_policy_permissive() {
         let eff = EffectivePolicy::default();
         assert!(enforce_policy(&eff, 0, false, true).is_ok());
@@ -467,21 +529,41 @@ mod tests {
 
     #[test]
     fn test_load_operator_policy_missing_file() {
-        unsafe {
-            env::set_var(
-                crate::env_vars::CONFIG_DIR,
-                "/tmp/__nonexistent_flavor_policy_dir__",
-            );
-        }
-        let policy = load_operator_policy();
+        let system = std::path::PathBuf::from("/tmp/__nonexistent_flavor_system_policy.toml");
+        let user = std::path::PathBuf::from("/tmp/__nonexistent_flavor_user_policy.toml");
+        let policy =
+            load_operator_policy_from_paths(Some(&system), Some(&user)).expect("policy load");
         assert!(!policy.require_trusted_key);
+    }
+
+    #[test]
+    fn test_load_operator_policy_invalid_system_file_errors() {
+        let system_dir = tempfile::TempDir::new().expect("tempdir");
+        let system_file = system_dir.path().join("policy.toml");
+        std::fs::write(&system_file, b"[trust\nrequire_trusted_key = true\n")
+            .expect("write bad policy");
+        let result = load_operator_policy_from_paths(Some(&system_file), None);
+        assert!(result.is_err(), "invalid system policy must fail closed");
+    }
+
+    #[test]
+    fn test_load_operator_policy_invalid_user_file_errors() {
+        let user_dir = tempfile::TempDir::new().expect("tempdir");
+        let user_file = user_dir.path().join("policy.toml");
+        std::fs::write(
+            &user_file,
+            b"[trust]\nrequire_trusted_key = true\nunknown_key = true\n",
+        )
+        .expect("write bad policy");
+        let result = load_operator_policy_from_paths(None, Some(&user_file));
+        assert!(result.is_err(), "invalid user policy must fail closed");
     }
 
     #[test]
     fn test_parse_policy_file_all_fields() {
         let content = "[trust]\nrequire_trusted_key = true\nuse_os_keychain = true\n[execution]\nrefuse_root = true\nmax_age_days = 90\n[attestation]\nrequire_sbom = true\n";
         let mut policy = OperatorPolicy::default();
-        parse_policy_file(content, &mut policy);
+        parse_policy_file(content, &mut policy).expect("parse policy");
         assert!(policy.require_trusted_key);
         assert!(policy.use_os_keychain);
         assert!(policy.refuse_root);
@@ -493,7 +575,7 @@ mod tests {
     fn test_parse_policy_file_ignores_comments() {
         let content = "# top comment\n[trust]\n# inline comment\nrequire_trusted_key = true\n";
         let mut policy = OperatorPolicy::default();
-        parse_policy_file(content, &mut policy);
+        parse_policy_file(content, &mut policy).expect("parse policy");
         assert!(policy.require_trusted_key);
     }
 
@@ -501,7 +583,7 @@ mod tests {
     fn test_parse_policy_file_inline_comment() {
         let content = "[execution]\nrefuse_root = true # disable if needed\n";
         let mut policy = OperatorPolicy::default();
-        parse_policy_file(content, &mut policy);
+        parse_policy_file(content, &mut policy).expect("parse policy");
         assert!(policy.refuse_root, "should strip inline comment");
     }
 
@@ -509,26 +591,34 @@ mod tests {
     fn test_parse_policy_file_allow_platforms() {
         let content = "[execution]\nallow_platforms = [\"linux_amd64\", \"linux_arm64\"]\n";
         let mut policy = OperatorPolicy::default();
-        parse_policy_file(content, &mut policy);
+        parse_policy_file(content, &mut policy).expect("parse policy");
         assert_eq!(policy.allow_platforms, vec!["linux_amd64", "linux_arm64"]);
     }
 
     #[test]
-    fn test_parse_toml_string_list_single_quotes() {
-        let result = parse_toml_string_list("['darwin_arm64', 'linux_amd64']");
-        assert_eq!(result, vec!["darwin_arm64", "linux_amd64"]);
+    fn test_parse_policy_file_preserves_hash_inside_string() {
+        let content = "[execution]\nallow_platforms = [\"linux_amd64#beta\"]\n";
+        let mut policy = OperatorPolicy::default();
+        parse_policy_file(content, &mut policy).expect("parse policy");
+        assert_eq!(policy.allow_platforms, vec!["linux_amd64#beta"]);
     }
 
     #[test]
-    fn test_parse_toml_string_list_empty() {
-        let result = parse_toml_string_list("[]");
-        assert!(result.is_empty());
+    fn test_parse_policy_file_rejects_unknown_keys() {
+        let content = "[trust]\nrequire_trusted_key = true\nunknown_key = true\n";
+        let mut policy = OperatorPolicy::default();
+        let err = parse_policy_file(content, &mut policy).expect_err("unknown key must fail");
+        let err = err.to_string();
+        assert!(err.contains("unknown_key") || err.contains("unknown"));
     }
 
     #[test]
-    fn test_parse_toml_string_list_invalid() {
-        let result = parse_toml_string_list("not_a_list");
-        assert!(result.is_empty());
+    fn test_enforce_policy_rejects_use_os_keychain() {
+        let eff = EffectivePolicy {
+            use_os_keychain: true,
+            ..Default::default()
+        };
+        assert!(enforce_policy(&eff, 0, false, true).is_err());
     }
 
     #[test]

--- a/src/flavor-rs/src/psp/format_2025/trust.rs
+++ b/src/flavor-rs/src/psp/format_2025/trust.rs
@@ -71,6 +71,35 @@ pub fn compute_key_fingerprint(raw_key: &[u8]) -> Result<String, String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+/// Derive the canonical trust fingerprint from an index's embedded public key.
+///
+/// Returns:
+/// - `Ok(None)` for unsigned packages with an all-zero public key and no attestation fingerprint.
+/// - `Ok(Some(fp))` for signed packages when the stored attestation fingerprint is absent or matches.
+/// - `Err(...)` when the attestation fingerprint is present but mismatches the embedded public key.
+pub fn derive_index_key_fingerprint(index: &super::index::Index) -> Result<Option<String>, String> {
+    if index.public_key.iter().all(|&b| b == 0) {
+        if index.attestation_key_fp.iter().any(|&b| b != 0) {
+            return Err("attestation_key_fp is present but public_key is missing".to_string());
+        }
+        return Ok(None);
+    }
+
+    let derived = compute_key_fingerprint(&index.public_key)?;
+    let stored = String::from_utf8_lossy(&index.attestation_key_fp)
+        .trim_end_matches('\0')
+        .to_string();
+
+    if !stored.is_empty() && stored != derived {
+        return Err(format!(
+            "attestation_key_fp mismatch: stored={} derived={}",
+            stored, derived
+        ));
+    }
+
+    Ok(Some(derived))
+}
+
 /// Loads all .pub PEM files from a directory.
 /// Returns empty map if directory doesn't exist.
 fn load_keys_from_dir(dir: &Path) -> HashMap<String, TrustedKey> {
@@ -222,6 +251,42 @@ mod tests {
             err.contains("invalid Ed25519 key length"),
             "unexpected: {err}"
         );
+    }
+
+    #[test]
+    fn test_derive_index_key_fingerprint_unsigned_package_returns_none() {
+        let index = crate::psp::format_2025::index::Index::new();
+        let fingerprint = derive_index_key_fingerprint(&index).expect("derive fingerprint");
+        assert_eq!(fingerprint, None);
+    }
+
+    #[test]
+    fn test_derive_index_key_fingerprint_matches_public_key() {
+        let seed = [7u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let public_key = signing_key.verifying_key().to_bytes();
+        let mut index = crate::psp::format_2025::index::Index::new();
+        index.public_key = public_key;
+
+        let fingerprint = derive_index_key_fingerprint(&index).expect("derive fingerprint");
+        assert_eq!(
+            fingerprint,
+            Some(compute_key_fingerprint(&public_key).expect("fingerprint"))
+        );
+    }
+
+    #[test]
+    fn test_derive_index_key_fingerprint_rejects_mismatch() {
+        let seed = [8u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let public_key = signing_key.verifying_key().to_bytes();
+        let mut index = crate::psp::format_2025::index::Index::new();
+        index.public_key = public_key;
+        index.attestation_key_fp[..64]
+            .copy_from_slice(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+        let err = derive_index_key_fingerprint(&index).expect_err("mismatch must fail");
+        assert!(err.contains("mismatch") || err.contains("attestation"));
     }
 
     #[test]

--- a/src/flavor/commands/policy.py
+++ b/src/flavor/commands/policy.py
@@ -13,10 +13,12 @@ from pathlib import Path
 import sys
 
 import click
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from provide.foundation.console import perr, pout
 
 from flavor.config.dirs import get_policy_file
-from flavor.config.policy import load_operator_policy, merge_policy, parse_package_policy
+from flavor.config.policy import enforce_policy, load_operator_policy, merge_policy, parse_package_policy
+from flavor.config.trust import compute_key_fingerprint, is_key_trusted
 from flavor.console import get_command_logger
 
 log = get_command_logger("policy")
@@ -109,7 +111,7 @@ def policy_show() -> None:
 
 @policy_group.command("check")
 @click.argument("package_file", type=click.Path(exists=True, dir_okay=False, resolve_path=True))
-def policy_check(package_file: str) -> None:
+def policy_check(package_file: str) -> None:  # noqa: C901
     """Dry-run: would this package be allowed to run on this host?"""
     from datetime import datetime
 
@@ -124,6 +126,7 @@ def policy_check(package_file: str) -> None:
     pkg_policy = parse_package_policy(pkg_raw)
     op_policy = load_operator_policy()
     effective = merge_policy(pkg_policy, op_policy)
+    has_sbom = any(slot.get("lifecycle") == "attestation" for slot in metadata.get("slots", []))
 
     current_platform = _get_current_platform()
     if effective.platforms and current_platform not in effective.platforms:
@@ -148,10 +151,84 @@ def policy_check(package_file: str) -> None:
             perr(f"❌ Required environment variable not set: {var}")
         sys.exit(1)
 
+    if effective.use_os_keychain:
+        perr("❌ use_os_keychain is enabled, but OS keychain trust is not implemented")
+        sys.exit(1)
+
+    if effective.require_sbom and not has_sbom:
+        perr("❌ Package built without attestation slot — operator policy requires SBOM")
+        sys.exit(1)
+
+    metadata_error = _validate_package_key_metadata(index)
+    if metadata_error:
+        perr(f"❌ {metadata_error}")
+        sys.exit(1)
+
+    if effective.require_trusted_key:
+        trusted, error = _check_package_key_trust(index)
+        if not trusted:
+            perr(f"❌ {error}")
+            sys.exit(1)
+
+    try:
+        enforce_policy(effective, int(index.build_timestamp), has_sbom, True)
+    except ValueError as exc:
+        perr(f"❌ {exc}")
+        sys.exit(1)
+
     pout("✓ Package would be allowed on this host.")
     pout(f"  Platform: {current_platform}")
     pout(f"  refuse_root: {effective.refuse_root}")
     pout(f"  max_age_days: {effective.max_age_days or '(no limit)'}")
+
+
+def _validate_package_key_metadata(index: object) -> str | None:
+    """Validate signer metadata consistency independently of trust-store policy."""
+    public_key = bytes(getattr(index, "public_key", b""))
+    stored_fingerprint = bytes(getattr(index, "attestation_key_fp", b"")).rstrip(b"\x00")
+
+    if stored_fingerprint and (not public_key or set(public_key) == {0}):
+        return "package attestation key fingerprint is present but embedded public key is missing"
+
+    if not public_key or set(public_key) == {0}:
+        return None
+
+    try:
+        public_key_obj = Ed25519PublicKey.from_public_bytes(public_key)
+    except ValueError:
+        return "embedded public key is not a valid Ed25519 key"
+
+    fingerprint = compute_key_fingerprint(public_key_obj)
+    if stored_fingerprint:
+        try:
+            stored_fingerprint_text = stored_fingerprint.decode("ascii")
+        except UnicodeDecodeError:
+            return "package attestation key fingerprint is not valid ASCII"
+        if stored_fingerprint_text != fingerprint:
+            return "package attestation key fingerprint does not match embedded public key"
+
+    return None
+
+
+def _check_package_key_trust(index: object) -> tuple[bool, str | None]:
+    metadata_error = _validate_package_key_metadata(index)
+    if metadata_error:
+        return False, metadata_error
+
+    public_key = bytes(getattr(index, "public_key", b""))
+    if not public_key or set(public_key) == {0}:
+        return False, "operator policy requires a trusted signing key — package is not signed"
+
+    fingerprint = compute_key_fingerprint(Ed25519PublicKey.from_public_bytes(public_key))
+    trusted = is_key_trusted(fingerprint)
+    if trusted is True:
+        return True, None
+    if trusted is None:
+        return (
+            False,
+            "operator policy requires a trusted signing key — no trusted-keys store is configured",
+        )
+    return False, "operator policy requires a trusted signing key — package key is not in the trusted store"
 
 
 def _get_current_platform() -> str:

--- a/src/flavor/commands/policy.py
+++ b/src/flavor/commands/policy.py
@@ -151,10 +151,6 @@ def policy_check(package_file: str) -> None:  # noqa: C901
             perr(f"❌ Required environment variable not set: {var}")
         sys.exit(1)
 
-    if effective.use_os_keychain:
-        perr("❌ use_os_keychain is enabled, but OS keychain trust is not implemented")
-        sys.exit(1)
-
     if effective.require_sbom and not has_sbom:
         perr("❌ Package built without attestation slot — operator policy requires SBOM")
         sys.exit(1)

--- a/src/flavor/config/policy.py
+++ b/src/flavor/config/policy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import os
+from pathlib import Path
 import platform
 import sys
 import tomllib
@@ -20,6 +21,21 @@ from flavor.config.dirs import get_policy_file, get_system_config_dir
 from flavor.console import get_command_logger
 
 log = get_command_logger("config.policy")
+
+_POLICY_SCHEMA: dict[str, dict[str, object]] = {
+    "trust": {
+        "require_trusted_key": bool,
+        "use_os_keychain": bool,
+    },
+    "execution": {
+        "refuse_root": bool,
+        "max_age_days": int,
+        "allow_platforms": list,
+    },
+    "attestation": {
+        "require_sbom": bool,
+    },
+}
 
 
 @define
@@ -82,6 +98,60 @@ def _parse_operator_policy(raw: dict[str, Any]) -> OperatorPolicy:
     )
 
 
+def _raise_invalid_policy(path: Path, message: str) -> None:
+    raise ValueError(f"{path}: {message}")
+
+
+def _validate_operator_policy_value(path: Path, section: str, key: str, value: Any) -> None:
+    expected = _POLICY_SCHEMA[section][key]
+    label = f"[{section}].{key}"
+
+    if expected is bool:
+        if type(value) is not bool:
+            _raise_invalid_policy(path, f"{label} must be a boolean")
+        return
+
+    if expected is int:
+        if type(value) is not int:
+            _raise_invalid_policy(path, f"{label} must be an integer")
+        return
+
+    if expected is list:
+        if not isinstance(value, list) or any(type(item) is not str for item in value):
+            _raise_invalid_policy(path, f"{label} must be a list of strings")
+        return
+
+    _raise_invalid_policy(path, f"{label} has unsupported schema type")
+
+
+def _validate_operator_policy_file(path: Path, raw: dict[str, Any]) -> None:
+    for section, values in raw.items():
+        if section not in _POLICY_SCHEMA:
+            _raise_invalid_policy(path, f"unknown policy section [{section}]")
+        if not isinstance(values, dict):
+            _raise_invalid_policy(path, f"unknown top-level key {section!r}")
+
+        allowed_keys = _POLICY_SCHEMA[section]
+        for key, value in values.items():
+            if key not in allowed_keys:
+                _raise_invalid_policy(path, f"unknown policy key [{section}].{key}")
+            _validate_operator_policy_value(path, section, key, value)
+
+
+def _load_policy_file(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as f:
+            raw = tomllib.load(f)
+    except Exception as exc:
+        raise ValueError(f"{path}: invalid policy.toml ({exc})") from exc
+
+    if not isinstance(raw, dict):
+        _raise_invalid_policy(path, "policy.toml root must be a table")
+
+    _validate_operator_policy_file(path, raw)
+    return raw
+
+
 def load_operator_policy(*, system: bool = True, user: bool = True) -> OperatorPolicy:
     """Load the operator policy file(s).
 
@@ -93,25 +163,14 @@ def load_operator_policy(*, system: bool = True, user: bool = True) -> OperatorP
     if system:
         system_file = get_system_config_dir() / "policy.toml"
         if system_file.exists():
-            try:
-                with system_file.open("rb") as f:
-                    merged.update(tomllib.load(f))
-            except Exception as exc:
-                log.warning("Failed to read system policy", path=str(system_file), error=str(exc))
+            merged.update(_load_policy_file(system_file))
 
     if user:
         user_file = get_policy_file(system=False)
         if user_file.exists():
-            try:
-                with user_file.open("rb") as f:
-                    user_raw = tomllib.load(f)
-                for section, values in user_raw.items():
-                    if isinstance(values, dict):
-                        merged.setdefault(section, {}).update(values)
-                    else:
-                        merged[section] = values
-            except Exception as exc:
-                log.warning("Failed to read user policy", path=str(user_file), error=str(exc))
+            user_raw = _load_policy_file(user_file)
+            for section, values in user_raw.items():
+                merged.setdefault(section, {}).update(values)
 
     return _parse_operator_policy(merged)
 
@@ -186,6 +245,9 @@ def enforce_policy(policy: EffectivePolicy, build_timestamp: int, has_sbom: bool
     missing = [var for var in policy.require_env if not os.environ.get(var)]
     if missing:
         raise ValueError(f"required environment variable not set: {missing[0]}")
+
+    if policy.use_os_keychain:
+        raise ValueError("use_os_keychain is enabled, but OS keychain trust is not implemented")
 
     if policy.require_sbom and not has_sbom:
         raise ValueError("package built without attestation slot — operator policy requires SBOM")

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -284,16 +284,27 @@ class PSPFLauncher(PSPFReader):
         """Substitute {slot:N} references in command."""
         return self._workenv_manager.substitute_slot_references(command, workenv_dir)
 
-    def _is_package_key_trusted(self) -> bool:
+    def _is_package_key_trusted(self, index: Any | None = None) -> bool:
         """Return whether the package signing key is trusted for operator-policy enforcement."""
-        index = self.read_index()
-        public_key = getattr(index, "public_key", b"")
-        if not public_key or set(public_key) == {0}:
-            return True
+        if index is None:
+            index = self.read_index()
 
-        fingerprint = compute_key_fingerprint(Ed25519PublicKey.from_public_bytes(bytes(public_key)))
+        public_key = bytes(getattr(index, "public_key", b""))
+        if not public_key or set(public_key) == {0}:
+            return False
+
+        fingerprint = compute_key_fingerprint(Ed25519PublicKey.from_public_bytes(public_key))
+        stored_fingerprint = bytes(getattr(index, "attestation_key_fp", b"")).rstrip(b"\x00")
+        if stored_fingerprint:
+            try:
+                stored_fingerprint_text = stored_fingerprint.decode("ascii")
+            except UnicodeDecodeError as exc:
+                raise ValueError("attestation key fingerprint is not valid ASCII") from exc
+            if stored_fingerprint_text != fingerprint:
+                raise ValueError("attestation key fingerprint does not match embedded public key")
+
         trusted = is_key_trusted(fingerprint)
-        return trusted is not False
+        return trusted is True
 
     def _enforce_launch_security(self, metadata: dict[str, Any]) -> None:
         """Verify integrity and enforce launch-time operator/package policy."""
@@ -310,7 +321,7 @@ class PSPFLauncher(PSPFReader):
             effective_policy,
             int(getattr(index, "build_timestamp", 0)),
             has_sbom,
-            self._is_package_key_trusted(),
+            self._is_package_key_trusted(index),
         )
 
     def execute(self, args: list[str] | None = None) -> dict[str, Any]:

--- a/tests/cli/test_policy_command.py
+++ b/tests/cli/test_policy_command.py
@@ -13,6 +13,8 @@ import time
 from unittest import mock
 
 from click.testing import CliRunner
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from flavor.cli import cli
 from flavor.commands.policy import _get_current_platform, _is_root
@@ -34,6 +36,11 @@ def _make_mock_reader(metadata: dict[str, object] | None = None, build_timestamp
     reader.read_metadata.return_value = metadata if metadata is not None else {}
     reader.read_index.return_value = mock_index
     return reader
+
+
+def _raw_public_key_bytes() -> bytes:
+    key = Ed25519PrivateKey.generate().public_key()
+    return key.public_bytes(Encoding.Raw, PublicFormat.Raw)
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +433,117 @@ def test_policy_check_env_var_present(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert "✓ Package would be allowed on this host." in result.output
+
+
+def test_policy_check_rejects_missing_sbom_when_required(tmp_path: Path) -> None:
+    """policy check must reflect require_sbom, not just platform/root/env."""
+    pkg = tmp_path / "test.psp"
+    pkg.write_bytes(b"fake")
+
+    mock_reader = _make_mock_reader(metadata={"slots": []})
+    runner = CliRunner()
+
+    with (
+        mock.patch("flavor.psp.format_2025.reader.PSPFReader", return_value=mock_reader),
+        mock.patch(
+            "flavor.commands.policy.load_operator_policy", return_value=OperatorPolicy(require_sbom=True)
+        ),
+    ):
+        result = runner.invoke(cli, ["policy", "check", str(pkg)])
+
+    assert result.exit_code == 1
+    assert "SBOM" in result.output
+
+
+def test_policy_check_rejects_unsigned_package_when_trusted_key_required(tmp_path: Path) -> None:
+    """Unsigned bundles must fail policy check when require_trusted_key is enabled."""
+    pkg = tmp_path / "test.psp"
+    pkg.write_bytes(b"fake")
+
+    mock_reader = _make_mock_reader(metadata={})
+    mock_reader.read_index.return_value.public_key = b"\x00" * 32
+    mock_reader.read_index.return_value.attestation_key_fp = b"\x00" * 64
+
+    runner = CliRunner()
+    with (
+        mock.patch("flavor.psp.format_2025.reader.PSPFReader", return_value=mock_reader),
+        mock.patch(
+            "flavor.commands.policy.load_operator_policy",
+            return_value=OperatorPolicy(require_trusted_key=True),
+        ),
+    ):
+        result = runner.invoke(cli, ["policy", "check", str(pkg)])
+
+    assert result.exit_code == 1
+    assert "trusted" in result.output or "signed" in result.output
+
+
+def test_policy_check_rejects_missing_trust_store_when_trusted_key_required(tmp_path: Path) -> None:
+    """A missing trust store must not be treated as implicitly trusted."""
+    pkg = tmp_path / "test.psp"
+    pkg.write_bytes(b"fake")
+
+    mock_reader = _make_mock_reader(metadata={})
+    mock_reader.read_index.return_value.public_key = _raw_public_key_bytes()
+    mock_reader.read_index.return_value.attestation_key_fp = b"\x00" * 64
+
+    runner = CliRunner()
+    with (
+        mock.patch("flavor.psp.format_2025.reader.PSPFReader", return_value=mock_reader),
+        mock.patch(
+            "flavor.commands.policy.load_operator_policy",
+            return_value=OperatorPolicy(require_trusted_key=True),
+        ),
+        mock.patch("flavor.commands.policy.is_key_trusted", return_value=None),
+    ):
+        result = runner.invoke(cli, ["policy", "check", str(pkg)])
+
+    assert result.exit_code == 1
+    assert "trusted" in result.output or "store" in result.output
+
+
+def test_policy_check_rejects_attestation_fingerprint_mismatch_without_trusted_key_requirement(
+    tmp_path: Path,
+) -> None:
+    """policy check must reject malformed signer metadata even when trust-store policy is permissive."""
+    pkg = tmp_path / "test.psp"
+    pkg.write_bytes(b"fake")
+
+    mock_reader = _make_mock_reader(metadata={})
+    mock_reader.read_index.return_value.public_key = _raw_public_key_bytes()
+    mock_reader.read_index.return_value.attestation_key_fp = b"sha256:wrong-fingerprint"
+
+    runner = CliRunner()
+    with (
+        mock.patch("flavor.psp.format_2025.reader.PSPFReader", return_value=mock_reader),
+        mock.patch("flavor.commands.policy.load_operator_policy", return_value=OperatorPolicy()),
+    ):
+        result = runner.invoke(cli, ["policy", "check", str(pkg)])
+
+    assert result.exit_code == 1
+    assert "fingerprint" in result.output
+    assert "embedded public key" in result.output
+
+
+def test_policy_check_rejects_unsupported_os_keychain(tmp_path: Path) -> None:
+    """use_os_keychain must fail closed in policy check until implemented."""
+    pkg = tmp_path / "test.psp"
+    pkg.write_bytes(b"fake")
+
+    mock_reader = _make_mock_reader(metadata={})
+    runner = CliRunner()
+
+    with (
+        mock.patch("flavor.psp.format_2025.reader.PSPFReader", return_value=mock_reader),
+        mock.patch(
+            "flavor.commands.policy.load_operator_policy",
+            return_value=OperatorPolicy(use_os_keychain=True),
+        ),
+    ):
+        result = runner.invoke(cli, ["policy", "check", str(pkg)])
+
+    assert result.exit_code == 1
+    assert "use_os_keychain" in result.output or "unsupported" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test_policy.py
+++ b/tests/config/test_policy.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from flavor.config.policy import (
     EffectivePolicy,
     OperatorPolicy,
     PackagePolicy,
+    enforce_policy,
     load_operator_policy,
     merge_policy,
     parse_package_policy,
@@ -268,7 +271,7 @@ def test_load_operator_policy_system_false_skips_system(tmp_path: Path) -> None:
 
 
 def test_load_operator_policy_malformed_system_toml(tmp_path: Path) -> None:
-    """Malformed system TOML logs a warning and falls back to defaults."""
+    """Malformed system TOML is a hard failure when the file exists."""
     system_dir = tmp_path / "system"
     system_dir.mkdir()
     bad_system = system_dir / "policy.toml"
@@ -277,38 +280,69 @@ def test_load_operator_policy_malformed_system_toml(tmp_path: Path) -> None:
     with (
         mock.patch("flavor.config.policy.get_system_config_dir", return_value=system_dir),
         mock.patch("flavor.config.policy.get_policy_file", return_value=tmp_path / "no-policy.toml"),
+        pytest.raises(ValueError, match=r"policy\.toml"),
     ):
-        op = load_operator_policy(system=True, user=False)
-    # Should not raise; returns defaults
-    assert op.require_trusted_key is False
+        load_operator_policy(system=True, user=False)
 
 
 def test_load_operator_policy_malformed_user_toml(tmp_path: Path) -> None:
-    """Malformed user TOML logs a warning and uses whatever was loaded before."""
+    """Malformed user TOML is a hard failure when the file exists."""
     bad_user = tmp_path / "policy.toml"
     bad_user.write_bytes(b"[broken\nnot = valid ===\n")
 
     with (
         mock.patch("flavor.config.policy.get_system_config_dir", return_value=tmp_path / "no-system"),
         mock.patch("flavor.config.policy.get_policy_file", return_value=bad_user),
+        pytest.raises(ValueError, match=r"policy\.toml"),
     ):
-        op = load_operator_policy(system=False, user=True)
-    # Should not raise; returns defaults
-    assert op.require_trusted_key is False
+        load_operator_policy(system=False, user=True)
 
 
 def test_load_operator_policy_user_non_dict_section(tmp_path: Path) -> None:
-    """A top-level non-dict value in user policy is merged directly (not as sub-section)."""
+    """Unexpected top-level scalars are rejected instead of being silently merged."""
     user_policy = tmp_path / "policy.toml"
-    # TOML: top-level scalar (not a table section)
     user_policy.write_text("version = 1\n[trust]\nrequire_trusted_key = true\n")
 
     with (
         mock.patch("flavor.config.policy.get_system_config_dir", return_value=tmp_path / "no-system"),
         mock.patch("flavor.config.policy.get_policy_file", return_value=user_policy),
+        pytest.raises(ValueError, match=r"unknown policy section|unknown top-level key"),
     ):
-        op = load_operator_policy(system=False, user=True)
-    assert op.require_trusted_key is True
+        load_operator_policy(system=False, user=True)
+
+
+def test_load_operator_policy_unknown_section_raises(tmp_path: Path) -> None:
+    """Unknown sections are rejected to prevent silent policy drift."""
+    user_policy = tmp_path / "policy.toml"
+    user_policy.write_text("[mystery]\nflag = true\n")
+
+    with (
+        mock.patch("flavor.config.policy.get_system_config_dir", return_value=tmp_path / "no-system"),
+        mock.patch("flavor.config.policy.get_policy_file", return_value=user_policy),
+        pytest.raises(ValueError, match=r"unknown policy section"),
+    ):
+        load_operator_policy(system=False, user=True)
+
+
+def test_load_operator_policy_unknown_key_raises(tmp_path: Path) -> None:
+    """Unknown keys in known sections are rejected to keep runtimes aligned."""
+    user_policy = tmp_path / "policy.toml"
+    user_policy.write_text("[trust]\nrequire_trusted_key = true\nsurprise = true\n")
+
+    with (
+        mock.patch("flavor.config.policy.get_system_config_dir", return_value=tmp_path / "no-system"),
+        mock.patch("flavor.config.policy.get_policy_file", return_value=user_policy),
+        pytest.raises(ValueError, match=r"unknown policy key"),
+    ):
+        load_operator_policy(system=False, user=True)
+
+
+def test_enforce_policy_rejects_unsupported_os_keychain() -> None:
+    """use_os_keychain must fail closed until a real backend exists."""
+    policy = EffectivePolicy(use_os_keychain=True)
+
+    with pytest.raises(ValueError, match="use_os_keychain"):
+        enforce_policy(policy, 0, False, True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/format_2025/test_launcher_security_parity.py
+++ b/tests/format_2025/test_launcher_security_parity.py
@@ -66,6 +66,147 @@ def test_launcher_execute_blocks_untrusted_package_when_policy_requires_trusted_
     mock_executor.assert_not_called()
 
 
+def test_launcher_execute_blocks_unsigned_package_when_policy_requires_trusted_key(tmp_path: Path) -> None:
+    """Unsigned bundles must not satisfy require_trusted_key."""
+    bundle_path = tmp_path / "unsigned.psp"
+    bundle_path.write_bytes(b"bundle")
+
+    launcher = PSPFLauncher(bundle_path)
+    metadata = {
+        "package": {"name": "pkg", "version": "1.0.0"},
+        "execution": {"command": "echo hi"},
+        "slots": [],
+    }
+    index = SimpleNamespace(public_key=b"\x00" * 32, attestation_key_fp=b"\x00" * 64, build_timestamp=0)
+
+    with (
+        patch.object(launcher, "read_metadata", return_value=metadata),
+        patch.object(launcher, "read_index", return_value=index),
+        patch("flavor.psp.format_2025.launcher.verify_package_integrity", return_value={"valid": True}),
+        patch(
+            "flavor.psp.format_2025.launcher.load_operator_policy",
+            return_value=OperatorPolicy(require_trusted_key=True),
+        ),
+        patch.object(launcher._workenv_manager, "setup_workenv") as mock_setup_workenv,
+        patch("flavor.psp.format_2025.executor.BundleExecutor") as mock_executor,
+    ):
+        mock_executor.return_value.execute.return_value = {"executed": True, "exit_code": 0}
+        result = launcher.execute([])
+
+    assert result["executed"] is False
+    assert "trusted" in result["error"] or "signed" in result["error"]
+    mock_setup_workenv.assert_not_called()
+    mock_executor.assert_not_called()
+
+
+def test_launcher_execute_blocks_when_trust_store_missing_and_policy_requires_trusted_key(
+    tmp_path: Path,
+) -> None:
+    """Missing trust stores must fail closed when trusted-key policy is enabled."""
+    bundle_path = tmp_path / "package.psp"
+    bundle_path.write_bytes(b"bundle")
+
+    launcher = PSPFLauncher(bundle_path)
+    metadata = {
+        "package": {"name": "pkg", "version": "1.0.0"},
+        "execution": {"command": "echo hi"},
+        "slots": [],
+    }
+    public_key = _raw_public_key_bytes()
+    index = SimpleNamespace(public_key=public_key, attestation_key_fp=b"\x00" * 64, build_timestamp=0)
+
+    with (
+        patch.object(launcher, "read_metadata", return_value=metadata),
+        patch.object(launcher, "read_index", return_value=index),
+        patch("flavor.psp.format_2025.launcher.verify_package_integrity", return_value={"valid": True}),
+        patch(
+            "flavor.psp.format_2025.launcher.load_operator_policy",
+            return_value=OperatorPolicy(require_trusted_key=True),
+        ),
+        patch("flavor.psp.format_2025.launcher.is_key_trusted", return_value=None),
+        patch.object(launcher._workenv_manager, "setup_workenv") as mock_setup_workenv,
+        patch("flavor.psp.format_2025.executor.BundleExecutor") as mock_executor,
+    ):
+        mock_executor.return_value.execute.return_value = {"executed": True, "exit_code": 0}
+        result = launcher.execute([])
+
+    assert result["executed"] is False
+    assert "trusted" in result["error"] or "store" in result["error"]
+    mock_setup_workenv.assert_not_called()
+    mock_executor.assert_not_called()
+
+
+def test_launcher_execute_blocks_when_attestation_fingerprint_mismatches_public_key(tmp_path: Path) -> None:
+    """Embedded attestation_key_fp must match the embedded public key fingerprint."""
+    bundle_path = tmp_path / "package.psp"
+    bundle_path.write_bytes(b"bundle")
+
+    launcher = PSPFLauncher(bundle_path)
+    metadata = {
+        "package": {"name": "pkg", "version": "1.0.0"},
+        "execution": {"command": "echo hi"},
+        "slots": [],
+    }
+    index = SimpleNamespace(
+        public_key=_raw_public_key_bytes(), attestation_key_fp=b"f" * 64, build_timestamp=0
+    )
+
+    with (
+        patch.object(launcher, "read_metadata", return_value=metadata),
+        patch.object(launcher, "read_index", return_value=index),
+        patch("flavor.psp.format_2025.launcher.verify_package_integrity", return_value={"valid": True}),
+        patch(
+            "flavor.psp.format_2025.launcher.load_operator_policy",
+            return_value=OperatorPolicy(require_trusted_key=False),
+        ),
+        patch.object(launcher._workenv_manager, "setup_workenv") as mock_setup_workenv,
+        patch("flavor.psp.format_2025.executor.BundleExecutor") as mock_executor,
+    ):
+        mock_executor.return_value.execute.return_value = {"executed": True, "exit_code": 0}
+        result = launcher.execute([])
+
+    assert result["executed"] is False
+    assert "fingerprint" in result["error"] or "metadata" in result["error"]
+    mock_setup_workenv.assert_not_called()
+    mock_executor.assert_not_called()
+
+
+def test_launcher_execute_blocks_when_os_keychain_policy_is_enabled(tmp_path: Path) -> None:
+    """use_os_keychain must fail closed until a real backend exists."""
+    bundle_path = tmp_path / "package.psp"
+    bundle_path.write_bytes(b"bundle")
+
+    launcher = PSPFLauncher(bundle_path)
+    metadata = {
+        "package": {"name": "pkg", "version": "1.0.0"},
+        "execution": {"command": "echo hi"},
+        "slots": [],
+    }
+    index = SimpleNamespace(
+        public_key=_raw_public_key_bytes(), attestation_key_fp=b"\x00" * 64, build_timestamp=0
+    )
+
+    with (
+        patch.object(launcher, "read_metadata", return_value=metadata),
+        patch.object(launcher, "read_index", return_value=index),
+        patch("flavor.psp.format_2025.launcher.verify_package_integrity", return_value={"valid": True}),
+        patch(
+            "flavor.psp.format_2025.launcher.load_operator_policy",
+            return_value=OperatorPolicy(use_os_keychain=True),
+        ),
+        patch("flavor.psp.format_2025.launcher.is_key_trusted", return_value=True),
+        patch.object(launcher._workenv_manager, "setup_workenv") as mock_setup_workenv,
+        patch("flavor.psp.format_2025.executor.BundleExecutor") as mock_executor,
+    ):
+        mock_executor.return_value.execute.return_value = {"executed": True, "exit_code": 0}
+        result = launcher.execute([])
+
+    assert result["executed"] is False
+    assert "use_os_keychain" in result["error"] or "unsupported" in result["error"]
+    mock_setup_workenv.assert_not_called()
+    mock_executor.assert_not_called()
+
+
 def test_workenv_path_is_bundle_specific_for_identical_package_metadata(tmp_path: Path) -> None:
     """Distinct bundles with the same package metadata must not share one Python workenv path."""
     bundle_one = tmp_path / "package-one.psp"

--- a/tests/test_quality_observability.py
+++ b/tests/test_quality_observability.py
@@ -7,6 +7,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROOT_MAKEFILE = REPO_ROOT / "Makefile"
 QUALITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "05-code-quality.yml"
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 RUST_MAKEFILE = REPO_ROOT / "src" / "flavor-rs" / "Makefile"
 RUST_FUZZ_CARGO = REPO_ROOT / "src" / "flavor-rs" / "fuzz" / "Cargo.toml"
 
@@ -76,3 +77,21 @@ def test_rust_quality_surface_defines_real_fuzz_targets() -> None:
 
     assert 'name = "pspf_operations_roundtrip"' in fuzz_manifest
     assert 'name = "pspf_reader_no_panic"' in fuzz_manifest
+
+
+def test_release_workflow_uses_trusted_publishing_for_pypi() -> None:
+    workflow = yaml.load(RELEASE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    publish_testpypi = workflow["jobs"]["publish-testpypi"]
+    publish_pypi = workflow["jobs"]["publish-pypi"]
+
+    assert publish_testpypi["permissions"]["id-token"] == "write"
+    assert publish_pypi["permissions"]["id-token"] == "write"
+
+    testpypi_publish = publish_testpypi["steps"][-1]
+    pypi_publish = publish_pypi["steps"][-1]
+
+    assert testpypi_publish["uses"] == "pypa/gh-action-pypi-publish@release/v1"
+    assert pypi_publish["uses"] == "pypa/gh-action-pypi-publish@release/v1"
+
+    assert testpypi_publish["with"]["password"] == "${{ secrets.TEST_PYPI_API_TOKEN }}"
+    assert "password" not in pypi_publish["with"]

--- a/tests/tools/test_validate_wheel.py
+++ b/tests/tools/test_validate_wheel.py
@@ -103,7 +103,27 @@ def test_platform_wheel_duplicate_helpers_fails() -> None:
     try:
         success, msgs = validate_helpers(whl)
         assert not success
-        assert any("Multiple" in m for m in msgs)
+        assert any("Unexpected helper" in m or "Expected helper not found" in m for m in msgs)
+    finally:
+        whl.unlink(missing_ok=True)
+
+
+def test_platform_wheel_extra_foreign_platform_helper_fails() -> None:
+    """Platform wheels must contain exactly the helper set for their own platform."""
+    whl = make_wheel(
+        "flavorpack-0.3.21-py3-none-linux_x86_64",
+        [
+            "flavor-go-builder-0.3.21-linux_amd64",
+            "flavor-go-launcher-0.3.21-linux_amd64",
+            "flavor-rs-builder-0.3.21-linux_amd64",
+            "flavor-rs-launcher-0.3.21-linux_amd64",
+            "flavor-rs-launcher-0.3.21-windows_amd64",
+        ],
+    )
+    try:
+        success, msgs = validate_helpers(whl)
+        assert not success
+        assert any("unexpected helper" in m.lower() or "foreign-platform" in m.lower() for m in msgs)
     finally:
         whl.unlink(missing_ok=True)
 
@@ -119,6 +139,46 @@ def test_platform_wheel_missing_helper_fails() -> None:
     try:
         success, _ = validate_helpers(whl)
         assert not success
+    finally:
+        whl.unlink(missing_ok=True)
+
+
+def test_platform_wheel_wrong_helper_version_fails() -> None:
+    """Platform wheels must not validate against stale helper versions."""
+    whl = make_wheel(
+        "flavorpack-0.3.21-py3-none-linux_x86_64",
+        [
+            "flavor-go-builder-0.3.20-linux_amd64",
+            "flavor-go-launcher-0.3.21-linux_amd64",
+            "flavor-rs-builder-0.3.21-linux_amd64",
+            "flavor-rs-launcher-0.3.21-linux_amd64",
+        ],
+    )
+    try:
+        success, msgs = validate_helpers(whl)
+        assert not success
+        assert any("Expected helper not found" in m for m in msgs)
+        assert any("Unexpected helper" in m for m in msgs)
+    finally:
+        whl.unlink(missing_ok=True)
+
+
+def test_platform_wheel_wrong_helper_prefix_fails() -> None:
+    """Platform wheels must not accept helpers that only share a broad family prefix."""
+    whl = make_wheel(
+        "flavorpack-0.3.21-py3-none-linux_x86_64",
+        [
+            "flavor-go-builder-malicious-0.3.21-linux_amd64",
+            "flavor-go-launcher-0.3.21-linux_amd64",
+            "flavor-rs-builder-0.3.21-linux_amd64",
+            "flavor-rs-launcher-0.3.21-linux_amd64",
+        ],
+    )
+    try:
+        success, msgs = validate_helpers(whl)
+        assert not success
+        assert any("Expected helper not found" in m for m in msgs)
+        assert any("Unexpected helper" in m for m in msgs)
     finally:
         whl.unlink(missing_ok=True)
 

--- a/tools/validate_wheel.py
+++ b/tools/validate_wheel.py
@@ -88,7 +88,28 @@ def _parse_wheel_platform(wheel_path: Path) -> str:
     return platform_tag  # fallback: return as-is
 
 
-def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:
+def _parse_wheel_version(wheel_path: Path) -> str:
+    """Parse the wheel version from the wheel filename."""
+    parts = wheel_path.stem.split("-")
+    if len(parts) < 4:
+        return "unknown"
+    return parts[-4]
+
+
+def _expected_helper_names(family: str, version: str, platform: str) -> set[str]:
+    """Return the exact helper filename(s) allowed for a wheel helper family."""
+    name = f"{family}-{version}-{platform}"
+    if platform.startswith("windows_"):
+        return {f"{name}.exe"}
+    return {name}
+
+
+def _is_helper_family_file(name: str) -> bool:
+    """Return whether a filename belongs to a known helper family naming space."""
+    return any(name == family or name.startswith(f"{family}-") for family in HELPER_FAMILIES)
+
+
+def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:  # noqa: C901
     """
     Validate that helpers in the wheel are correct for the wheel's platform.
 
@@ -98,6 +119,7 @@ def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:
     messages = []
     success = True
     platform = _parse_wheel_platform(wheel_path)
+    wheel_version = _parse_wheel_version(wheel_path)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(wheel_path, "r") as whl:
@@ -117,19 +139,15 @@ def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:
             return False, messages
 
         all_files = [f for f in helpers_dir.iterdir() if f.is_file()]
+        expected_matches: set[str] = set()
 
         for family in HELPER_FAMILIES:
-            # Match helpers for this family and platform
-            # Filename pattern: {family}-{version}-{platform}[.exe]
-            matches = [
-                f
-                for f in all_files
-                if f.name.startswith(family)
-                and (f.name.endswith(f"-{platform}") or f.name.endswith(f"-{platform}.exe"))
-            ]
+            expected_names = _expected_helper_names(family, wheel_version, platform)
+            matches = [f for f in all_files if f.name in expected_names]
 
             if not matches:
-                messages.append(f"  ❌ {family}-*-{platform}[.exe] not found")
+                names = ", ".join(sorted(expected_names))
+                messages.append(f"  ❌ Expected helper not found: {names}")
                 success = False
                 continue
 
@@ -140,6 +158,7 @@ def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:
                 continue
 
             helper_path = matches[0]
+            expected_matches.add(helper_path.name)
             size_kb = helper_path.stat().st_size / 1024
             messages.append(f"  ✓ {helper_path.name} ({size_kb:.0f} KB)")
 
@@ -167,6 +186,14 @@ def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:
                         messages.append("    ⚠️  Failed to run --version")
                 except Exception as e:
                     messages.append(f"    ⚠️  Cannot execute: {e}")
+
+        unexpected = [
+            f.name for f in all_files if f.name not in expected_matches and _is_helper_family_file(f.name)
+        ]
+        if unexpected:
+            names = ", ".join(sorted(unexpected))
+            messages.append(f"  ❌ Unexpected helper(s) for {platform}: {names}")
+            success = False
 
     return success, messages
 


### PR DESCRIPTION
## Summary
- harden Python, Go, and Rust operator-policy parsing so existing invalid `policy.toml` files fail closed
- align trusted-key enforcement across runtimes for unsigned bundles, missing trust stores, and attestation/public-key mismatches
- make Go builder emit `attestation_key_fp` and validate signer metadata from the embedded public key in launch paths
- tighten `flavor policy check` parity with launcher behavior and harden wheel validation to require the exact expected helper set
- add regression coverage for TOML parsing, trust-policy enforcement, attestation mismatch, and wheel helper validation edge cases

## Verification
- `pytest tests/config/test_policy.py tests/format_2025/test_launcher_security_parity.py tests/tools/test_validate_wheel.py tests/cli/test_policy_command.py tests/parity/test_policy_parity.py -q`
- `go test ./... -count=1`
- `go vet ./...`
- `cargo test --lib -- --test-threads=1`
- `cargo audit`
- `cargo deny check`
- local `pre-push` strict lane: `mypy`, `bandit`, `go vet`, `go build`, `go test`, `cargo clippy`, `cargo test`, `version sync`

## Follow-up
- Windows-native launcher/resource validation is still pending on a Windows runner/client.
- Broader pre-existing Go `gosec` backlog outside the touched files is not part of this PR.