### PR TITLE
fix: address fragility hotspots #4, #5, #8

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/reader_verify.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_verify.go
@@ -94,7 +94,9 @@ func (r *Reader) VerifyIntegritySeal() (bool, error) {
 		return false, err
 	}
 
-	// Get signature from index (first 64 bytes of IntegritySignature field)
+	// IntegritySignature is a fixed [512]byte array; only the first 64 bytes carry
+	// the Ed25519 signature (the rest are zero-padded). Slicing a fixed array is
+	// always in-bounds, so this cannot panic.
 	signature := index.IntegritySignature[:64]
 
 	// Check if signature is present (not all zeros)

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -237,7 +237,7 @@ class PSPFLauncher(PSPFReader):
 
         is_tarball = False
         with (
-            contextlib.suppress(tarfile.TarError, EOFError, OSError),
+            contextlib.suppress(tarfile.TarError, EOFError),
             tarfile.open(fileobj=io.BytesIO(data), mode="r:*"),
         ):
             # If we can open it, it's a tarball

--- a/src/flavor/psp/format_2025/slots.py
+++ b/src/flavor/psp/format_2025/slots.py
@@ -355,9 +355,11 @@ class SlotView:
 
                 # For now, handle simple cases
                 if ops == [OP_GZIP]:
-                    import zlib
+                    import gzip
 
-                    self._decompressed = zlib.decompress(self.data)
+                    self._decompressed = gzip.decompress(
+                        bytes(self.data) if isinstance(self.data, memoryview) else self.data
+                    )
                 elif ops == [OP_TAR, OP_GZIP]:
                     # For tar.gz, return as-is (launcher handles extraction)
                     self._decompressed = bytes(self.data) if isinstance(self.data, memoryview) else self.data

--- a/tests/format_2025/test_coverage_gaps.py
+++ b/tests/format_2025/test_coverage_gaps.py
@@ -1337,12 +1337,13 @@ class TestSlotsEdgeCases:
             SlotMetadata.from_dict(data)
 
     def test_slot_view_content_gzip(self) -> None:
-        """Lines 357-360: SlotView content with GZIP operations uses zlib."""
+        """Lines 357-360: SlotView content with GZIP operations uses gzip (RFC 1952)."""
+        import gzip as gzip_mod
+
         from flavor.psp.format_2025.operations import OP_GZIP, pack_operations
 
         raw_data = b"hello gzip"
-        # zlib compressed (not gzip)
-        compressed = zlib.compress(raw_data)
+        compressed = gzip_mod.compress(raw_data)
 
         ops = pack_operations([OP_GZIP])
         descriptor = SlotDescriptor(id=0, offset=0, size=len(compressed), checksum=0, operations=ops)

--- a/tests/format_2025/test_slots.py
+++ b/tests/format_2025/test_slots.py
@@ -284,13 +284,13 @@ class TestSlotView:
         assert view.content == b"raw content"
 
     def test_content_gzip_decompresses(self) -> None:
-        """content decompresses gzip data."""
-        import zlib
+        """content decompresses gzip (RFC 1952) data."""
+        import gzip as gzip_mod
 
         from flavor.psp.format_2025.operations import OP_GZIP, pack_operations
 
         original = b"hello world"
-        compressed = zlib.compress(original)
+        compressed = gzip_mod.compress(original)
         desc = self._make_descriptor(operations=pack_operations([OP_GZIP]))
         view = SlotView(desc)
         view._data = compressed


### PR DESCRIPTION
## Summary

- **#4** (`launcher.py:240`): Remove `OSError` from the tarball-detection `contextlib.suppress` list. Disk I/O errors must propagate — silently swallowing them makes "slot is not a tarball" indistinguishable from "disk read failed".
- **#5** (`reader_verify.go:98`): Document why `IntegritySignature[:64]` cannot panic. `IntegritySignature` is a fixed `[512]byte` array; a runtime length guard would be dead code. The comment now makes the invariant explicit.
- **#8** (`slots.py:358`): Replace `zlib.decompress` with `gzip.decompress` for `OP_GZIP` slots. zlib (RFC 1950, `0x78` magic) is the wrong decompressor for gzip (RFC 1952, `0x1f 0x8b` magic) content. Two tests updated to use actual gzip-compressed fixture data.

## Test plan

- [ ] `pytest tests/` — all 2397 tests pass (verified locally)
- [ ] `go test ./...` in `src/flavor-go` — all Go tests pass (verified locally)
- [ ] Confirm `test_slot_view_content_gzip` and `test_content_gzip_decompresses` exercise the corrected `gzip.decompress` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)