### PR TITLE
fix(go): resolve staticcheck linter violations

### DIFF
--- a/src/flavor-go/internal/workenv/workenv_test.go
+++ b/src/flavor-go/internal/workenv/workenv_test.go
@@ -39,33 +39,35 @@ func TestGetCacheRoot(t *testing.T) {
 	}
 
 	t.Setenv(envvars.EnvCacheDir, "")
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "linux":
 		if got, want := GetCacheRoot(), filepath.Join("/tmp/xdg-cache", "flavor"); got != want {
 			t.Fatalf("GetCacheRoot xdg mismatch: got %q want %q", got, want)
 		}
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		// On Windows, LOCALAPPDATA may be set; clear it to test fallback to TempDir.
 		t.Setenv("LOCALAPPDATA", "")
 		if got, want := GetCacheRoot(), filepath.Join(os.TempDir(), "flavor", "cache"); got != want {
 			t.Fatalf("GetCacheRoot windows fallback mismatch: got %q want %q", got, want)
 		}
-	} else {
+	default:
 		if got, want := GetCacheRoot(), filepath.Join("/tmp/home", "Library", "Caches", "flavor"); got != want {
 			t.Fatalf("GetCacheRoot home mismatch: got %q want %q", got, want)
 		}
 	}
 
 	t.Setenv("XDG_CACHE_HOME", "")
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "linux":
 		if got, want := GetCacheRoot(), filepath.Join("/tmp/home", ".cache", "flavor"); got != want {
 			t.Fatalf("GetCacheRoot home mismatch: got %q want %q", got, want)
 		}
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		// LOCALAPPDATA already cleared above; fallback is TempDir.
 		if got, want := GetCacheRoot(), filepath.Join(os.TempDir(), "flavor", "cache"); got != want {
 			t.Fatalf("GetCacheRoot windows fallback mismatch: got %q want %q", got, want)
 		}
-	} else {
+	default:
 		if got, want := GetCacheRoot(), filepath.Join("/tmp/home", "Library", "Caches", "flavor"); got != want {
 			t.Fatalf("GetCacheRoot home mismatch: got %q want %q", got, want)
 		}

--- a/src/flavor-go/pkg/psp/format_2025/attestation_verify_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/attestation_verify_test.go
@@ -205,7 +205,7 @@ func TestVerifyAttestationSbomDigest_DigestPresentNoSlot(t *testing.T) {
 	if _, err := f.Write(slotContent); err != nil {
 		t.Fatalf("write slot data: %v", err)
 	}
-	var offset uint64 = uint64(len(slotContent))
+	offset := uint64(len(slotContent))
 
 	slotTableOffset := offset
 	if _, err := f.Write(desc.Pack()); err != nil {

--- a/src/flavor-go/pkg/psp/format_2025/execution_slots.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slots.go
@@ -90,7 +90,7 @@ func extractAndMergeSlotsToWorkenv(
 		nameJ := entries[j].Name()
 
 		// Extract slot numbers for slot_N_* directories
-		var slotI, slotJ int = -1, -1
+		slotI, slotJ := -1, -1
 		if _, err := fmt.Sscanf(nameI, "slot_%d_", &slotI); err == nil && entries[i].IsDir() {
 			// nameI is a slot directory
 		} else {


### PR DESCRIPTION
## Summary

- **Task 1 (persist-credentials)**: Already applied to all checkout steps — no changes needed.
- **Task 3 (linter violations)**: Fixed 4 staticcheck findings that were surfacing as CI annotations:
  - `workenv_test.go`: Two `if/else-if/else` chains on `runtime.GOOS` converted to tagged `switch` statements (QF1003)
  - `attestation_verify_test.go`: Redundant `uint64` type annotation removed (QF1011)
  - `execution_slots.go`: Redundant `int` type annotation on short variable declaration removed (QF1011)

No errcheck violations were found — those were resolved by the earlier `slot_processor.go` refactor (PR #8).

## Test plan

- [ ] `go test ./...` in `src/flavor-go` — all tests pass (verified locally)
- [ ] `golangci-lint run` — 0 issues (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)