### PR TITLE
fix: Go launcher TAR slots extract to destDir — fixes wheels not found on Windows

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
@@ -721,6 +721,9 @@ func TestExtractAndMergeSlotsToWorkenvMovesSlotTopLevelFilesToWorkenvRoot(t *tes
 }
 
 func TestExtractAndMergeSlotsToWorkenvMergesRegularTargetDirectories(t *testing.T) {
+	// TAR slots extract to workenv root using the tar's own directory structure.
+	// A slot with target="assets" and tar entries "images/logo.txt" → workenv/images/logo.txt.
+	// Pre-existing workenv/images/ content is merged (not replaced).
 	cacheRoot := t.TempDir()
 	t.Setenv(EnvCacheDir, cacheRoot)
 
@@ -764,11 +767,13 @@ func TestExtractAndMergeSlotsToWorkenvMergesRegularTargetDirectories(t *testing.
 	}
 
 	paths := NewWorkenvPaths(cacheRoot, bundle)
-	targetDir := filepath.Join(paths.Workenv(), "assets")
-	if err := os.MkdirAll(filepath.Join(targetDir, "images"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(target) error = %v", err)
+	// TAR ignores slot target for extraction — files land at workenv root using tar paths.
+	// The tar has "images/logo.txt", so the pre-existing file goes in workenv/images/.
+	imagesDir := filepath.Join(paths.Workenv(), "images")
+	if err := os.MkdirAll(imagesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(images dir) error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(targetDir, "images", "existing.txt"), []byte("existing"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(imagesDir, "existing.txt"), []byte("existing"), 0o644); err != nil {
 		t.Fatalf("WriteFile(existing) error = %v", err)
 	}
 
@@ -776,10 +781,10 @@ func TestExtractAndMergeSlotsToWorkenvMergesRegularTargetDirectories(t *testing.
 		t.Fatalf("extractAndMergeSlotsToWorkenv() error = %v", err)
 	}
 
-	if got, err := os.ReadFile(filepath.Join(targetDir, "images", "logo.txt")); err != nil || string(got) != "logo" {
-		t.Fatalf("expected merged regular target directory file, err=%v content=%q", err, string(got))
+	if got, err := os.ReadFile(filepath.Join(imagesDir, "logo.txt")); err != nil || string(got) != "logo" {
+		t.Fatalf("expected merged tar directory file, err=%v content=%q", err, string(got))
 	}
-	if got, err := os.ReadFile(filepath.Join(targetDir, "images", "existing.txt")); err != nil || string(got) != "existing" {
+	if got, err := os.ReadFile(filepath.Join(imagesDir, "existing.txt")); err != nil || string(got) != "existing" {
 		t.Fatalf("expected existing file to remain after merge, err=%v content=%q", err, string(got))
 	}
 }

--- a/src/flavor-go/pkg/psp/format_2025/reader_slots.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_slots.go
@@ -208,21 +208,21 @@ func (r *Reader) ExtractSlot(slotIndex int, destDir string) (string, error) {
 	// Check if this is a tarball first (needed for logic below)
 	isTar := isTarball(decompressed)
 
-	if targetPath == "" || targetPath == "." {
-		// Target was "{workenv}" or "."
-		if isTar {
-			// TAR slots targeting {workenv}: extract directly to destDir (matches Rust behavior)
-			// The tarball contents will be extracted directly to destDir
-			destPath = destDir
-			extractDir = destDir
-		} else {
-			// Non-TAR slots targeting {workenv}: extract to slot-specific subdirectory for atomic move
-			slotSubdir := fmt.Sprintf("slot_%d_%s", slotIndex, slotMeta.ID)
-			destPath = filepath.Join(destDir, slotSubdir)
-			extractDir = destPath
-		}
+	if isTar {
+		// TAR slots always extract to destDir regardless of target — the tar entries encode the
+		// directory structure (e.g., "wheels/foo.whl"). This matches Rust launcher behavior
+		// where extract_tarball ignores slot_target and extracts directly to the workenv path.
+		// Using targetPath as an extraction subdirectory would double-nest the content:
+		// e.g., target="wheels" + tar entry "wheels/foo.whl" → wheels/wheels/foo.whl (wrong).
+		destPath = destDir
+		extractDir = destDir
+	} else if targetPath == "" || targetPath == "." {
+		// Non-TAR slots targeting {workenv}: extract to slot-specific subdirectory for atomic move
+		slotSubdir := fmt.Sprintf("slot_%d_%s", slotIndex, slotMeta.ID)
+		destPath = filepath.Join(destDir, slotSubdir)
+		extractDir = destPath
 	} else {
-		// Target has a subpath - join it with destDir
+		// Non-TAR (single file) slots with explicit target path
 		destPath = filepath.Join(destDir, targetPath)
 		extractDir = destPath
 	}

--- a/src/flavor-go/pkg/psp/format_2025/reader_slots_additional_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_slots_additional_test.go
@@ -306,7 +306,11 @@ func TestExtractSlotRejectsSymlink(t *testing.T) {
 	}
 }
 
-func TestExtractSlotTarRespectsTargetSubdirectory(t *testing.T) {
+func TestExtractSlotTarIgnoresTargetForArchives(t *testing.T) {
+	// TAR slots extract to destDir regardless of the target field — the tar entries encode
+	// the directory structure. A slot with target="assets" and tar entries "images/logo.txt"
+	// extracts to destDir/images/logo.txt (not destDir/assets/images/logo.txt).
+	// This matches Rust launcher behavior where extract_tarball ignores slot_target.
 	t.Parallel()
 
 	tarRaw := buildTarArchiveWithDirAndFile(t, "images", "logo.txt", 0o644, []byte("logo"))
@@ -328,12 +332,12 @@ func TestExtractSlotTarRespectsTargetSubdirectory(t *testing.T) {
 		t.Fatalf("ExtractSlot(targeted tar) error = %v", err)
 	}
 
-	wantDir := filepath.Join(destDir, "assets")
-	if extractedDir != wantDir {
-		t.Fatalf("ExtractSlot(targeted tar) path = %q, want %q", extractedDir, wantDir)
+	// TAR extracts to destDir (not destDir/assets) — tar entries encode the path
+	if extractedDir != destDir {
+		t.Fatalf("ExtractSlot(targeted tar) path = %q, want %q", extractedDir, destDir)
 	}
 
-	got, err := os.ReadFile(filepath.Join(wantDir, "images", "logo.txt"))
+	got, err := os.ReadFile(filepath.Join(destDir, "images", "logo.txt"))
 	if err != nil {
 		t.Fatalf("ReadFile(targeted tar payload) error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Root cause:** The Go launcher was using the slot's `target` field (e.g., `"wheels"`) as an extraction subdirectory for TAR slots. Since the Python builder's `wheels.tar.gz` already encodes `wheels/` inside the tar entries (matching the Rust launcher's expectation), files ended up double-nested at `{workenvDir}/wheels/wheels/*.whl`. The `enumerate_and_execute` setup command searched `{workenv}/wheels/*.whl`, found nothing, and pip ran with no arguments — failing the taster PSP on Windows.
- **Fix:** TAR slots now always extract to `destDir` regardless of the `target` field, matching Rust launcher behavior. Non-TAR (single file) slots continue to use `target` as the destination path.
- **Tests updated:** `TestExtractSlotTarRespectsTargetSubdirectory` renamed `TestExtractSlotTarIgnoresTargetForArchives` with corrected assertions; `TestExtractAndMergeSlotsToWorkenvMergesRegularTargetDirectories` updated to match new (correct) path expectations.

## Test plan

- [ ] All targeted Go unit tests pass: `TestExtractSlotTarIgnoresTargetForArchives`, `TestExtractAndMergeSlotsToWorkenvMergesRegularTargetDirectories`
- [ ] No new test failures introduced (pre-existing Windows permission-based failures are unchanged)
- [ ] Taster PSP on Windows (Go launcher): `enumerate_and_execute` finds `{workenv}/wheels/*.whl` and pip installs succeed
- [ ] Taster PSP with Rust launcher: behavior unchanged (Rust already extracted to workenv root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)