### PR TITLE
fix(packaging): ask pip for every manylinux tag a build accepts

### DIFF
--- a/docs/guide/packaging/manifest.md
+++ b/docs/guide/packaging/manifest.md
@@ -64,6 +64,7 @@ All other `[project]` fields (description, readme, license, etc.) are preserved 
 | Field | Status | Description |
 |-------|--------|-------------|
 | `dependencies` | ✅ Supported | Build-time dependencies |
+| `manylinux` | ✅ Supported | Manylinux tags Linux wheels may be downloaded for, most preferred first |
 
 #### `[tool.flavor.execution.runtime.env]` Section ✅
 
@@ -256,6 +257,42 @@ dependencies = [                  # ✅ Supported
     "wheel>=0.38",
     "setuptools>=65.0",
 ]
+
+# Which Linux wheels this package may be built from, most preferred first.
+# Defaults to ["manylinux2014", "manylinux_2_28"].
+manylinux = [                     # ✅ Supported
+    "manylinux2014",
+    "manylinux_2_28",
+]
+```
+
+##### Choosing manylinux tags
+
+`pip download --platform TAG` does not mean *prefer* `TAG`. It replaces the set
+of platform tags pip will consider, and pip expands each one **downward only**:
+asking for `manylinux2014` (an alias of `manylinux_2_17`) makes 2_17, 2_12, 2_5
+and `manylinux1` wheels visible, and everything newer invisible. A single tag is
+therefore a ceiling on what the ecosystem is allowed to have moved on to, not a
+floor under compatibility.
+
+That ceiling gets reached. jq published manylinux2014 wheels through 1.10.0 and
+`manylinux_2_26/2_28` from 1.11.0, so a lock resolving jq 1.12.0 failed the
+Linux build outright with `No matching distribution found`, while the same
+build succeeded on macOS and Windows.
+
+Every tag listed is passed to pip as its own `--platform`, and **pip prefers the
+one listed first**. The default therefore keeps `manylinux2014` at the front: a
+package that still publishes a 2_17 wheel is selected exactly as before, and
+`manylinux_2_28` applies only where nothing older is published at all.
+
+Order the list by what the artifact must run on. Putting a newer tag first
+raises the glibc floor of everything you build — that is a deliberate
+compatibility decision, not a default:
+
+```toml
+[tool.flavor.build]
+# "This artifact targets RHEL 9 and newer; prefer the modern wheels."
+manylinux = ["manylinux_2_28", "manylinux2014"]
 ```
 
 !!! warning "📋 Planned Features - Not Yet Implemented"

--- a/src/flavor/packaging/python/dependency_resolver.py
+++ b/src/flavor/packaging/python/dependency_resolver.py
@@ -19,6 +19,7 @@ from provide.foundation.platform import get_arch_name, get_os_name
 from provide.foundation.process import run
 from provide.foundation.resilience.types import BackoffStrategy
 
+from flavor.packaging.python.manylinux import DEFAULT_MANYLINUX_TAGS, platform_tags_for_arch
 from flavor.packaging.python.pypapip_manager import PyPaPipManager
 from flavor.packaging.python.uv_manager import UVManager
 
@@ -238,17 +239,17 @@ class DependencyResolver:
             logger.warning(f"Failed to download UV wheel via pip: {e}")
             return None
 
-    def _get_uv_platform_tag(self) -> str | None:
-        """Get platform tag for UV wheel download."""
-        # ⚠️ CRITICAL: Using pip_manager for correct manylinux handling ⚠️
-        # DO NOT replace this with direct uv commands - they don't handle platform tags correctly!
-        arch = get_arch_name()
-        if get_os_name() == "linux":
-            if arch == "amd64":
-                return "manylinux2014_x86_64"
-            elif arch == "arm64":
-                return "manylinux2014_aarch64"
-        return None
+    def _get_uv_platform_tag(self) -> list[str]:
+        """Platform tags for the UV wheel download.
+
+        ⚠️ CRITICAL: Using pip_manager for correct manylinux handling ⚠️
+        DO NOT replace this with direct uv commands - they don't handle platform
+        tags correctly! The tags themselves come from the shared policy, so this
+        does not drift from what the rest of the build asks for.
+        """
+        if get_os_name() != "linux":
+            return []
+        return platform_tags_for_arch(DEFAULT_MANYLINUX_TAGS, get_arch_name())
 
     @retry(
         ConnectionError,

--- a/src/flavor/packaging/python/manylinux.py
+++ b/src/flavor/packaging/python/manylinux.py
@@ -1,0 +1,124 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Which Linux wheels a packaged build is allowed to see.
+
+`pip download --platform TAG` does not mean "prefer TAG". It replaces the set of
+platform tags pip will consider, and pip expands each one *downward* only:
+asking for `manylinux2014` (an alias of `manylinux_2_17`) makes 2_17, 2_12, 2_5
+and `manylinux1` wheels visible, and everything newer invisible. A single
+hardcoded tag is therefore a ceiling on what the ecosystem is allowed to have
+moved on to, not a floor under compatibility.
+
+That ceiling is reached in practice. jq published manylinux2014 wheels through
+1.10.0 and `manylinux_2_26/2_28` from 1.11.0, so a lock that resolved jq 1.12.0
+failed the Linux build outright with "No matching distribution found", while
+darwin and windows built fine.
+
+pip accepts `--platform` more than once, and prefers the tag listed *first*.
+The default here lists `manylinux2014` first, so a package that still publishes
+a 2_17 wheel is selected exactly as before and the artifact's glibc floor is
+unchanged; `manylinux_2_28` is a fallback that only applies where nothing older
+is published at all. Widening the default in that direction is not the same as
+choosing a newer glibc floor deliberately -- a package can set `manylinux` in
+`[tool.flavor.build]` to state the floor it actually intends.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from provide.foundation import logger
+
+#: Ordered by preference. `manylinux2014` first keeps the wheels chosen for an
+#: artifact identical to what a single-tag build chose; `manylinux_2_28` is
+#: reached only for packages that publish nothing older.
+DEFAULT_MANYLINUX_TAGS: tuple[str, ...] = ("manylinux2014", "manylinux_2_28")
+
+#: flavorpack's architecture names to the ones manylinux tags spell.
+_ARCH_SUFFIXES: dict[str, str] = {
+    "amd64": "x86_64",
+    "x86_64": "x86_64",
+    "arm64": "aarch64",
+    "aarch64": "aarch64",
+}
+
+#: The key a package sets under `[tool.flavor.build]`.
+CONFIG_KEY = "manylinux"
+
+
+def resolve_manylinux_tags(build_config: dict[str, Any] | None) -> tuple[str, ...]:
+    """Read the manylinux policy out of a package's build configuration.
+
+    Accepts a single tag or an ordered list of them, most preferred first. An
+    unusable value is reported and the default is used rather than failing the
+    build: a malformed string here should not be the reason a package cannot be
+    packaged at all.
+    """
+    if not build_config:
+        return DEFAULT_MANYLINUX_TAGS
+
+    configured = build_config.get(CONFIG_KEY)
+    if configured is None:
+        return DEFAULT_MANYLINUX_TAGS
+
+    if isinstance(configured, str):
+        configured = [configured]
+
+    if not isinstance(configured, Sequence) or isinstance(configured, bytes):
+        logger.warning(
+            f"⚠️ Ignoring [tool.flavor.build] {CONFIG_KEY}: expected a tag or list of tags, "
+            f"got {type(configured).__name__}. Using {', '.join(DEFAULT_MANYLINUX_TAGS)}."
+        )
+        return DEFAULT_MANYLINUX_TAGS
+
+    tags = tuple(tag for tag in configured if isinstance(tag, str) and tag.strip())
+    if len(tags) != len(list(configured)):
+        logger.warning(f"⚠️ Ignoring non-string entries in [tool.flavor.build] {CONFIG_KEY}.")
+    if not tags:
+        logger.warning(
+            f"⚠️ [tool.flavor.build] {CONFIG_KEY} is empty. Using {', '.join(DEFAULT_MANYLINUX_TAGS)}."
+        )
+        return DEFAULT_MANYLINUX_TAGS
+
+    return tags
+
+
+def platform_tags_for_arch(tags: Sequence[str], arch: str) -> list[str]:
+    """Expand bare manylinux tags into the arch-qualified ones pip wants.
+
+    An architecture with no manylinux spelling yields nothing, which leaves the
+    caller passing no `--platform` at all -- the right outcome, since pip then
+    resolves for the machine it is running on.
+    """
+    suffix = _ARCH_SUFFIXES.get(arch)
+    if suffix is None:
+        logger.debug(f"No manylinux tag mapping for arch {arch!r}; leaving platform unconstrained")
+        return []
+    expanded = [f"{tag}_{suffix}" for tag in tags]
+    if logger.is_trace_enabled():
+        logger.trace(f"Linux build detected, arch={arch}, requesting wheels for {', '.join(expanded)}")
+    return expanded
+
+
+def platform_constraint_hint(platform_tags: Sequence[str]) -> str:
+    """Explain a download failure that a platform constraint could have caused.
+
+    A bare "No matching distribution found" says nothing about the constraint
+    that hid the distribution, which is what makes this class of failure cost
+    hours. Naming the tags, and the fact that pip only expands them downward,
+    turns it into a one-line diagnosis.
+    """
+    if not platform_tags:
+        return ""
+    requested = ", ".join(platform_tags)
+    return (
+        f"\n\nWheels were requested for platform tags: {requested}. "
+        "pip only considers these tags and older ones, never newer, so a package that "
+        "has moved to a newer manylinux baseline is invisible here even though it is "
+        f"published. Set `{CONFIG_KEY}` under [tool.flavor.build] to the tags this "
+        "artifact should accept, most preferred first."
+    )

--- a/src/flavor/packaging/python/packager.py
+++ b/src/flavor/packaging/python/packager.py
@@ -18,6 +18,7 @@ from provide.foundation.file.formats import write_json
 
 from flavor.packaging.python.dist_manager import PythonDistManager
 from flavor.packaging.python.environment_builder import PythonEnvironmentBuilder
+from flavor.packaging.python.manylinux import resolve_manylinux_tags
 from flavor.packaging.python.pypapip_manager import PyPaPipManager
 from flavor.packaging.python.slot_builder import PythonSlotBuilder
 from flavor.packaging.python.uv_manager import UVManager
@@ -37,8 +38,10 @@ class PythonPackager:
     - UVManager: Handles UV operations
     """
 
-    # Class-level constants
-    MANYLINUX_TAG = "manylinux2014"
+    @property
+    def MANYLINUX_TAG(self) -> str:
+        """The manylinux tag this package prefers, first in its policy."""
+        return self.manylinux_tags[0]
 
     def __init__(
         self,
@@ -64,16 +67,20 @@ class PythonPackager:
         self.build_config = build_config or {}
         self.python_version = python_version
 
+        # Which Linux wheels this package is willing to see. One policy, read
+        # once, handed to everything that downloads.
+        self.manylinux_tags = resolve_manylinux_tags(self.build_config)
+
         # Platform detection
         self.is_windows = sys.platform == "win32"
         self.venv_bin_dir = "Scripts" if self.is_windows else "bin"
         self.uv_exe = "uv.exe" if self.is_windows else "uv"
 
         # Initialize manager instances
-        self.pypapip = PyPaPipManager()
+        self.pypapip = PyPaPipManager(manylinux_tags=self.manylinux_tags)
         self.uv = UVManager()
         self.uv_manager = self.uv  # Alias for compatibility
-        self.wheel_builder = WheelBuilder(python_version=python_version)
+        self.wheel_builder = WheelBuilder(python_version=python_version, manylinux_tags=self.manylinux_tags)
         self.dist_manager = PythonDistManager(python_version=python_version)
 
         # Initialize specialized builders

--- a/src/flavor/packaging/python/pypapip_manager.py
+++ b/src/flavor/packaging/python/pypapip_manager.py
@@ -4,11 +4,15 @@
 #
 
 """This module handles all pip-specific operations with proper platform support
-and manylinux2014 compatibility for maximum Linux distribution coverage.
+and manylinux compatibility for maximum Linux distribution coverage.
+
+Which manylinux tags a download may see is decided in one place, by
+:mod:`flavor.packaging.python.manylinux`; this module only asks for them.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import os
 from pathlib import Path
 import sys
@@ -20,6 +24,11 @@ from provide.foundation.process import run
 from provide.foundation.resilience.types import BackoffStrategy
 
 from flavor.config.defaults import ENV_WHEEL_CACHE
+from flavor.packaging.python.manylinux import (
+    DEFAULT_MANYLINUX_TAGS,
+    platform_constraint_hint,
+    platform_tags_for_arch,
+)
 from flavor.packaging.python.uv_manager import _windows_system_env
 
 # On Windows GHA runners, pip's vendored truststore fails:
@@ -65,17 +74,27 @@ class PyPaPipManager:
     DO NOT REPLACE pip commands with uv pip - they have different capabilities!
     """
 
-    # manylinux2014 = glibc 2.17+ (CentOS 7, Amazon Linux 2, Ubuntu 14.04+)
-    MANYLINUX_TAG = "manylinux2014"
-
-    def __init__(self, python_version: str = "3.11") -> None:
+    def __init__(
+        self,
+        python_version: str = "3.11",
+        manylinux_tags: Sequence[str] | None = None,
+    ) -> None:
         """
         Initialize the pip manager.
 
         Args:
             python_version: Target Python version for pip operations
+            manylinux_tags: Manylinux tags this build accepts, most preferred
+                first. Defaults to the shared policy; a package overrides it
+                with `manylinux` under [tool.flavor.build].
         """
         self.python_version = python_version
+        self.manylinux_tags: tuple[str, ...] = tuple(manylinux_tags or DEFAULT_MANYLINUX_TAGS)
+
+    @property
+    def MANYLINUX_TAG(self) -> str:
+        """The tag pip will prefer, which is the first one offered to it."""
+        return self.manylinux_tags[0]
 
     # ╔══════════════════════════════════════════════════════════════════════════════╗
     # ║                           CRITICAL PyPA HELPER METHODS                          ║
@@ -129,6 +148,40 @@ class PyPaPipManager:
         cmd.append(source.as_posix())
         return cmd
 
+    def _platform_failure_hint(self, stderr: str) -> str:
+        """Say so when a platform constraint is the likely reason for a failure.
+
+        pip reports a hidden wheel as "No matching distribution found", which
+        reads like the package does not exist. Naming the requested tags is the
+        difference between a one-line diagnosis and an afternoon: this is
+        exactly how jq 1.12.0 -- published, but only for a newer manylinux
+        baseline -- silently broke every Linux build.
+        """
+        if not stderr:
+            return ""
+        symptoms = ("No matching distribution found", "Could not find a version that satisfies")
+        if not any(symptom in stderr for symptom in symptoms):
+            return ""
+        return platform_constraint_hint(self._download_platform_tags())
+
+    def _download_platform_tags(
+        self,
+        platform_tag: str | Sequence[str] | None = None,
+        binary_only: bool = True,
+    ) -> list[str]:
+        """The `--platform` values a download should ask for.
+
+        An explicit tag wins: callers that already know exactly what they need
+        keep that ability. Otherwise a Linux build asks for this manager's
+        manylinux policy, and every other host is left unconstrained so pip
+        resolves for the machine it is running on.
+        """
+        if platform_tag:
+            return [platform_tag] if isinstance(platform_tag, str) else list(platform_tag)
+        if get_os_name() != "linux" or not binary_only:
+            return []
+        return platform_tags_for_arch(self.manylinux_tags, get_arch_name())
+
     # ⚠️ CRITICAL: This method handles manylinux platform tags - DO NOT REMOVE! ⚠️
     def _get_pypapip_download_cmd(
         self,
@@ -137,7 +190,7 @@ class PyPaPipManager:
         requirements_file: Path | None = None,
         packages: list[str] | None = None,
         binary_only: bool = True,
-        platform_tag: str | None = None,
+        platform_tag: str | Sequence[str] | None = None,
         find_links: str | None = None,
     ) -> list[str]:
         """
@@ -152,7 +205,9 @@ class PyPaPipManager:
             requirements_file: Optional requirements file
             packages: Optional list of packages to download
             binary_only: Whether to download only binary wheels
-            platform_tag: Optional platform tag to use (e.g., "manylinux2014_x86_64")
+            platform_tag: Optional platform tag, or ordered tags, to use
+                (e.g. "manylinux2014_x86_64"). Defaults to this manager's
+                manylinux policy on Linux.
             find_links: Optional local wheel directory to check before PyPI
         """
         cmd = [*_pip_base_cmd(python_exe), "download", "--dest", dest_dir.as_posix()]
@@ -166,30 +221,11 @@ class PyPaPipManager:
         cmd.extend(["--python-version", f"{py_major}.{py_minor}"])
         logger.debug(f"Added Python version constraint: {py_major}.{py_minor}")
 
-        # Handle platform tags
-        if platform_tag:
-            # Use explicitly provided platform tag (works on any OS)
-            cmd.extend(["--platform", platform_tag])
-            logger.debug(f"Added platform constraint: {platform_tag}")
-        elif get_os_name() == "linux" and binary_only:
-            # For Linux builds, explicitly request manylinux wheels for maximum compatibility
-            # manylinux2014 = glibc 2.17+ (CentOS 7, Amazon Linux 2, Ubuntu 14.04+)
-            arch = get_arch_name()
-            if logger.is_trace_enabled():
-                logger.trace(f"Linux build detected, arch={arch}, requesting {self.MANYLINUX_TAG} wheels")
-
-            # Use manylinux2014 format for maximum compatibility
-            # manylinux2014 = glibc 2.17+ (CentOS 7, Amazon Linux 2, Ubuntu 14.04+)
-            if arch == "amd64":
-                cmd.extend(["--platform", f"{self.MANYLINUX_TAG}_x86_64"])
-                logger.debug(f"Added platform constraint: {self.MANYLINUX_TAG}_x86_64")
-            elif arch == "arm64":
-                # ARM64 uses manylinux2014_aarch64 to match published wheels
-                # Note: This is equivalent to manylinux_2_17_aarch64 (glibc 2.17)
-                # We use manylinux2014 format for compatibility with published wheels
-                cmd.extend(["--platform", f"{self.MANYLINUX_TAG}_aarch64"])
-                logger.debug(f"Added platform constraint: {self.MANYLINUX_TAG}_aarch64")
-                logger.warning("⚠️ grpcio on CentOS 7 ARM64 may have C++ ABI issues")
+        # Handle platform tags. Every tag offered is passed as its own --platform:
+        # pip considers all of them and prefers the one listed first.
+        for tag in self._download_platform_tags(platform_tag, binary_only=binary_only):
+            cmd.extend(["--platform", tag])
+            logger.debug(f"Added platform constraint: {tag}")
 
         # When a local wheel directory is provided, check it before hitting PyPI.
         # This supplies C-extension wheels for platforms with no PyPI binary wheels
@@ -246,6 +282,7 @@ class PyPaPipManager:
 
         if result.returncode != 0:
             error_msg = f"Failed to download required wheels: {result.stderr}"
+            error_msg += self._platform_failure_hint(result.stderr)
             logger.error(error_msg)
             raise RuntimeError(error_msg)
         else:
@@ -291,6 +328,7 @@ class PyPaPipManager:
 
         if result.returncode != 0:
             error_msg = f"Failed to download required packages: {result.stderr}"
+            error_msg += self._platform_failure_hint(result.stderr)
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 

--- a/src/flavor/packaging/python/uv_manager.py
+++ b/src/flavor/packaging/python/uv_manager.py
@@ -33,6 +33,7 @@ from provide.foundation.tools.base import (
 )
 
 from flavor.config.defaults import ENV_WHEEL_CACHE
+from flavor.packaging.python.manylinux import DEFAULT_MANYLINUX_TAGS, platform_tags_for_arch
 
 
 def _windows_system_env() -> dict[str, str]:
@@ -580,14 +581,11 @@ class UVManager(BaseToolManager):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
 
-            # Determine platform for manylinux2014 compatibility
-            arch = get_arch_name()
-            uv_platform_tag = None
+            # Platform tags come from the shared manylinux policy so this path
+            # cannot drift from what the rest of the build asks pip for.
+            uv_platform_tag: list[str] = []
             if get_os_name() == "linux":
-                if arch == "amd64":
-                    uv_platform_tag = "manylinux2014_x86_64"
-                elif arch == "arm64":
-                    uv_platform_tag = "manylinux2014_aarch64"
+                uv_platform_tag = platform_tags_for_arch(DEFAULT_MANYLINUX_TAGS, get_arch_name())
 
             # Download UV wheel using PyPA pip
             download_cmd = pypapip._get_pypapip_download_cmd(

--- a/src/flavor/packaging/python/wheel_builder.py
+++ b/src/flavor/packaging/python/wheel_builder.py
@@ -11,6 +11,7 @@ combining UV performance where appropriate with PyPA pip compatibility.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import importlib.metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
@@ -45,17 +46,23 @@ class WheelBuilder:
     - Proper manylinux compatibility
     """
 
-    def __init__(self, python_version: str = "3.11") -> None:
+    def __init__(
+        self,
+        python_version: str = "3.11",
+        manylinux_tags: Sequence[str] | None = None,
+    ) -> None:
         """
         Initialize the wheel builder.
 
         Args:
             python_version: Target Python version for wheel building
+            manylinux_tags: Manylinux tags this build accepts, most preferred
+                first. Passed straight through to the downloader.
         """
         self.python_version = python_version
 
         # Initialize managers
-        self.pypapip = PyPaPipManager(python_version=python_version)
+        self.pypapip = PyPaPipManager(python_version=python_version, manylinux_tags=manylinux_tags)
         self.uv = UVManager()  # UV manager for performance where appropriate
 
         logger.debug(f"Initialized WheelBuilder for Python {python_version}")

--- a/tests/packaging/python/test_coverage_gaps.py
+++ b/tests/packaging/python/test_coverage_gaps.py
@@ -1331,7 +1331,7 @@ class TestDependencyResolverFallbackDownload:
         assert result is None
 
     def test_get_uv_platform_tag_linux_amd64(self) -> None:
-        """Lines 245-250 - Linux amd64 platform tag."""
+        """Linux amd64 asks for the whole policy, preferred tag first."""
         from flavor.packaging.python.dependency_resolver import DependencyResolver
 
         resolver = DependencyResolver()
@@ -1340,10 +1340,10 @@ class TestDependencyResolverFallbackDownload:
             patch("flavor.packaging.python.dependency_resolver.get_arch_name", return_value="amd64"),
         ):
             result = resolver._get_uv_platform_tag()
-        assert result == "manylinux2014_x86_64"
+        assert result == ["manylinux2014_x86_64", "manylinux_2_28_x86_64"]
 
     def test_get_uv_platform_tag_linux_arm64(self) -> None:
-        """Lines 249-250 - Linux arm64 platform tag."""
+        """Linux arm64 asks for the whole policy, preferred tag first."""
         from flavor.packaging.python.dependency_resolver import DependencyResolver
 
         resolver = DependencyResolver()
@@ -1352,16 +1352,16 @@ class TestDependencyResolverFallbackDownload:
             patch("flavor.packaging.python.dependency_resolver.get_arch_name", return_value="arm64"),
         ):
             result = resolver._get_uv_platform_tag()
-        assert result == "manylinux2014_aarch64"
+        assert result == ["manylinux2014_aarch64", "manylinux_2_28_aarch64"]
 
     def test_get_uv_platform_tag_non_linux(self) -> None:
-        """Line 251 - non-Linux returns None."""
+        """Non-Linux constrains nothing, so pip resolves for the running machine."""
         from flavor.packaging.python.dependency_resolver import DependencyResolver
 
         resolver = DependencyResolver()
         with patch("flavor.packaging.python.dependency_resolver.get_os_name", return_value="darwin"):
             result = resolver._get_uv_platform_tag()
-        assert result is None
+        assert result == []
 
     def test_execute_download_command_success(self) -> None:
         """Lines 268-278 - successful download command."""

--- a/tests/packaging/python/test_manylinux_policy.py
+++ b/tests/packaging/python/test_manylinux_policy.py
@@ -1,0 +1,165 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""The manylinux tag policy, and the download commands built from it.
+
+The regression these guard: pip's `--platform` replaces the set of tags pip will
+consider and expands each one downward only, so a single hardcoded tag hides
+every package that has moved to a newer manylinux baseline. jq is the canary --
+it published manylinux2014 wheels through 1.10.0 and manylinux_2_26/2_28 from
+1.11.0, and a lock holding jq 1.12.0 failed the Linux build outright.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from flavor.packaging.python.manylinux import (
+    DEFAULT_MANYLINUX_TAGS,
+    platform_constraint_hint,
+    platform_tags_for_arch,
+    resolve_manylinux_tags,
+)
+from flavor.packaging.python.pypapip_manager import PyPaPipManager
+
+
+class TestDefaultPolicy:
+    def test_default_prefers_manylinux2014_so_existing_artifacts_do_not_move(self) -> None:
+        """pip prefers the tag listed first, and that has to stay 2014.
+
+        Listing a newer tag first would silently raise the glibc floor of every
+        artifact that has a 2_17 wheel available, which is a compatibility
+        decision, not a bug fix.
+        """
+        assert DEFAULT_MANYLINUX_TAGS[0] == "manylinux2014"
+
+    def test_default_also_admits_manylinux_2_28(self) -> None:
+        assert "manylinux_2_28" in DEFAULT_MANYLINUX_TAGS
+
+    def test_no_config_yields_the_default(self) -> None:
+        assert resolve_manylinux_tags(None) == DEFAULT_MANYLINUX_TAGS
+        assert resolve_manylinux_tags({}) == DEFAULT_MANYLINUX_TAGS
+        assert resolve_manylinux_tags({"other": "value"}) == DEFAULT_MANYLINUX_TAGS
+
+
+class TestConfiguredPolicy:
+    def test_a_single_tag_is_accepted_as_a_string(self) -> None:
+        assert resolve_manylinux_tags({"manylinux": "manylinux_2_34"}) == ("manylinux_2_34",)
+
+    def test_a_list_keeps_the_declared_order(self) -> None:
+        config = {"manylinux": ["manylinux_2_28", "manylinux2014"]}
+        assert resolve_manylinux_tags(config) == ("manylinux_2_28", "manylinux2014")
+
+    def test_an_unusable_value_falls_back_rather_than_failing_the_build(self) -> None:
+        assert resolve_manylinux_tags({"manylinux": 42}) == DEFAULT_MANYLINUX_TAGS
+        assert resolve_manylinux_tags({"manylinux": []}) == DEFAULT_MANYLINUX_TAGS
+        assert resolve_manylinux_tags({"manylinux": ["", "  "]}) == DEFAULT_MANYLINUX_TAGS
+
+    def test_non_string_entries_are_dropped_and_the_rest_kept(self) -> None:
+        assert resolve_manylinux_tags({"manylinux": ["manylinux2014", None]}) == ("manylinux2014",)
+
+
+class TestArchExpansion:
+    def test_amd64_uses_the_x86_64_spelling(self) -> None:
+        assert platform_tags_for_arch(("manylinux2014",), "amd64") == ["manylinux2014_x86_64"]
+
+    def test_arm64_uses_the_aarch64_spelling(self) -> None:
+        assert platform_tags_for_arch(("manylinux2014",), "arm64") == ["manylinux2014_aarch64"]
+
+    def test_order_survives_expansion(self) -> None:
+        assert platform_tags_for_arch(DEFAULT_MANYLINUX_TAGS, "amd64") == [
+            "manylinux2014_x86_64",
+            "manylinux_2_28_x86_64",
+        ]
+
+    def test_an_unmapped_arch_leaves_the_platform_unconstrained(self) -> None:
+        """Better to let pip resolve for the running machine than to invent a tag."""
+        assert platform_tags_for_arch(DEFAULT_MANYLINUX_TAGS, "riscv64") == []
+
+
+class TestDownloadCommand:
+    def _cmd(self, manager: PyPaPipManager, **kwargs: object) -> list[str]:
+        return manager._get_pypapip_download_cmd(
+            python_exe=Path("/usr/bin/python3"),
+            dest_dir=Path("/tmp/wheels"),
+            packages=["jq"],
+            binary_only=True,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    def test_linux_download_requests_every_configured_tag(self) -> None:
+        manager = PyPaPipManager()
+        with (
+            patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"),
+            patch("flavor.packaging.python.pypapip_manager.get_arch_name", return_value="amd64"),
+        ):
+            cmd = self._cmd(manager)
+
+        assert cmd.count("--platform") == 2
+        assert "manylinux2014_x86_64" in cmd
+        assert "manylinux_2_28_x86_64" in cmd
+
+    def test_the_preferred_tag_is_passed_first(self) -> None:
+        """pip picks the first matching tag, so order in the command is the policy."""
+        manager = PyPaPipManager()
+        with (
+            patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"),
+            patch("flavor.packaging.python.pypapip_manager.get_arch_name", return_value="arm64"),
+        ):
+            cmd = self._cmd(manager)
+
+        platforms = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--platform"]
+        assert platforms == ["manylinux2014_aarch64", "manylinux_2_28_aarch64"]
+
+    def test_a_packages_own_policy_replaces_the_default(self) -> None:
+        manager = PyPaPipManager(manylinux_tags=("manylinux_2_34",))
+        with (
+            patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"),
+            patch("flavor.packaging.python.pypapip_manager.get_arch_name", return_value="amd64"),
+        ):
+            cmd = self._cmd(manager)
+
+        platforms = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--platform"]
+        assert platforms == ["manylinux_2_34_x86_64"]
+
+    def test_an_explicit_platform_tag_still_wins(self) -> None:
+        """Callers that already know the exact tag they need keep that ability."""
+        manager = PyPaPipManager()
+        with patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"):
+            cmd = self._cmd(manager, platform_tag="manylinux2014_x86_64")
+
+        platforms = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--platform"]
+        assert platforms == ["manylinux2014_x86_64"]
+
+    def test_several_explicit_tags_are_all_passed(self) -> None:
+        manager = PyPaPipManager()
+        with patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"):
+            cmd = self._cmd(manager, platform_tag=["manylinux2014_x86_64", "manylinux_2_28_x86_64"])
+
+        platforms = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--platform"]
+        assert platforms == ["manylinux2014_x86_64", "manylinux_2_28_x86_64"]
+
+    def test_non_linux_hosts_are_left_unconstrained(self) -> None:
+        manager = PyPaPipManager()
+        with patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="darwin"):
+            cmd = self._cmd(manager)
+
+        assert "--platform" not in cmd
+
+
+class TestFailureHint:
+    def test_the_hint_names_the_tags_that_were_requested(self) -> None:
+        hint = platform_constraint_hint(["manylinux2014_x86_64", "manylinux_2_28_x86_64"])
+        assert "manylinux2014_x86_64" in hint
+        assert "manylinux_2_28_x86_64" in hint
+
+    def test_the_hint_explains_that_newer_tags_are_invisible(self) -> None:
+        """The whole point: the constraint hides published wheels."""
+        hint = platform_constraint_hint(["manylinux2014_x86_64"])
+        assert "never newer" in hint
+
+    def test_no_constraint_means_no_hint(self) -> None:
+        assert platform_constraint_hint([]) == ""

--- a/tests/packaging/python/test_pypapip_manager.py
+++ b/tests/packaging/python/test_pypapip_manager.py
@@ -128,7 +128,9 @@ class TestPyPaPipManager:
                 python_exe, dest_dir, packages=packages, binary_only=True
             )
 
-        # CRITICAL: Must include manylinux2014_x86_64 platform tag for Linux compatibility
+        # CRITICAL: manylinux2014_x86_64 must come first -- pip prefers the tag it is
+        # offered first, and that is what keeps the artifact's glibc floor where it was.
+        # manylinux_2_28 follows as a fallback for packages that publish nothing older.
         expected = [
             "/usr/bin/python3",
             "-m",
@@ -142,6 +144,8 @@ class TestPyPaPipManager:
             "3.11",
             "--platform",
             "manylinux2014_x86_64",
+            "--platform",
+            "manylinux_2_28_x86_64",
             "numpy",
         ]
         assert cmd == expected
@@ -162,7 +166,7 @@ class TestPyPaPipManager:
                 python_exe, dest_dir, packages=packages, binary_only=True
             )
 
-        # CRITICAL: Must include manylinux2014_aarch64 platform tag for ARM64 Linux
+        # CRITICAL: manylinux2014_aarch64 first, manylinux_2_28_aarch64 as the fallback.
         # Note: This matches published wheels (manylinux2014 == manylinux_2_17, both glibc 2.17+)
         expected = [
             "/usr/bin/python3",
@@ -177,6 +181,8 @@ class TestPyPaPipManager:
             "3.11",
             "--platform",
             "manylinux2014_aarch64",
+            "--platform",
+            "manylinux_2_28_aarch64",
             "scipy",
         ]
         assert cmd == expected
@@ -240,6 +246,8 @@ class TestPyPaPipManager:
             "3.11",
             "--platform",
             "manylinux2014_x86_64",
+            "--platform",
+            "manylinux_2_28_x86_64",
             "-r",
             "/tmp/requirements.txt",
         ]

--- a/tests/test_coverage_final3.py
+++ b/tests/test_coverage_final3.py
@@ -203,7 +203,7 @@ class TestPypapipManagerBranches:
         from flavor.packaging.python.pypapip_manager import PyPaPipManager
 
         mgr = PyPaPipManager.__new__(PyPaPipManager)
-        mgr.MANYLINUX_TAG = "manylinux2014"
+        mgr.manylinux_tags = ("manylinux2014",)
         mgr.python_version = "3.11"
 
         with (

--- a/tests/test_coverage_final4.py
+++ b/tests/test_coverage_final4.py
@@ -112,7 +112,8 @@ class TestDependencyResolverTraceBranches:
         ):
             result = resolver._get_uv_platform_tag()
 
-        assert result is None
+        # An arch with no manylinux spelling constrains nothing.
+        assert result == []
 
     @pytest.mark.unit
     def test_execute_download_command_trace_logging(self) -> None:

--- a/tests/test_coverage_gaps_batch2_medium.py
+++ b/tests/test_coverage_gaps_batch2_medium.py
@@ -366,7 +366,7 @@ class TestPyPaPipManagerCoverage:
     """Cover missing branches in PyPaPipManager."""
 
     def test_download_cmd_trace_logging_for_linux_arch(self) -> None:
-        """Linux binary download triggers trace log for arch (line 179)."""
+        """Linux binary download traces which platform tags it asked for."""
         from flavor.packaging.python.pypapip_manager import PyPaPipManager
 
         mgr = PyPaPipManager(python_version="3.11")
@@ -377,7 +377,7 @@ class TestPyPaPipManagerCoverage:
         with (
             patch("flavor.packaging.python.pypapip_manager.get_os_name", return_value="linux"),
             patch("flavor.packaging.python.pypapip_manager.get_arch_name", return_value="amd64"),
-            patch("flavor.packaging.python.pypapip_manager.logger", mock_logger),
+            patch("flavor.packaging.python.manylinux.logger", mock_logger),
             patch("sys.platform", "linux"),
         ):
             cmd = mgr._get_pypapip_download_cmd(

--- a/tests/test_coverage_gaps_final.py
+++ b/tests/test_coverage_gaps_final.py
@@ -809,8 +809,9 @@ class TestUVManagerLinuxArmTag:
             call_kwargs = mock_pypapip._get_pypapip_download_cmd.call_args
             kwargs = call_kwargs.kwargs if call_kwargs and call_kwargs.kwargs else {}
             platform_tag = kwargs.get("platform_tag")
-            if platform_tag is not None:
-                assert "aarch64" in platform_tag
+            if platform_tag:
+                # An ordered list of tags now, all of them arm64-spelled.
+                assert all("aarch64" in tag for tag in platform_tag)
 
 
 # ===========================================================================

--- a/tests/test_coverage_gaps_final2.py
+++ b/tests/test_coverage_gaps_final2.py
@@ -416,7 +416,7 @@ class TestDependencyResolverGaps:
             patch("flavor.packaging.python.dependency_resolver.get_arch_name", return_value="arm64"),
         ):
             result = resolver._get_uv_platform_tag()
-            assert result == "manylinux2014_aarch64"
+            assert result == ["manylinux2014_aarch64", "manylinux_2_28_aarch64"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## The bug

`pip download --platform TAG` does not mean *prefer* `TAG`. It replaces the set of platform tags pip will consider, and pip expands each one **downward only** — asking for `manylinux2014` (an alias of `manylinux_2_17`) makes 2_17, 2_12, 2_5 and `manylinux1` wheels visible, and everything newer invisible.

The single hardcoded tag was therefore a ceiling on what the ecosystem is allowed to have moved on to, not a floor under compatibility. And the ceiling was reached: jq published manylinux2014 wheels through 1.10.0 and `manylinux_2_26/2_28` from 1.11.0, so terraform-provider-pyvider's lock landing on jq 1.12.0 killed both Linux targets of its packaged build while darwin and windows built fine.

```
ERROR: Could not find a version that satisfies the requirement jq==1.12.0
       (from versions: 1.2.3, ..., 1.9.1, 1.10.0)
ERROR: No matching distribution found for jq==1.12.0
```

That reads like the package doesn't exist. It does exist — it was hidden by a flag.

## What changed

**1. Every accepted tag is passed.** pip takes `--platform` repeatedly and prefers the one listed first. The default keeps `manylinux2014` in front, so a package that still publishes a 2_17 wheel resolves to *exactly the same wheel as before* — no artifact's glibc floor moves — and `manylinux_2_28` applies only where nothing older is published at all. Verified both directions:

| tags passed | wheel selected for `cryptography==46.0.0` |
|---|---|
| `manylinux2014` then `manylinux_2_28` | `…manylinux2014_x86_64.manylinux_2_17_x86_64.whl` |
| `manylinux_2_28` then `manylinux2014` | `…manylinux_2_28_x86_64.whl` |

**2. One policy instead of four copies.** The literal lived in `pypapip_manager`, `packager`, `uv_manager` and `dependency_resolver`. It now lives in `flavor/packaging/python/manylinux.py`, and a package states its own with `manylinux` under `[tool.flavor.build]`. Raising the glibc floor becomes a deliberate per-artifact decision rather than an edit to a shared constant.

**3. The failure explains itself.**

> Wheels were requested for platform tags: manylinux2014_x86_64. pip only considers these tags and older ones, never newer, so a package that has moved to a newer manylinux baseline is invisible here even though it is published. Set `manylinux` under [tool.flavor.build] to the tags this artifact should accept, most preferred first.

`MANYLINUX_TAG` survives on both classes as the *preferred* tag, which is what it always effectively meant.

## Verification

Running the command flavorpack itself builds, against the package that broke it:

```
download --dest … --only-binary :all: --python-version 3.11
  --platform manylinux2014_x86_64 --platform manylinux_2_28_x86_64 jq==1.12.0
exit: 0
jq-1.12.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
```

And with a deliberately narrowed policy, the same download fails with the new explanation attached.

**2702 tests pass**, including 20 new ones covering tag ordering, config parsing and rejection, arch expansion, the command built for each host, and the hint text. The pretaster integration test needs `dist/bin/flavor-tastesh-*`, a CI-produced artifact absent locally, and fails identically on `main`.

## Follow-up this unblocks

terraform-provider-pyvider and terraform-provider-tofusoup both carry `jq>=1.9.1,<1.11` with a comment saying to lift it once flavorpack asks for a newer tag. Once this ships, both caps can go.