### PR TITLE
fix: clarify slot storage invariant and replace operation magic numbers

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/slot_processor.go
+++ b/src/flavor-go/pkg/psp/format_2025/slot_processor.go
@@ -34,17 +34,21 @@ func isSelfReferential(source string) bool {
 //
 // The processor handles:
 // - Loading slot data from disk
-// - Applying encoding/compression
-// - Calculating checksums
+// - Calculating checksums of the stored data
 // - Creating slot descriptors for the binary format
 // - Creating slot metadata for the JSON metadata section
 //
+// Slot storage invariant: slot sources are stored verbatim (as read from disk).
+// If a slot declares Operations "gzip" or "tar.gz", the source file must already
+// be in that format — the builder does not apply compression.  The descriptor's
+// Checksum field always covers the data exactly as written to the package file.
+//
 // Slot processing workflow:
 // 1. Load manifest slots configuration
-// 2. Process each slot (read, compress, checksum)
+// 2. Process each slot (read, checksum, create descriptor)
 // 3. Create descriptors for binary slot table
 // 4. Create metadata for JSON metadata section
-// 5. Store compressed data for writing to package
+// 5. Store raw data for writing to package
 type SlotProcessor struct {
 	// Slots from manifest configuration
 	manifestSlots []Slot
@@ -255,13 +259,16 @@ func (sp *SlotProcessor) processSlot(index int, slot *Slot) error {
 	}
 
 	// Normal slot processing - read and process slot data
-	slotData, compressed, _, err := sp.loadSlotData(slot)
+	rawData, err := sp.loadSlotData(slot)
 	if err != nil {
 		return fmt.Errorf("failed to load slot data: %w", err)
 	}
 
-	// Calculate checksum of compressed data
-	checksumData := sha256.Sum256(compressed)
+	// Checksum is always of the data as stored (rawData).
+	// Sources are stored verbatim; if Operations declares "gzip" the source must
+	// already be gzip-compressed.  This checksum must stay consistent with what
+	// the reader's computeSlotChecksum call verifies on read.
+	checksumData := sha256.Sum256(rawData)
 	checksumStr := fmt.Sprintf("sha256:%x", checksumData)
 
 	// Create slot metadata
@@ -270,7 +277,7 @@ func (sp *SlotProcessor) processSlot(index int, slot *Slot) error {
 		ID:          slot.ID,
 		Source:      slot.Source,
 		Target:      slot.Target,
-		Size:        int64(len(slotData)),
+		Size:        int64(len(rawData)),
 		Checksum:    checksumStr,
 		Operations:  slot.Operations,
 		Purpose:     slot.Purpose,
@@ -298,10 +305,10 @@ func (sp *SlotProcessor) processSlot(index int, slot *Slot) error {
 		ID:              uint64(index),
 		NameHash:        HashName(slot.Target),
 		Offset:          0, // Will be set during write phase
-		Size:            uint64(len(compressed)),
-		OriginalSize:    uint64(len(slotData)),
+		Size:            uint64(len(rawData)),
+		OriginalSize:    uint64(len(rawData)), // same: sources stored verbatim
 		Operations:      operations,
-		Checksum:        computeSlotChecksum(compressed), // SHA-256 first 8 bytes
+		Checksum:        computeSlotChecksum(rawData), // SHA-256 first 8 bytes of stored data
 		Purpose:         mapPurposeToUint8(slot.Purpose),
 		Lifecycle:       mapLifecycleToUint8(slot.Lifecycle),
 		Priority:        128, // normal priority
@@ -312,33 +319,31 @@ func (sp *SlotProcessor) processSlot(index int, slot *Slot) error {
 		PermissionsHigh: uint8(parsePermissions(slot.Permissions) >> 8),
 	}
 
-	// Store processed data
+	// Store raw data to be written verbatim to the package file
 	sp.metadataSlots = append(sp.metadataSlots, slotMeta)
 	sp.slotDescriptors = append(sp.slotDescriptors, descriptor)
-	sp.slotData = append(sp.slotData, compressed)
+	sp.slotData = append(sp.slotData, rawData)
 
 	sp.logger.Debug("✅ Slot processed", "index", index, "id", slot.ID,
-		"compressed_size", len(compressed), "original_size", len(slotData))
+		"size", len(rawData))
 
 	return nil
 }
 
-// loadSlotData loads and processes slot data based on encoding.
+// loadSlotData reads a slot's source file from disk verbatim.
 //
-// This method reads the slot data from disk and applies any specified
-// encoding. It supports path resolution with {workenv} placeholder and
-// various codec formats (gzip, tar, tar.gz, none).
+// Slot sources are stored as-is.  If a slot declares Operations "gzip" or
+// "tar.gz", the caller is responsible for providing a source file that is
+// already in that format — this function does not apply any compression.
 //
 // Args:
 //
-//	slot: The slot configuration containing source path and encoding
+//	slot: The slot configuration containing source path and operations
 //
 // Returns:
-//   - Original uncompressed data
-//   - Compressed/encoded data
-//   - Encoding method constant for the binary format
+//   - Raw data read from disk (= the bytes that will be written to the package)
 //   - Error if the data cannot be loaded
-func (sp *SlotProcessor) loadSlotData(slot *Slot) ([]byte, []byte, uint8, error) {
+func (sp *SlotProcessor) loadSlotData(slot *Slot) ([]byte, error) {
 	// Resolve {workenv} placeholder
 	slotPath := slot.Source
 	if strings.Contains(slotPath, "{workenv}") {
@@ -351,19 +356,15 @@ func (sp *SlotProcessor) loadSlotData(slot *Slot) ([]byte, []byte, uint8, error)
 			"resolved", slotPath, "base", baseDir)
 	}
 
-	// Read slot data
-	slotData, err := os.ReadFile(slotPath)
+	// Read slot data verbatim
+	rawData, err := os.ReadFile(slotPath)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to read slot from %s: %w", slotPath, err)
+		return nil, fmt.Errorf("failed to read slot from %s: %w", slotPath, err)
 	}
 
-	sp.logger.Debug("📊 Slot size", "original", len(slotData), "operations", slot.Operations)
+	sp.logger.Debug("📊 Slot size", "bytes", len(rawData), "operations", slot.Operations)
 
-	// For now, we don't actually compress here - that's handled elsewhere
-	// This function just validates and prepares the data
-	compressed := slotData
-
-	return slotData, compressed, 0, nil
+	return rawData, nil
 }
 
 // GetDescriptors returns the processed slot descriptors
@@ -376,7 +377,9 @@ func (sp *SlotProcessor) GetMetadata() []SlotMetadata {
 	return sp.metadataSlots
 }
 
-// GetSlotData returns the compressed slot data
+// GetSlotData returns the raw slot data as it will be written to the package file.
+// Each entry is the verbatim bytes of the slot source; no compression is applied
+// by the builder.
 func (sp *SlotProcessor) GetSlotData() [][]byte {
 	return sp.slotData
 }

--- a/src/flavor-go/pkg/psp/format_2025/slot_processor_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/slot_processor_test.go
@@ -126,18 +126,15 @@ func TestSlotProcessorLoadSlotDataResolvesWorkenvPlaceholder(t *testing.T) {
 	t.Setenv(EnvWorkenvBase, tmpDir)
 
 	processor := NewSlotProcessor(nil, hclog.NewNullLogger())
-	original, compressed, encoding, err := processor.loadSlotData(&Slot{
+	rawData, err := processor.loadSlotData(&Slot{
 		Source:     "{workenv}/nested/payload.txt",
 		Operations: "raw",
 	})
 	if err != nil {
 		t.Fatalf("loadSlotData() error = %v", err)
 	}
-	if string(original) != "via-workenv" || string(compressed) != "via-workenv" {
-		t.Fatalf("unexpected slot contents: original=%q compressed=%q", string(original), string(compressed))
-	}
-	if encoding != 0 {
-		t.Fatalf("expected encoding 0 for raw slot, got %d", encoding)
+	if string(rawData) != "via-workenv" {
+		t.Fatalf("unexpected slot contents: %q", string(rawData))
 	}
 }
 

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -22,11 +22,19 @@ from provide.foundation.file.directory import ensure_dir, ensure_parent_dir, saf
 from flavor.config.defaults import DEFAULT_DISK_SPACE_MULTIPLIER
 from flavor.config.policy import enforce_policy, load_operator_policy, merge_policy, parse_package_policy
 from flavor.config.trust import compute_key_fingerprint, is_key_trusted
-from flavor.psp.format_2025.constants import DEFAULT_SLOT_DESCRIPTOR_SIZE
+from flavor.psp.format_2025.constants import DEFAULT_SLOT_DESCRIPTOR_SIZE, OP_GZIP, OP_NONE, OP_TAR
+from flavor.psp.format_2025.operations import pack_operations
 from flavor.psp.format_2025.reader import PSPFReader
 from flavor.psp.format_2025.targets import normalize_workenv_target
 from flavor.psp.format_2025.workenv import WorkEnvManager
 from flavor.psp.security import verify_package_integrity
+
+# Pre-computed operation chain values — must match Go/Rust implementations.
+# Operations field is a packed 64-bit integer: each byte is one operation code.
+_OP_NONE = OP_NONE  # 0x00 — raw data, no processing
+_OP_TAR = pack_operations([OP_TAR])  # 0x01 — tar archive
+_OP_GZIP = pack_operations([OP_GZIP])  # 0x10 — gzip compressed
+_OP_TAR_GZ = pack_operations([OP_TAR, OP_GZIP])  # 0x1001 — gzip-compressed tar
 
 
 class PSPFLauncher(PSPFReader):
@@ -197,16 +205,16 @@ class PSPFLauncher(PSPFReader):
 
         # NOTE: Decoding logic must match Go/Rust implementations
         # Decode if needed
-        if slot_entry["operations"] == 0:  # raw/none
+        if slot_entry["operations"] == _OP_NONE:
             data = slot_data
-        elif slot_entry["operations"] == 0x01:  # tar
+        elif slot_entry["operations"] == _OP_TAR:
             data = slot_data  # Tar archives are extracted later
-        elif slot_entry["operations"] == 0x10:  # gzip
+        elif slot_entry["operations"] == _OP_GZIP:
             logger.debug(f"🗜️ Decompressing slot {slot_index} with gzip")
             import gzip
 
             data = gzip.decompress(slot_data)
-        elif slot_entry["operations"] == 0x1001:  # tar.gz
+        elif slot_entry["operations"] == _OP_TAR_GZ:
             data = slot_data  # Will be decompressed and extracted later
         else:
             logger.error(f"❌ Unsupported operations: {slot_entry['operations']}")

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -22,19 +22,19 @@ from provide.foundation.file.directory import ensure_dir, ensure_parent_dir, saf
 from flavor.config.defaults import DEFAULT_DISK_SPACE_MULTIPLIER
 from flavor.config.policy import enforce_policy, load_operator_policy, merge_policy, parse_package_policy
 from flavor.config.trust import compute_key_fingerprint, is_key_trusted
-from flavor.psp.format_2025.constants import DEFAULT_SLOT_DESCRIPTOR_SIZE, OP_GZIP, OP_NONE, OP_TAR
+from flavor.psp.format_2025.constants import DEFAULT_SLOT_DESCRIPTOR_SIZE, OP_NONE, OPERATION_CHAINS
 from flavor.psp.format_2025.operations import pack_operations
 from flavor.psp.format_2025.reader import PSPFReader
 from flavor.psp.format_2025.targets import normalize_workenv_target
 from flavor.psp.format_2025.workenv import WorkEnvManager
 from flavor.psp.security import verify_package_integrity
 
-# Pre-computed operation chain values — must match Go/Rust implementations.
+# Pre-computed operation chain values — derived from OPERATION_CHAINS (the canonical source).
 # Operations field is a packed 64-bit integer: each byte is one operation code.
 _OP_NONE = OP_NONE  # 0x00 — raw data, no processing
-_OP_TAR = pack_operations([OP_TAR])  # 0x01 — tar archive
-_OP_GZIP = pack_operations([OP_GZIP])  # 0x10 — gzip compressed
-_OP_TAR_GZ = pack_operations([OP_TAR, OP_GZIP])  # 0x1001 — gzip-compressed tar
+_OP_TAR = pack_operations(OPERATION_CHAINS["tar"])
+_OP_GZIP = pack_operations(OPERATION_CHAINS["gzip"])
+_OP_TAR_GZ = pack_operations(OPERATION_CHAINS["tar.gz"])
 
 
 class PSPFLauncher(PSPFReader):


### PR DESCRIPTION
## Summary

- **Fragility #3 — `slot_processor.go`**: `loadSlotData` returned two identical values (`compressed = slotData`) with a comment claiming "compression handled elsewhere" — there was no "elsewhere". The design is that slot sources are stored verbatim; if a slot declares `Operations="gzip"` the caller provides a pre-gzipped source. Collapsed to a single return value, renamed the misleading `compressed` variable to `rawData` throughout, updated all doc comments to state the invariant explicitly, and fixed `GetSlotData()` to say "raw" instead of "compressed". Updated the one test that called `loadSlotData` directly.

- **Fragility #2 — `launcher.py`**: Replace hardcoded operation literals (`0`, `0x01`, `0x10`, `0x1001`) in `extract_slot` with module-level constants computed via `pack_operations()` and the shared `OP_GZIP`/`OP_TAR`/`OP_NONE` constants from `constants.py`. The values were correct but would silently diverge if the packing scheme changed. A comment now cross-references Go/Rust for parity checks.

## Test plan

- [x] `go test ./pkg/psp/format_2025/...` — all slot processor tests pass
- [x] `pytest tests/format_2025/test_launcher_*` — 35 passed
- [x] All pre-push hooks passed (mypy, bandit, go test, cargo test, go vet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)