### PR TITLE
feat(packaging): fail the build when a wheel outruns the bundled interpreter

### DIFF
--- a/src/flavor/packaging/python/environment_builder.py
+++ b/src/flavor/packaging/python/environment_builder.py
@@ -22,6 +22,7 @@ from provide.foundation.resilience.types import BackoffStrategy
 
 from flavor.config.defaults import DEFAULT_EXECUTABLE_PERMS
 from flavor.packaging.python.dependency_resolver import DependencyResolver
+from flavor.packaging.python.glibc import GlibcVersion, max_glibc_in_tree
 from flavor.packaging.python.pypapip_manager import PyPaPipManager
 from flavor.packaging.python.uv_manager import UVManager, _windows_system_env
 
@@ -45,6 +46,10 @@ class PythonEnvironmentBuilder:
         self.python_version = python_version
         self.is_windows = is_windows
         self.manylinux_tag = manylinux_tag
+        #: Filled in on Linux once the interpreter has been downloaded; the
+        #: bundled wheels are verified against it. None elsewhere, and on a
+        #: fallback tarball, where there is no interpreter to measure.
+        self.interpreter_glibc_floor: GlibcVersion | None = None
         self.uv_manager = UVManager()
         self.pypapip = PyPaPipManager()
         self.uv_exe = "uv.exe" if is_windows else "uv"
@@ -82,6 +87,15 @@ class PythonEnvironmentBuilder:
             if not python_install_dir:
                 self._create_fallback_python_tarball(python_tgz)
                 return
+
+            # Read the interpreter's own glibc floor while its tree is still on
+            # disk; once it is a tarball this costs a full extraction. The
+            # wheels are checked against it later, in the slot builder.
+            if get_os_name() == "linux":
+                self.interpreter_glibc_floor = max_glibc_in_tree(python_install_dir)
+                if self.interpreter_glibc_floor:
+                    major, minor = self.interpreter_glibc_floor
+                    logger.info(f"🔎 Bundled interpreter requires glibc {major}.{minor}")
 
             self._create_python_tarball(python_install_dir, python_tgz)
 

--- a/src/flavor/packaging/python/glibc.py
+++ b/src/flavor/packaging/python/glibc.py
@@ -1,0 +1,172 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Check that no bundled wheel needs a newer glibc than the bundled interpreter.
+
+A packaged build assembles two things that carry a glibc requirement and know
+nothing about each other: the interpreter, whose floor comes from whichever
+python-build-standalone release uv resolves, and the wheels, whose floor comes
+from the manylinux tags pip was allowed to see. When the wheel side drifts
+above the interpreter side the build still succeeds -- the mismatch surfaces on
+a user's machine as the dynamic linker refusing to load an extension module,
+which is the worst possible place to learn about it.
+
+The requirement is read from the ELF objects themselves rather than from
+manylinux tags, because the tags overstate it. jq 1.12.0 publishes a wheel
+tagged `manylinux_2_26.manylinux_2_28` whose `.so` in fact requires only
+GLIBC 2.25: auditwheel stamps the glibc of the build image, not the minimum the
+code needs. Checking tags would reject wheels that would have run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import struct
+import zipfile
+
+from provide.foundation import logger
+
+#: Version strings the dynamic linker records, e.g. `GLIBC_2.28`.
+_GLIBC_SYMBOL = re.compile(rb"GLIBC_(\d+)\.(\d+)")
+
+_ELF_MAGIC = b"\x7fELF"
+
+#: Only these carry native code; everything else in an interpreter tree or a
+#: wheel is data we would waste time reading.
+_NATIVE_SUFFIXES = (".so", ".so.1.0")
+
+GlibcVersion = tuple[int, int]
+
+
+def _section_offsets(data: bytes) -> dict[str, tuple[int, int]]:
+    """Map section name to (offset, size) for a little-endian ELF64 object."""
+    # A truncated or foreign object is skipped, never fatal: one unreadable
+    # file in a tree must not be able to fail a build.
+    if len(data) < 0x40 or data[4] != 2 or data[5] != 1:  # 64-bit, little-endian
+        return {}
+
+    try:
+        e_shoff = struct.unpack_from("<Q", data, 0x28)[0]
+        e_shentsize = struct.unpack_from("<H", data, 0x3A)[0]
+        e_shnum = struct.unpack_from("<H", data, 0x3C)[0]
+        e_shstrndx = struct.unpack_from("<H", data, 0x3E)[0]
+    except struct.error:
+        return {}
+    if not e_shoff or not e_shnum or e_shstrndx >= e_shnum or e_shoff >= len(data):
+        return {}
+
+    def header(index: int) -> tuple[int, int, int]:
+        base = e_shoff + index * e_shentsize
+        name = struct.unpack_from("<I", data, base)[0]
+        offset = struct.unpack_from("<Q", data, base + 0x18)[0]
+        size = struct.unpack_from("<Q", data, base + 0x20)[0]
+        return name, offset, size
+
+    try:
+        _, strtab_offset, _ = header(e_shstrndx)
+        sections: dict[str, tuple[int, int]] = {}
+        for index in range(e_shnum):
+            name_offset, offset, size = header(index)
+            start = strtab_offset + name_offset
+            end = data.index(b"\0", start)
+            sections[data[start:end].decode("utf-8", "replace")] = (offset, size)
+        return sections
+    except (struct.error, ValueError, IndexError):
+        return {}
+
+
+def glibc_versions(data: bytes) -> set[GlibcVersion]:
+    """Every GLIBC_x.y version an ELF object names.
+
+    The versions live in `.dynstr`, referenced from `.gnu.version_r`. Reading
+    the string table directly finds all of them without walking the version
+    records, and a non-ELF or unreadable object simply yields nothing.
+    """
+    if not data.startswith(_ELF_MAGIC):
+        return set()
+
+    sections = _section_offsets(data)
+    dynstr = sections.get(".dynstr")
+    if dynstr is None:
+        return set()
+
+    offset, size = dynstr
+    blob = data[offset : offset + size]
+    return {(int(major), int(minor)) for major, minor in _GLIBC_SYMBOL.findall(blob)}
+
+
+def max_glibc_in_tree(root: Path) -> GlibcVersion | None:
+    """The highest glibc any native object under `root` requires."""
+    highest: GlibcVersion | None = None
+    for path in root.rglob("*"):
+        if not path.is_file() or not path.name.endswith(_NATIVE_SUFFIXES):
+            continue
+        try:
+            versions = glibc_versions(path.read_bytes())
+        except OSError:
+            continue
+        if versions and (highest is None or max(versions) > highest):
+            highest = max(versions)
+    return highest
+
+
+def wheel_glibc_requirement(wheel: Path) -> tuple[GlibcVersion, str] | None:
+    """The highest glibc any extension module in a wheel requires, and which one.
+
+    Returns None for a wheel with no native code, which is most of them.
+    """
+    highest: GlibcVersion | None = None
+    culprit = ""
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            for name in archive.namelist():
+                if not name.endswith(_NATIVE_SUFFIXES):
+                    continue
+                versions = glibc_versions(archive.read(name))
+                if versions and (highest is None or max(versions) > highest):
+                    highest = max(versions)
+                    culprit = name
+    except (zipfile.BadZipFile, OSError) as exc:
+        logger.debug(f"Could not inspect {wheel.name} for glibc requirements: {exc}")
+        return None
+    return (highest, culprit) if highest else None
+
+
+def verify_wheels_against_floor(wheels_dir: Path, floor: GlibcVersion) -> None:
+    """Fail the build when a wheel needs a newer glibc than the interpreter.
+
+    Raises:
+        RuntimeError: if any bundled wheel requires more than `floor`.
+    """
+    violations: list[str] = []
+    inspected = 0
+
+    for wheel in sorted(wheels_dir.glob("*.whl")):
+        requirement = wheel_glibc_requirement(wheel)
+        if requirement is None:
+            continue
+        inspected += 1
+        needed, culprit = requirement
+        if needed > floor:
+            violations.append(f"{wheel.name} needs GLIBC {needed[0]}.{needed[1]} ({culprit})")
+
+    if violations:
+        listed = "\n  ".join(violations)
+        raise RuntimeError(
+            f"Bundled wheels require a newer glibc than the bundled interpreter, "
+            f"which supports {floor[0]}.{floor[1]}:\n  {listed}\n\n"
+            "This package would build cleanly and then fail to start on any system "
+            "the interpreter itself supports, because the dynamic linker refuses to "
+            "load these extension modules. Pin the offending packages to versions "
+            "built against an older glibc, or state a newer baseline with "
+            "`manylinux` under [tool.flavor.build] and accept the narrower support."
+        )
+
+    logger.info(
+        "✅ Bundled wheels are within the interpreter's glibc floor",
+        floor=f"{floor[0]}.{floor[1]}",
+        native_wheels=inspected,
+    )

--- a/src/flavor/packaging/python/slot_builder.py
+++ b/src/flavor/packaging/python/slot_builder.py
@@ -23,6 +23,7 @@ from provide.foundation.process import run
 
 from flavor.config.defaults import DEFAULT_DIR_PERMS, DEFAULT_EXECUTABLE_PERMS, ENV_WHEEL_CACHE
 from flavor.packaging.python.environment_builder import PythonEnvironmentBuilder
+from flavor.packaging.python.glibc import verify_wheels_against_floor
 from flavor.packaging.python.pypapip_manager import _pip_base_cmd
 from flavor.packaging.python.uv_manager import UVManager
 
@@ -187,6 +188,17 @@ class PythonSlotBuilder:
         python_tgz = work_dir / "python.tgz"
         self.env_builder.create_python_placeholder(python_tgz)
         artifacts["python_tgz"] = python_tgz
+
+        # Both halves of the package now exist, so they can be compared. The
+        # interpreter and the wheels acquire their glibc requirements from
+        # entirely separate places -- whichever python-build-standalone release
+        # uv resolved, and whichever manylinux tags pip was allowed to see --
+        # and nothing else notices when the wheel side drifts above the
+        # interpreter side. Left unchecked that ships: the build succeeds and
+        # the dynamic linker refuses the extension module on a user's machine.
+        floor = self.env_builder.interpreter_glibc_floor
+        if floor is not None:
+            verify_wheels_against_floor(wheels_dir, floor)
 
         return artifacts
 

--- a/tests/packaging/python/test_glibc_verification.py
+++ b/tests/packaging/python/test_glibc_verification.py
@@ -1,0 +1,177 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Reading glibc requirements out of ELF objects, and enforcing them.
+
+The regression this guards: a wheel needing a newer glibc than the bundled
+interpreter builds cleanly and then fails at a user's dynamic linker. The ELF
+fixtures here are synthesised rather than checked in, so the tests stay
+hermetic and run on any host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+import zipfile
+
+import pytest
+
+from flavor.packaging.python.glibc import (
+    glibc_versions,
+    max_glibc_in_tree,
+    verify_wheels_against_floor,
+    wheel_glibc_requirement,
+)
+
+
+def make_elf(*symbols: str) -> bytes:
+    """A minimal little-endian ELF64 whose .dynstr names the given symbols.
+
+    Only the pieces the parser reads are real: the identification bytes, the
+    section-header table, and two sections -- .shstrtab naming them and .dynstr
+    holding the version strings.
+    """
+    dynstr = b"\0" + b"\0".join(s.encode() for s in symbols) + b"\0"
+    shstrtab = b"\0.shstrtab\0.dynstr\0"
+
+    header_size = 0x40
+    shentsize = 0x40
+    dynstr_offset = header_size
+    shstrtab_offset = dynstr_offset + len(dynstr)
+    shoff = shstrtab_offset + len(shstrtab)
+
+    elf = bytearray(header_size)
+    elf[0:4] = b"\x7fELF"
+    elf[4] = 2  # ELFCLASS64
+    elf[5] = 1  # little-endian
+    struct.pack_into("<Q", elf, 0x28, shoff)
+    struct.pack_into("<H", elf, 0x3A, shentsize)
+    struct.pack_into("<H", elf, 0x3C, 3)  # null, .dynstr, .shstrtab
+    struct.pack_into("<H", elf, 0x3E, 2)  # .shstrtab is section 2
+
+    elf += dynstr
+    elf += shstrtab
+
+    def section(name_offset: int, offset: int, size: int) -> bytes:
+        entry = bytearray(shentsize)
+        struct.pack_into("<I", entry, 0x00, name_offset)
+        struct.pack_into("<Q", entry, 0x18, offset)
+        struct.pack_into("<Q", entry, 0x20, size)
+        return bytes(entry)
+
+    elf += section(0, 0, 0)  # SHT_NULL
+    elf += section(shstrtab.index(b".dynstr"), dynstr_offset, len(dynstr))
+    elf += section(shstrtab.index(b".shstrtab"), shstrtab_offset, len(shstrtab))
+    return bytes(elf)
+
+
+def write_wheel(path: Path, members: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, payload in members.items():
+            archive.writestr(name, payload)
+    return path
+
+
+class TestReadingElfObjects:
+    def test_finds_every_glibc_version_named(self) -> None:
+        elf = make_elf("GLIBC_2.17", "GLIBC_2.25", "malloc")
+        assert glibc_versions(elf) == {(2, 17), (2, 25)}
+
+    def test_a_non_elf_file_yields_nothing(self) -> None:
+        assert glibc_versions(b"not an ELF at all") == set()
+
+    def test_an_object_naming_no_glibc_yields_nothing(self) -> None:
+        assert glibc_versions(make_elf("malloc", "free")) == set()
+
+    def test_truncated_elf_does_not_raise(self) -> None:
+        """A corrupt object should be skipped, not crash the build."""
+        assert glibc_versions(make_elf("GLIBC_2.17")[:20]) == set()
+
+
+class TestScanningATree:
+    def test_reports_the_highest_requirement_found(self, tmp_path: Path) -> None:
+        (tmp_path / "lib").mkdir()
+        (tmp_path / "lib" / "a.so").write_bytes(make_elf("GLIBC_2.17"))
+        (tmp_path / "lib" / "b.so").write_bytes(make_elf("GLIBC_2.28"))
+        (tmp_path / "lib" / "notes.txt").write_text("ignored")
+
+        assert max_glibc_in_tree(tmp_path) == (2, 28)
+
+    def test_a_tree_with_no_native_objects_reports_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.md").write_text("no ELF here")
+        assert max_glibc_in_tree(tmp_path) is None
+
+
+class TestInspectingWheels:
+    def test_reports_the_requirement_and_which_object_carries_it(self, tmp_path: Path) -> None:
+        wheel = write_wheel(
+            tmp_path / "jq-1.12.0-cp311-cp311-manylinux_2_28_x86_64.whl",
+            {
+                "jq.cpython-311-x86_64-linux-gnu.so": make_elf("GLIBC_2.25"),
+                "jq-1.12.0.dist-info/METADATA": b"Name: jq\n",
+            },
+        )
+        assert wheel_glibc_requirement(wheel) == ((2, 25), "jq.cpython-311-x86_64-linux-gnu.so")
+
+    def test_a_pure_python_wheel_has_no_requirement(self, tmp_path: Path) -> None:
+        wheel = write_wheel(tmp_path / "attrs-25.4.0-py3-none-any.whl", {"attr/__init__.py": b"x = 1\n"})
+        assert wheel_glibc_requirement(wheel) is None
+
+    def test_a_corrupt_wheel_is_skipped_rather_than_fatal(self, tmp_path: Path) -> None:
+        broken = tmp_path / "broken-1.0-cp311-cp311-linux_x86_64.whl"
+        broken.write_bytes(b"this is not a zip")
+        assert wheel_glibc_requirement(broken) is None
+
+
+class TestEnforcement:
+    def test_wheels_within_the_floor_pass(self, tmp_path: Path) -> None:
+        write_wheel(
+            tmp_path / "ok-1.0-cp311-cp311-manylinux_2_17_x86_64.whl", {"ok.so": make_elf("GLIBC_2.14")}
+        )
+        write_wheel(tmp_path / "pure-1.0-py3-none-any.whl", {"pure/__init__.py": b""})
+
+        verify_wheels_against_floor(tmp_path, (2, 17))  # does not raise
+
+    def test_a_wheel_above_the_floor_fails_the_build(self, tmp_path: Path) -> None:
+        """The jq case: builds clean today, dies at the user's dynamic linker."""
+        write_wheel(
+            tmp_path / "jq-1.12.0-cp311-cp311-manylinux_2_28_x86_64.whl",
+            {"jq.cpython-311-x86_64-linux-gnu.so": make_elf("GLIBC_2.25")},
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            verify_wheels_against_floor(tmp_path, (2, 17))
+
+        message = str(excinfo.value)
+        assert "jq-1.12.0" in message
+        assert "GLIBC 2.25" in message
+        assert "2.17" in message
+        # It must say what to do about it, not just that it happened.
+        assert "manylinux" in message
+
+    def test_a_wheel_exactly_at_the_floor_passes(self, tmp_path: Path) -> None:
+        write_wheel(
+            tmp_path / "edge-1.0-cp311-cp311-manylinux_2_17_x86_64.whl", {"edge.so": make_elf("GLIBC_2.17")}
+        )
+
+        verify_wheels_against_floor(tmp_path, (2, 17))  # does not raise
+
+    def test_every_offender_is_listed_not_just_the_first(self, tmp_path: Path) -> None:
+        write_wheel(
+            tmp_path / "one-1.0-cp311-cp311-manylinux_2_28_x86_64.whl", {"one.so": make_elf("GLIBC_2.28")}
+        )
+        write_wheel(
+            tmp_path / "two-1.0-cp311-cp311-manylinux_2_34_x86_64.whl", {"two.so": make_elf("GLIBC_2.34")}
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            verify_wheels_against_floor(tmp_path, (2, 17))
+
+        assert "one-1.0" in str(excinfo.value)
+        assert "two-1.0" in str(excinfo.value)
+
+    def test_an_empty_wheel_directory_passes(self, tmp_path: Path) -> None:
+        verify_wheels_against_floor(tmp_path, (2, 17))  # does not raise


### PR DESCRIPTION
Follow-up to #20, and the piece that catches this class of problem at the source.

## The gap

A package assembles two things that each carry a glibc requirement and know nothing about each other:

| | where its floor comes from |
|---|---|
| the bundled interpreter | whichever python-build-standalone release uv resolved |
| the bundled wheels | whichever manylinux tags pip was allowed to see |

Both are **glibc 2.17 today — by coincidence.** Nothing holds them together. When the wheel side drifts above the interpreter side the build still succeeds, and the mismatch surfaces on a user's machine as the dynamic linker refusing to load an extension module.

## Why ELF, not tags

Tags overstate the requirement — auditwheel stamps the build image's glibc, not the minimum the code needs:

```
jq-1.10.0  tagged manylinux_2_17  →  .so actually needs GLIBC 2.14
jq-1.12.0  tagged manylinux_2_26/2_28  →  .so actually needs GLIBC 2.25
```

A tag comparison would reject wheels that would have run fine. So the requirement is read from the objects themselves — `.dynstr` scanned for `GLIBC_x.y`, pure stdlib, no new dependency.

## Where it hooks in

The interpreter's floor is measured in `create_python_placeholder`, while the tree is still on disk and before it becomes a tarball (measuring it afterwards would cost a full extraction). The wheels are checked at the end of `prepare_artifacts`, once both halves exist. Non-Linux builds measure nothing and skip.

## Verification against real artifacts

Not fixtures — the actual `cpython-3.11.16+20260825-x86_64-unknown-linux-gnu` build uv installs, and real jq wheels:

```
interpreter floor measured by the shipped code: (2, 17)
  jq-1.10.0-…-manylinux_2_17_x86_64.whl  -> ((2, 14), 'jq.cpython-311-…so')   passes
  jq-1.12.0-…-manylinux_2_28_x86_64.whl  -> ((2, 25), 'jq.cpython-311-…so')   raises

Bundled wheels require a newer glibc than the bundled interpreter, which supports 2.17:
  jq-1.12.0-…whl needs GLIBC 2.25 (jq.cpython-311-x86_64-linux-gnu.so)

This package would build cleanly and then fail to start on any system the interpreter
itself supports… Pin the offending packages to versions built against an older glibc, or
state a newer baseline with `manylinux` under [tool.flavor.build] and accept the narrower
support.
```

**Cost:** 0.08s to scan the 5,232-path interpreter tree, ~4ms per wheel.

## Tests

14 new, on synthesised ELF objects so they stay hermetic and run on any host — including the exact jq scenario, multiple offenders listed together, a wheel exactly at the floor, pure-Python wheels, and corrupt inputs.

One of them earned its keep while being written: a truncated object raised `struct.error` out of the header read, *before* the guard meant to catch it. Fixed in the parser rather than the test.

Full suite: **2716 passed** (the pretaster integration test needs `dist/bin/flavor-tastesh-*`, a CI-produced artifact absent locally, and fails identically on `main`).