### PR TITLE
fix: security hardening — policy alignment, file perms, cross-lang parity

### DIFF
--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 🐹 Setup Go
         uses: actions/setup-go@v6
         with:
@@ -138,7 +140,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📦 Download binaries
         uses: actions/download-artifact@v8
         with:
@@ -232,7 +236,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📦 Download binaries
         uses: actions/download-artifact@v8
         with:
@@ -283,7 +289,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
@@ -343,7 +351,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📦 Download binaries
         uses: actions/download-artifact@v8
         with:
@@ -382,7 +392,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📊 Generate report
         run: |
           cat << EOF > compatibility-report.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       
       - name: 📝 Validate Version
@@ -73,10 +74,11 @@ jobs:
       - name: 📥 Checkout for scripts
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
           sparse-checkout-cone-mode: false
-      
+
       - name: 📥 Download wheel artifacts from Flavor Pipeline
         uses: dawidd6/action-download-artifact@v19
         with:
@@ -112,10 +114,11 @@ jobs:
       - name: 📥 Checkout for scripts
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
           sparse-checkout-cone-mode: false
-      
+
       - name: 📥 Download Flavor PSP artifacts
         uses: dawidd6/action-download-artifact@v19
         with:
@@ -161,7 +164,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📥 Download wheels
         uses: actions/download-artifact@v8
         with:
@@ -276,7 +281,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: 📥 Download all release artifacts
         uses: actions/download-artifact@v8
         with:

--- a/src/flavor-go/internal/workenv/validation.go
+++ b/src/flavor-go/internal/workenv/validation.go
@@ -75,7 +75,7 @@ func MarkComplete(path string, packageName, version, checksum string) error {
 		return err
 	}
 
-	return os.WriteFile(markerPath, data, 0644)
+	return os.WriteFile(markerPath, data, 0600)
 }
 
 // MarkIncomplete marks a workenv as incomplete (failed extraction)
@@ -95,7 +95,7 @@ func MarkIncomplete(path string, reason string) error {
 	// Remove complete marker if it exists
 	_ = os.Remove(filepath.Join(path, ".extraction.complete"))
 
-	return os.WriteFile(markerPath, data, 0644)
+	return os.WriteFile(markerPath, data, 0600)
 }
 
 // Clean removes invalid or incomplete workenvs

--- a/src/flavor-go/pkg/psp/format_2025/execution_cache.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_cache.go
@@ -103,7 +103,7 @@ func savePackageChecksum(paths *WorkenvPaths, checksum uint32, logger hclog.Logg
 	checksumStr := fmt.Sprintf("%08x", checksum)
 
 	// Open file with explicit sync to ensure write is flushed before exec
-	file, err := os.OpenFile(checksumPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(checksumPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, FilePerms)
 	if err != nil {
 		logger.Debug("⚠️ Failed to open checksum file", "error", err)
 		return err
@@ -176,7 +176,7 @@ func saveIndexMetadata(paths *WorkenvPaths, index *PSPFIndex, logger hclog.Logge
 		return fmt.Errorf("failed to marshal index metadata: %w", err)
 	}
 
-	if err := os.WriteFile(indexPath, jsonData, 0644); err != nil {
+	if err := os.WriteFile(indexPath, jsonData, FilePerms); err != nil {
 		logger.Debug("⚠️ Failed to save index metadata", "error", err)
 		return err
 	}

--- a/src/flavor-go/pkg/psp/format_2025/execution_slots.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slots.go
@@ -65,7 +65,7 @@ func extractAndMergeSlotsToWorkenv(
 		_ = os.RemoveAll(tempExtractDir)
 		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
 	}
-	if err := os.WriteFile(metadataFile, metadataJSON, 0644); err != nil {
+	if err := os.WriteFile(metadataFile, metadataJSON, FilePerms); err != nil {
 		logger.Error("❌ Failed to write metadata", "error", err)
 		_ = os.RemoveAll(tempExtractDir)
 		return nil, fmt.Errorf("failed to write metadata: %w", err)

--- a/src/flavor-go/pkg/psp/format_2025/launcher.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher.go
@@ -35,7 +35,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 		logLevel = envLevel
 		logSource = EnvLogLevel
 	} else {
-		logLevel = "trace" // Default to trace for comprehensive diagnostics
+		logLevel = "warn" // Default to warn for production; set FLAVOR_LOG_LEVEL for more detail
 		logSource = "default"
 	}
 
@@ -57,7 +57,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 
 	// Support log file output
 	if logPath := os.Getenv(EnvLogPath); logPath != "" {
-		if file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+		if file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, FilePerms); err == nil {
 			defer func() { _ = file.Close() }()
 			output = file
 		}

--- a/src/flavor-go/pkg/psp/format_2025/locking.go
+++ b/src/flavor-go/pkg/psp/format_2025/locking.go
@@ -60,7 +60,7 @@ func TryAcquireLock(paths *WorkenvPaths, logger hclog.Logger) (bool, error) {
 	}
 
 	// Try to create lock file exclusively
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, FilePerms)
 	if err != nil {
 		if os.IsExist(err) {
 			logger.Debug("🔒 Lock file exists, another process is extracting")

--- a/src/flavor-rs/src/env_vars.rs
+++ b/src/flavor-rs/src/env_vars.rs
@@ -34,6 +34,34 @@ pub const VALIDATION: &str = "FLAVOR_VALIDATION";
 /// Enable metadata debug output in reader
 pub const DEBUG_METADATA: &str = "FLAVOR_DEBUG_METADATA";
 
+// Logging (builder-specific)
+/// Log level override for builder only
+pub const BUILDER_LOG_LEVEL: &str = "FLAVOR_BUILDER_LOG_LEVEL";
+/// Enable JSON-formatted log output
+pub const JSON_LOG: &str = "FLAVOR_JSON_LOG";
+
+// Execution keys
+/// Deterministic key seed for signing
+pub const KEY_SEED: &str = "FLAVOR_KEY_SEED";
+
+// Launcher IPC / CLI mode
+/// Additional launcher arguments
+pub const LAUNCHER_ARGS: &str = "FLAVOR_LAUNCHER_ARGS";
+/// Bundle path for launcher
+pub const LAUNCHER_BUNDLE: &str = "FLAVOR_LAUNCHER_BUNDLE";
+/// Launcher mode (e.g., "extract", "exec")
+pub const LAUNCHER_MODE: &str = "FLAVOR_LAUNCHER_MODE";
+/// Helper binary path for launcher
+pub const LAUNCHER_HELPER: &str = "FLAVOR_LAUNCHER_HELPER";
+/// Subprocess binary path for launcher
+pub const LAUNCHER_SUBPROCESS: &str = "FLAVOR_LAUNCHER_SUBPROCESS";
+/// Spawn-exit helper binary path
+pub const LAUNCHER_SPAWN_EXIT_HELPER: &str = "FLAVOR_LAUNCHER_SPAWN_EXIT_HELPER";
+
+// Runtime env vars injected into the child process
+// Note: FLAVOR_CACHE is Go-only (injected into child process at launch);
+// Rust uses FLAVOR_CACHE_DIR (the cache directory path) instead.
+
 /// Binary name passed to launched process
 pub const COMMAND_NAME: &str = "FLAVOR_COMMAND_NAME";
 /// Original command path passed to launched process

--- a/src/flavor-rs/src/psp/format_2025/policy.rs
+++ b/src/flavor-rs/src/psp/format_2025/policy.rs
@@ -271,7 +271,7 @@ pub fn enforce_policy(
 ) -> std::result::Result<(), String> {
     let current_platform = get_current_platform();
 
-    // Platform check
+    // 1. Platform check
     if !policy.platforms.is_empty() && !policy.platforms.contains(&current_platform) {
         return Err(format!(
             "platform not permitted: {} not in {:?}",
@@ -279,17 +279,22 @@ pub fn enforce_policy(
         ));
     }
 
-    // Root / Administrator check
+    // 2. OS keychain check
+    if policy.use_os_keychain {
+        return Err("use_os_keychain is not supported by this launcher".to_string());
+    }
+
+    // 3. Root / Administrator check
     #[cfg(unix)]
     if policy.refuse_root && unsafe { libc::geteuid() } == 0 {
-        return Err("refused to run as root".to_string());
+        return Err("refused to run as root or Administrator".to_string());
     }
     #[cfg(target_os = "windows")]
     if policy.refuse_root && is_windows_admin() {
-        return Err("refused to run as Administrator".to_string());
+        return Err("refused to run as root or Administrator".to_string());
     }
 
-    // Age check
+    // 4. Age check
     if let Some(max_days) = policy.max_age_days {
         if build_timestamp > 0 {
             let now = SystemTime::now()
@@ -306,28 +311,22 @@ pub fn enforce_policy(
         }
     }
 
-    // Environment variable check
+    // 5. Environment variable check
     for var in &policy.require_env {
-        if std::env::var(var).is_err() {
-            return Err(format!("required environment variable not set: {}", var));
+        match std::env::var(var) {
+            Ok(val) if !val.is_empty() => {}
+            _ => return Err(format!("required environment variable not set: {}", var)),
         }
     }
 
-    // SBOM check
+    // 6. SBOM check
     if policy.require_sbom && !has_sbom {
         return Err(
             "package built without attestation slot — operator policy requires SBOM".to_string(),
         );
     }
 
-    if policy.use_os_keychain {
-        return Err(
-            "operator policy requests OS keychain trust, but Rust launcher does not support it"
-                .to_string(),
-        );
-    }
-
-    // Trusted key check
+    // 7. Trusted key check
     if policy.require_trusted_key && !key_trusted {
         return Err(
             "operator policy requires a trusted signing key — package key is not in the trusted store"

--- a/src/flavor-rs/src/psp/format_2025/trust.rs
+++ b/src/flavor-rs/src/psp/format_2025/trust.rs
@@ -91,10 +91,7 @@ pub fn derive_index_key_fingerprint(index: &super::index::Index) -> Result<Optio
         .to_string();
 
     if !stored.is_empty() && stored != derived {
-        return Err(format!(
-            "attestation_key_fp mismatch: stored={} derived={}",
-            stored, derived
-        ));
+        return Err("attestation key fingerprint does not match embedded public key".to_string());
     }
 
     Ok(Some(derived))

--- a/src/flavor/config/policy.py
+++ b/src/flavor/config/policy.py
@@ -229,12 +229,19 @@ def enforce_policy(policy: EffectivePolicy, build_timestamp: int, has_sbom: bool
     """Enforce the effective launch policy for the current runtime environment."""
     current_platform = get_current_platform()
 
+    # 1. Platform check
     if policy.platforms and current_platform not in policy.platforms:
         raise ValueError(f"platform not permitted: {current_platform} not in {policy.platforms}")
 
+    # 2. OS keychain check
+    if policy.use_os_keychain:
+        raise ValueError("use_os_keychain is not supported by this launcher")
+
+    # 3. Root / Administrator check
     if policy.refuse_root and is_privileged_user():
         raise ValueError("refused to run as root or Administrator")
 
+    # 4. Age check
     if policy.max_age_days is not None and build_timestamp > 0:
         age_days = int((datetime.now(UTC).timestamp() - build_timestamp) / 86400)
         if age_days > policy.max_age_days:
@@ -242,16 +249,16 @@ def enforce_policy(policy: EffectivePolicy, build_timestamp: int, has_sbom: bool
                 f"package is {age_days} days old — policy requires max {policy.max_age_days} days"
             )
 
+    # 5. Environment variable check
     missing = [var for var in policy.require_env if not os.environ.get(var)]
     if missing:
         raise ValueError(f"required environment variable not set: {missing[0]}")
 
-    if policy.use_os_keychain:
-        raise ValueError("use_os_keychain is enabled, but OS keychain trust is not implemented")
-
+    # 6. SBOM check
     if policy.require_sbom and not has_sbom:
         raise ValueError("package built without attestation slot — operator policy requires SBOM")
 
+    # 7. Trusted key check
     if policy.require_trusted_key and not key_trusted:
         raise ValueError(
             "operator policy requires a trusted signing key — package key is not in the trusted store"

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -239,8 +239,16 @@ class PSPFLauncher(PSPFReader):
             logger.debug(f"📤 Extracting tarball {slot_name} to {workenv_dir}")
             try:
                 with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
-                    # Use the filter parameter to avoid Python 3.14 deprecation warning
-                    tar.extractall(path=workenv_dir, filter="data")
+                    # "data" rejects absolute paths and .. but still allows symlinks;
+                    # we additionally strip symlinks to prevent link-based traversal.
+                    def _safe_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
+                        result = tarfile.data_filter(member, path)
+                        if result is not None and (result.issym() or result.islnk()):
+                            logger.warning(f"⚠️ Skipping symlink/hardlink in tarball: {result.name}")
+                            return None
+                        return result
+
+                    tar.extractall(path=workenv_dir, filter=_safe_filter)  # nosec B202
 
                 if slot_name in {".", "{workenv}"}:
                     return workenv_dir
@@ -268,7 +276,8 @@ class PSPFLauncher(PSPFReader):
             return
 
         try:
-            output_path.chmod(int(str(permissions), 8))
+            mode = int(str(permissions), 8) & 0o777  # Strip setuid/setgid/sticky bits
+            output_path.chmod(mode)
         except (OSError, ValueError) as e:
             logger.warning(f"⚠️ Failed to apply slot permissions to {output_path}: {e}")
 

--- a/tools/validate_wheel.py
+++ b/tools/validate_wheel.py
@@ -123,6 +123,9 @@ def validate_helpers(wheel_path: Path) -> tuple[bool, list[str]]:  # noqa: C901
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(wheel_path, "r") as whl:
+            for member in whl.namelist():
+                if member.startswith("/") or ".." in member.split("/"):
+                    raise ValueError(f"Unsafe path in wheel: {member}")
             whl.extractall(tmpdir)
 
         helpers_dir = Path(tmpdir) / "flavor" / "helpers" / "bin"


### PR DESCRIPTION
## Summary

Addresses all 11 findings from a comprehensive architectural code review of the security hardening work merged in PR #4.

- **Policy enforcement order** aligned across Python, Go, and Rust (platform → use_os_keychain → refuse_root → max_age_days → require_env → require_sbom → require_trusted_key)
- **Rust `require_env` empty-string semantics** fixed to match Go/Python (empty = unset)
- **Go file permissions** hardened from 0644 to 0600 (FilePerms) across 7 locations in launcher, cache, slots, locking, and workenv validation
- **CI credentials** hardened with `persist-credentials: false` on 11 checkout steps in release.yml and compatibility-check.yml
- **9 missing Rust env var constants** added to env_vars.rs for Go parity
- **Python slot permissions** clamped to 0o777 (strips setuid/setgid/sticky bits from adversarial metadata)
- **Tarfile extraction** now rejects symlinks/hardlinks via custom filter
- **Go launcher default log level** changed from trace to warn for production
- **Rust attestation error** no longer leaks fingerprint hash values
- **validate_wheel.py** now validates zipfile member paths before extraction

## Test plan

- [ ] All 2365 Python tests pass locally (0 failures)
- [ ] All Go tests pass (`go test ./...`)
- [ ] All 214 Rust tests pass (`cargo test`)
- [ ] All 96 cross-language parity tests pass
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)