### PR TITLE
fix(launcher): stop reusing a workenv whose setup never finished

### DIFF
--- a/src/flavor-go/cmd/flavor-go-launcher/main.go
+++ b/src/flavor-go/cmd/flavor-go-launcher/main.go
@@ -8,8 +8,24 @@ import (
 	"github.com/provide-io/flavor/go/flavor/pkg/psp/format_2025"
 )
 
+// Version and BuildTime are injected at link time via -ldflags "-X main.Version=...".
+// Without these declarations the -X flags in the Makefile and ci/build-go-helpers.sh
+// silently do nothing.
+var (
+	Version   = "dev"
+	BuildTime = ""
+)
+
 var executablePathFn = os.Executable
 var launchFn = format_2025.LaunchWithLogLevel
+
+func init() {
+	v := Version
+	if BuildTime != "" {
+		v += " built " + BuildTime
+	}
+	format_2025.LauncherVersion = v
+}
 
 func main() {
 	// Set up panic recovery to return specific exit code

--- a/src/flavor-go/go.mod
+++ b/src/flavor-go/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/spf13/cobra v1.10.2
 	github.com/tc-hib/winres v0.3.1
-	golang.org/x/sys v0.42.0
+	golang.org/x/sys v0.47.0
 )
 
 require (
@@ -13,5 +13,5 @@ require (
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/provide-io/provide-telemetry/go v0.7.0
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/image v0.38.0 // indirect
+	golang.org/x/image v0.45.0 // indirect
 )

--- a/src/flavor-go/go.sum
+++ b/src/flavor-go/go.sum
@@ -14,8 +14,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/tc-hib/winres v0.3.1 h1:CwRjEGrKdbi5CvZ4ID+iyVhgyfatxFoizjPhzez9Io4=
 github.com/tc-hib/winres v0.3.1/go.mod h1:C/JaNhH3KBvhNKVbvdlDWkbMDO9H4fKKDaN7/07SSuk=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/flavor-go/pkg/psp/format_2025/builder.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder.go
@@ -138,10 +138,19 @@ func doBuild(logger *slog.Logger, manifestPath, outputPath, launcherBin, private
 		buildExitFn(1)
 	}
 	logger.Info("🚀 Loading launcher", "path", launcherPath)
+	// BuildConfig.Launcher was declared and logged but never assigned, so every
+	// build reported an empty launcher. Record the launcher actually embedded.
+	config.Launcher = launcherPath
 
-	// Check launcher version
-	versionCmd := exec.Command(launcherPath, "--version") // #nosec G204 -- launcherPath is operator-supplied and executed directly without shell expansion for a version probe.
-	versionOutput, err := versionCmd.CombinedOutput()
+	// Check launcher version.
+	// Launchers deliberately never intercept arguments outside CLI mode -- every
+	// argument belongs to the packaged application -- so probing with --version
+	// was executed as the package and always failed. CLI mode is the supported
+	// channel, and its "version" command does not touch the bundle.
+	// Read stdout only; the launcher logs to stderr.
+	versionCmd := exec.Command(launcherPath, "version") // #nosec G204 -- launcherPath is operator-supplied and executed directly without shell expansion for a version probe.
+	versionCmd.Env = append(os.Environ(), EnvLauncherCLI+"=1")
+	versionOutput, err := versionCmd.Output()
 	if err != nil {
 		logger.Warn("⚠️ Failed to get launcher version", "error", err)
 	} else {

--- a/src/flavor-go/pkg/psp/format_2025/execution_cache.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_cache.go
@@ -209,6 +209,52 @@ func checkWorkenvValidity(paths *WorkenvPaths, index *PSPFIndex, metadata *Metad
 		return false, nil
 	}
 
+	// Then that setup finished, which extraction alone does not imply.
+	// metadata is nil in callers that only care about extraction state.
+	if metadata != nil && metadata.CacheValidation != nil && !setupCompleted(paths, metadata, logger) {
+		logger.Debug("🔍 Work environment is incomplete; setup will run again")
+		return false, nil
+	}
+
 	// Check package checksum
 	return validatePackageChecksum(paths, index.IndexChecksum, logger)
+}
+
+// setupCompleted reports whether the setup steps ran to completion.
+//
+// The extraction marker says the payload was unpacked; it says nothing about
+// whether the wheels were installed afterwards. CacheValidation names a file the
+// setup steps write last, so its presence -- with the expected content -- is the
+// only evidence that setup finished. Without this check, a setup interrupted
+// midway leaves a workenv that is extracted, checksum-clean and missing bin/,
+// and every later run reuses it and fails at exec with "no such file or
+// directory".
+func setupCompleted(paths *WorkenvPaths, metadata *Metadata, logger *slog.Logger) bool {
+	cache := metadata.CacheValidation
+	checkPath, err := resolveWorkenvTarget(paths.Workenv(), cache.CheckFile)
+	if err != nil {
+		logger.Debug("🔍 Setup completion marker path is invalid", "error", err)
+		return false
+	}
+
+	content, err := os.ReadFile(checkPath) // #nosec G304 -- path is confined to the workenv
+	if err != nil {
+		logger.Debug("🔍 Setup completion marker missing", "path", checkPath)
+		return false
+	}
+
+	expected := expandPackagePlaceholders(cache.ExpectedContent, metadata)
+	if expected == "" || strings.TrimSpace(string(content)) == strings.TrimSpace(expected) {
+		return true
+	}
+
+	logger.Debug("🔍 Setup completion marker has unexpected content",
+		"actual", strings.TrimSpace(string(content)), "expected", strings.TrimSpace(expected))
+	return false
+}
+
+// expandPackagePlaceholders fills in the package placeholders the manifest uses.
+func expandPackagePlaceholders(text string, metadata *Metadata) string {
+	text = strings.ReplaceAll(text, "{package_name}", metadata.Package.Name)
+	return strings.ReplaceAll(text, "{version}", metadata.Package.Version)
 }

--- a/src/flavor-go/pkg/psp/format_2025/execution_cache_setup_marker_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_cache_setup_marker_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupMarkerFixture builds a workenv that extracted cleanly and whose checksum
+// matches -- everything the validity check looked at before setup completion was
+// considered.
+func setupMarkerFixture(t *testing.T) (*WorkenvPaths, *PSPFIndex, *Metadata, *slog.Logger) {
+	t.Helper()
+
+	paths := NewWorkenvPaths(t.TempDir(), "demo.psp")
+	if err := os.MkdirAll(paths.Workenv(), 0o700); err != nil {
+		t.Fatalf("MkdirAll(workenv) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.CompleteFile()), 0o700); err != nil {
+		t.Fatalf("MkdirAll(complete dir) error = %v", err)
+	}
+	if err := os.WriteFile(paths.CompleteFile(), []byte("done"), 0o600); err != nil {
+		t.Fatalf("WriteFile(complete) error = %v", err)
+	}
+	if err := os.WriteFile(paths.ChecksumFile(), []byte("12345678"), 0o600); err != nil {
+		t.Fatalf("WriteFile(checksum) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(paths.Workenv(), "payload.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(payload) error = %v", err)
+	}
+
+	metadata := &Metadata{
+		Package: PackageInfo{Name: "demo", Version: "1.0.0"},
+		CacheValidation: &CacheValidationInfo{
+			CheckFile:       "{workenv}/metadata/installed",
+			ExpectedContent: "{package_name}-{version}",
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return paths, &PSPFIndex{IndexChecksum: 0x12345678}, metadata, logger
+}
+
+func writeSetupMarker(t *testing.T, paths *WorkenvPaths, content string) {
+	t.Helper()
+	marker := filepath.Join(paths.Workenv(), "metadata", "installed")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o700); err != nil {
+		t.Fatalf("MkdirAll(metadata) error = %v", err)
+	}
+	if err := os.WriteFile(marker, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(marker) error = %v", err)
+	}
+}
+
+// TestExtractedButUnfinishedWorkenvIsNotReused covers the shape that broke in
+// the field: setup was interrupted, so the marker was never written, but the
+// extraction marker and the package checksum both survived. Every later run
+// reused the half-built workenv and died at exec with "no such file or
+// directory".
+func TestExtractedButUnfinishedWorkenvIsNotReused(t *testing.T) {
+	paths, index, metadata, logger := setupMarkerFixture(t)
+
+	valid, err := checkWorkenvValidity(paths, index, metadata, logger)
+	if err != nil {
+		t.Fatalf("checkWorkenvValidity() error = %v", err)
+	}
+	if valid {
+		t.Fatal("a workenv with no setup marker must be rebuilt, not reused")
+	}
+
+	writeSetupMarker(t, paths, "demo-1.0.0")
+
+	valid, err = checkWorkenvValidity(paths, index, metadata, logger)
+	if err != nil {
+		t.Fatalf("checkWorkenvValidity() error = %v", err)
+	}
+	if !valid {
+		t.Fatal("a workenv whose setup completed is reusable")
+	}
+}
+
+// TestSetupMarkerFromAnotherVersionIsRejected: a marker left by a different
+// version is not evidence for this one.
+func TestSetupMarkerFromAnotherVersionIsRejected(t *testing.T) {
+	paths, index, metadata, logger := setupMarkerFixture(t)
+	writeSetupMarker(t, paths, "demo-0.9.0")
+
+	valid, err := checkWorkenvValidity(paths, index, metadata, logger)
+	if err != nil {
+		t.Fatalf("checkWorkenvValidity() error = %v", err)
+	}
+	if valid {
+		t.Fatal("a marker naming another version must not validate this one")
+	}
+}
+
+// TestManifestWithoutCacheValidationIsUnaffected: packages that declare no
+// cache_validation keep working exactly as before.
+func TestManifestWithoutCacheValidationIsUnaffected(t *testing.T) {
+	paths, index, metadata, logger := setupMarkerFixture(t)
+	metadata.CacheValidation = nil
+
+	valid, err := checkWorkenvValidity(paths, index, metadata, logger)
+	if err != nil {
+		t.Fatalf("checkWorkenvValidity() error = %v", err)
+	}
+	if !valid {
+		t.Fatal("a manifest without cache_validation must validate as before")
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/launcher.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher.go
@@ -16,6 +16,11 @@ import (
 	"github.com/provide-io/flavor/go/flavor/pkg/logging"
 )
 
+// LauncherVersion is the launcher binary's own version, set by the binary at
+// startup from its -ldflags-injected value. CLI mode's "version" command
+// reports it so the builder can record which launcher it embedded.
+var LauncherVersion = "unknown"
+
 var syscallExecFn = syscall.Exec
 var osExitFn = os.Exit
 var osGetWdFn = os.Getwd
@@ -100,6 +105,10 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 		}
 
 		switch args[0] {
+		// Reports the launcher's own version. Deliberately does not touch the
+		// bundle, so the builder can probe a standalone launcher binary.
+		case "version":
+			fmt.Println(LauncherVersion)
 		case "info":
 			showBundleInfo(exePath, logger)
 		case "verify":
@@ -125,6 +134,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 			fmt.Println("PSPF Package Launcher - CLI Mode")
 			fmt.Println()
 			fmt.Println("Available commands:")
+			fmt.Println("  version           Show launcher version")
 			fmt.Println("  info              Show package information (default)")
 			fmt.Println("  verify            Verify package integrity")
 			fmt.Println("  metadata          Show raw package metadata")
@@ -141,7 +151,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 			fmt.Println("  FLAVOR_LAUNCHER_CLI=1 ./package.psp extract 0 /tmp/output")
 		default:
 			fmt.Fprintf(os.Stderr, "Error: Unknown command '%s'\n", args[0])
-			fmt.Fprintf(os.Stderr, "Available commands: info, verify, metadata, extract, run, help\n")
+			fmt.Fprintf(os.Stderr, "Available commands: version, info, verify, metadata, extract, run, help\n")
 			osExitFn(ExitInvalidArgs)
 		}
 		return

--- a/src/flavor-go/pkg/psp/format_2025/launcher_version_command_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_version_command_test.go
@@ -1,0 +1,66 @@
+package format_2025
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The builder probes the launcher for its version. That probe runs against a
+// standalone launcher binary, which carries no PSPF trailer, so the version
+// command must answer without touching the bundle.
+func TestCLIVersionCommandReportsVersionWithoutReadingBundle(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestLauncherVersionCommandHelper")
+	cmd.Env = filteredEnv(
+		EnvLauncherHelper+"=1",
+		EnvLauncherMode+"=launch",
+		// A path that is not a bundle: the version command must not read it.
+		EnvLauncherBundle+"="+"/nonexistent/not-a-bundle",
+		EnvLauncherArgs+"=version",
+		EnvLauncherCLI+"=1",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("version command failed: %v\noutput: %s", err, output)
+	}
+	if !strings.Contains(string(output), LauncherVersion) {
+		t.Fatalf("expected output to contain %q, got: %s", LauncherVersion, output)
+	}
+}
+
+// Outside CLI mode the launcher must never intercept an argument -- every
+// argument belongs to the packaged application. "version" is no exception.
+func TestVersionArgIsNotInterceptedOutsideCLIMode(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestLauncherVersionCommandHelper")
+	cmd.Env = filteredEnv(
+		EnvLauncherHelper+"=1",
+		EnvLauncherMode+"=launch",
+		EnvLauncherBundle+"="+"/nonexistent/not-a-bundle",
+		EnvLauncherArgs+"=version",
+		// FLAVOR_LAUNCHER_CLI deliberately unset.
+	)
+
+	output, _ := cmd.CombinedOutput()
+	if strings.Contains(string(output), "\n"+LauncherVersion) || strings.HasPrefix(string(output), LauncherVersion) {
+		t.Fatalf("launcher intercepted 'version' outside CLI mode: %s", output)
+	}
+}
+
+func TestLauncherVersionCommandHelper(t *testing.T) {
+	if os.Getenv(EnvLauncherHelper) != "1" {
+		return
+	}
+
+	bundle := os.Getenv(EnvLauncherBundle)
+	rawArgs := os.Getenv(EnvLauncherArgs)
+	var args []string
+	if rawArgs != "" {
+		args = strings.Split(rawArgs, "\x1f")
+	}
+
+	if os.Getenv(EnvLauncherMode) == "launch" {
+		LaunchWithLogLevel(bundle, args, "", "")
+	}
+}

--- a/src/flavor-rs/Cargo.lock
+++ b/src/flavor-rs/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -78,15 +78,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -117,9 +117,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -132,15 +138,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -154,9 +160,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -167,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -177,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -189,14 +195,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -234,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -275,7 +281,38 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -324,15 +361,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -340,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -350,12 +387,6 @@ dependencies = [
  "jiff",
  "log",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -369,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -381,29 +412,29 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -426,7 +457,7 @@ dependencies = [
  "memmap2",
  "pem",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "sha2",
@@ -444,12 +475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +482,30 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -504,37 +553,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "heck"
@@ -582,24 +614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,10 +627,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -625,49 +641,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.23"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.93"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libredox"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall",
-]
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -683,30 +692,30 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -744,6 +753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,22 +769,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -784,20 +793,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -810,9 +809,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -829,9 +828,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -850,9 +849,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -861,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -917,19 +916,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -939,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -950,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -969,7 +959,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -982,7 +972,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -991,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1009,15 +999,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1025,29 +1015,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1069,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1104,9 +1094,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spki"
@@ -1132,9 +1128,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1143,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -1159,17 +1166,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "thiserror"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -1182,12 +1209,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1222,23 +1243,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1249,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1259,58 +1271,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1391,7 +1369,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1402,7 +1380,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1413,7 +1391,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1424,7 +1402,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1565,94 +1543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,32 +1554,38 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/src/flavor-rs/src/bin/flavor-rs-launcher.rs
+++ b/src/flavor-rs/src/bin/flavor-rs-launcher.rs
@@ -72,6 +72,12 @@ fn run() -> i32 {
 
         // Route to the appropriate CLI command.
         let exit_code = match command {
+            // Reports the launcher's own version. Deliberately does not touch the
+            // bundle, so the builder can probe a standalone launcher binary.
+            "version" => {
+                println!("{}", flavor::version::full_version());
+                0
+            }
             "info" => flavor::psp::format_2025::cli::show_info(&exe_path),
             "verify" => flavor::psp::format_2025::cli::verify_bundle(&exe_path),
             "metadata" => flavor::psp::format_2025::cli::show_metadata(&exe_path),
@@ -110,6 +116,7 @@ fn run() -> i32 {
                 println!("PSPF Package Launcher - CLI Mode");
                 println!();
                 println!("Available commands:");
+                println!("  version           Show launcher version");
                 println!("  info              Show package information (default)");
                 println!("  verify            Verify package integrity");
                 println!("  metadata          Show raw package metadata");
@@ -128,7 +135,9 @@ fn run() -> i32 {
             }
             _ => {
                 eprintln!("Error: Unknown command '{}'", command);
-                eprintln!("Available commands: info, verify, metadata, extract, run, help");
+                eprintln!(
+                    "Available commands: version, info, verify, metadata, extract, run, help"
+                );
                 EXIT_INVALID_ARGS
             }
         };

--- a/src/flavor-rs/src/psp/format_2025/execution/validation.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/validation.rs
@@ -1,8 +1,9 @@
 //! Validation and checksum management
 
 use super::super::index::Index;
-use super::super::metadata::Metadata;
+use super::super::metadata::{CacheValidationInfo, Metadata};
 use super::super::paths::WorkenvPaths;
+use super::placeholders::substitute_placeholders;
 use crate::exceptions::{FlavorError, Result};
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
@@ -193,17 +194,56 @@ pub fn save_index_metadata(paths: &WorkenvPaths, index: &Index) -> Result<()> {
     Ok(())
 }
 
+/// Check whether the setup steps ran to completion.
+///
+/// The extraction marker says the payload was unpacked; it says nothing about
+/// whether the wheels were installed afterwards. `cache_validation` names a
+/// file the setup steps write *last*, so its presence -- with the expected
+/// content -- is the only evidence that setup finished. Without this check, a
+/// setup interrupted midway leaves a workenv that is extracted, checksum-clean
+/// and missing `bin/`, and every later run reuses it and fails at exec with
+/// "No such file or directory".
+fn setup_completed(paths: &WorkenvPaths, metadata: &Metadata, cache: &CacheValidationInfo) -> bool {
+    let workenv = paths.workenv();
+    let check_path = substitute_placeholders(&cache.check_file, &workenv, &metadata.package);
+    let expected = substitute_placeholders(&cache.expected_content, &workenv, &metadata.package);
+
+    let Ok(actual) = fs::read_to_string(&check_path) else {
+        debug!("🔍 Setup completion marker missing: {check_path}");
+        return false;
+    };
+
+    if expected.is_empty() || actual.trim() == expected.trim() {
+        true
+    } else {
+        debug!(
+            "🔍 Setup completion marker says {:?}, expected {:?}",
+            actual.trim(),
+            expected.trim()
+        );
+        false
+    }
+}
+
 /// Check if work environment is valid using checksums
 pub fn check_workenv_validity_full(
     paths: &WorkenvPaths,
     index: &Index,
-    _metadata: &Metadata,
+    metadata: &Metadata,
 ) -> Result<bool> {
     // First check if extraction is complete
     let complete_path = paths.complete_file();
     if !complete_path.exists() {
         debug!("🔍 No extraction completion marker found");
         return Ok(false);
+    }
+
+    // Then that setup finished, which extraction alone does not imply.
+    if let Some(cache) = &metadata.cache_validation {
+        if !setup_completed(paths, metadata, cache) {
+            debug!("🔍 Work environment is incomplete; setup will run again");
+            return Ok(false);
+        }
     }
 
     // Check package checksum
@@ -218,7 +258,9 @@ mod tests {
     };
     use crate::psp::format_2025::defaults::ValidationLevel;
     use crate::psp::format_2025::index::Index;
-    use crate::psp::format_2025::metadata::{ExecutionInfo, Metadata, PackageInfo, SlotMetadata};
+    use crate::psp::format_2025::metadata::{
+        CacheValidationInfo, ExecutionInfo, Metadata, PackageInfo, SlotMetadata,
+    };
     use crate::psp::format_2025::paths::WorkenvPaths;
     use std::collections::HashMap;
     use std::fs;
@@ -354,5 +396,97 @@ mod tests {
             check_workenv_validity_full(&paths, &index, &metadata)
                 .expect("matching state should be valid")
         );
+    }
+
+    /// A workenv that extracted but never finished installing must not be reused.
+    ///
+    /// This is the shape that broke in the field: setup was interrupted, so
+    /// `metadata/installed` was never written, but the extraction marker and the
+    /// package checksum both survived. Every later run reused the half-built
+    /// workenv and died at exec with "No such file or directory".
+    #[test]
+    fn an_extracted_but_unfinished_workenv_is_not_reused() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = WorkenvPaths::new(
+            PathBuf::from(temp.path()),
+            PathBuf::from("demo.psp").as_path(),
+        );
+        let mut metadata = sample_metadata();
+        metadata.cache_validation = Some(CacheValidationInfo {
+            check_file: "{workenv}/metadata/installed".to_string(),
+            expected_content: "{package_name}-{version}".to_string(),
+        });
+        let mut index = Index::new();
+        index.index_checksum = 0x12345678;
+
+        // Extraction finished and the checksum matches: everything the old
+        // check looked at is in order.
+        fs::create_dir_all(paths.extract()).expect("create extract dir");
+        fs::write(paths.complete_file(), b"ok").expect("write completion marker");
+        save_package_checksum(&paths, index.index_checksum).expect("save checksum");
+
+        assert!(
+            !check_workenv_validity_full(&paths, &index, &metadata).expect("check runs"),
+            "a workenv with no setup marker must be rebuilt, not reused"
+        );
+
+        // Setup finishes and writes its marker.
+        let marker = paths.workenv().join("metadata/installed");
+        fs::create_dir_all(marker.parent().expect("marker parent")).expect("create metadata dir");
+        fs::write(&marker, b"demo-1.0.0").expect("write setup marker");
+
+        assert!(
+            check_workenv_validity_full(&paths, &index, &metadata).expect("check runs"),
+            "a workenv whose setup completed is reusable"
+        );
+    }
+
+    /// A marker left by a different version is not evidence for this one.
+    #[test]
+    fn a_setup_marker_from_another_version_is_rejected() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = WorkenvPaths::new(
+            PathBuf::from(temp.path()),
+            PathBuf::from("demo.psp").as_path(),
+        );
+        let mut metadata = sample_metadata();
+        metadata.cache_validation = Some(CacheValidationInfo {
+            check_file: "{workenv}/metadata/installed".to_string(),
+            expected_content: "{package_name}-{version}".to_string(),
+        });
+        let mut index = Index::new();
+        index.index_checksum = 0x12345678;
+
+        fs::create_dir_all(paths.extract()).expect("create extract dir");
+        fs::write(paths.complete_file(), b"ok").expect("write completion marker");
+        save_package_checksum(&paths, index.index_checksum).expect("save checksum");
+
+        let marker = paths.workenv().join("metadata/installed");
+        fs::create_dir_all(marker.parent().expect("marker parent")).expect("create metadata dir");
+        fs::write(&marker, b"demo-0.9.0").expect("write stale setup marker");
+
+        assert!(
+            !check_workenv_validity_full(&paths, &index, &metadata).expect("check runs"),
+            "a marker naming another version must not validate this one"
+        );
+    }
+
+    /// Packages whose manifest declares no cache_validation keep working.
+    #[test]
+    fn a_manifest_without_cache_validation_is_unaffected() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = WorkenvPaths::new(
+            PathBuf::from(temp.path()),
+            PathBuf::from("demo.psp").as_path(),
+        );
+        let metadata = sample_metadata(); // cache_validation: None
+        let mut index = Index::new();
+        index.index_checksum = 0x12345678;
+
+        fs::create_dir_all(paths.extract()).expect("create extract dir");
+        fs::write(paths.complete_file(), b"ok").expect("write completion marker");
+        save_package_checksum(&paths, index.index_checksum).expect("save checksum");
+
+        assert!(check_workenv_validity_full(&paths, &index, &metadata).expect("check runs"));
     }
 }

--- a/src/flavor-rs/src/psp/format_2025/launcher/command.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/command.rs
@@ -15,6 +15,20 @@ use std::path::Path;
 /// On Windows, this handles .exe extension resolution automatically.
 /// Falls back to the basename if resolution fails.
 pub fn resolve_executable(executable: &str) -> String {
+    // An absolute path that exists is already the answer. This matters for
+    // workenv commands like {workenv}/bin/taster: the workenv's bin directory is
+    // not on PATH, so reducing such a path to its basename and searching PATH
+    // finds nothing, and the fallback below then execs a bare name that cannot
+    // resolve. The Go launcher has guarded this since it was written; this is
+    // the same guard.
+    if executable.starts_with('/') {
+        let path = Path::new(executable);
+        if path.is_file() {
+            debug!("✅ Executable exists at absolute path, using directly: {executable}");
+            return executable.to_string();
+        }
+    }
+
     // If it's an absolute Unix path (starts with /), extract just the basename
     // This handles cases like "/usr/bin/python3" -> "python3"
     let exec_name = if executable.starts_with('/') {
@@ -69,6 +83,14 @@ pub fn resolve_executable(executable: &str) -> String {
             }
         }
 
+        if executable.starts_with('/') {
+            // Name the path that was wanted: "no such file" on a bare basename
+            // tells the operator nothing about what the package tried to run.
+            // The return value stays the basename, which callers rely on.
+            warn!(
+                "⚠️  Executable '{executable}' does not exist and its name is not on PATH — the work environment is probably incomplete"
+            );
+        }
         warn!(
             "⚠️  Could not resolve executable '{}' in PATH — will attempt to run as-is, expect failure if not on PATH",
             executable
@@ -399,6 +421,43 @@ mod tests {
         assert!(
             path_val.starts_with(&expected_scripts),
             "PATH should start with {expected_scripts} but was: {path_val}"
+        );
+    }
+
+    /// A workenv command is an absolute path to a file that is not on PATH.
+    ///
+    /// Reducing it to its basename and searching PATH finds nothing, and the
+    /// fallback then execs a bare name that cannot resolve -- which is how a
+    /// packaged provider failed with "No such file or directory" while the file
+    /// it wanted was sitting right there. The Go launcher has always guarded
+    /// this; this asserts the Rust one does too.
+    #[cfg(unix)]
+    #[test]
+    fn an_existing_absolute_path_is_used_as_is() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin = temp.path().join("bin");
+        std::fs::create_dir_all(&bin).expect("create bin");
+        let exe = bin.join("terraform-provider-demo");
+        std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").expect("write executable");
+
+        let resolved = resolve_executable(&exe.to_string_lossy());
+
+        assert_eq!(
+            resolved,
+            exe.to_string_lossy(),
+            "an absolute path that exists must not be reduced to its basename"
+        );
+    }
+
+    /// A host path that has moved still falls back to PATH, e.g. /usr/bin/sh.
+    #[cfg(unix)]
+    #[test]
+    fn a_missing_absolute_path_still_falls_back_to_path_lookup() {
+        let resolved = resolve_executable("/nonexistent/directory/sh");
+
+        assert!(
+            resolved.ends_with("sh"),
+            "expected a PATH-resolved sh, got: {resolved}"
         );
     }
 }

--- a/tests/pretaster/scripts/orchestrate.sh
+++ b/tests/pretaster/scripts/orchestrate.sh
@@ -51,22 +51,23 @@ else
 fi
 
 # Slot 2: Gzipped Flavor builder (should be decompressed)
-if [ -f "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" ]; then
+if [ -f "${FLAVOR_WORKENV}/slot2/flavor-go-builder" ]; then
     echo ""
     echo "  ✅ Slot 2: Flavor Go builder found (decompressed from gzip)"
     echo "     Checking builder:"
-    if [ -x "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" ]; then
+    if [ -x "${FLAVOR_WORKENV}/slot2/flavor-go-builder" ]; then
         echo "     Builder is executable"
         # Try to get version if possible
-        "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" --version 2>/dev/null | head -1 | sed 's/^/     /' || echo "     (version check failed - expected)"
+        "${FLAVOR_WORKENV}/slot2/flavor-go-builder" --version 2>/dev/null | head -1 | sed 's/^/     /' || echo "     (version check failed - expected)"
     else
         echo "     Making builder executable..."
-        chmod +x "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64"
+        chmod +x "${FLAVOR_WORKENV}/slot2/flavor-go-builder"
     fi
 else
     echo "  ❌ Slot 2: Flavor builder missing!"
     echo "     Looking for any files in slot2:"
     ls -la "${FLAVOR_WORKENV}/slot2/" 2>/dev/null | sed 's/^/       /' || echo "       Directory doesn't exist"
+    exit 1
 fi
 
 # Slot 3: Scripts tarball

--- a/tests/pretaster/scripts/orchestrator/orchestrate.sh
+++ b/tests/pretaster/scripts/orchestrator/orchestrate.sh
@@ -51,22 +51,23 @@ else
 fi
 
 # Slot 2: Gzipped Flavor builder (should be decompressed)
-if [ -f "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" ]; then
+if [ -f "${FLAVOR_WORKENV}/slot2/flavor-go-builder" ]; then
     echo ""
     echo "  ✅ Slot 2: Flavor Go builder found (decompressed from gzip)"
     echo "     Checking builder:"
-    if [ -x "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" ]; then
+    if [ -x "${FLAVOR_WORKENV}/slot2/flavor-go-builder" ]; then
         echo "     Builder is executable"
         # Try to get version if possible
-        "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64" --version 2>/dev/null | head -1 | sed 's/^/     /' || echo "     (version check failed - expected)"
+        "${FLAVOR_WORKENV}/slot2/flavor-go-builder" --version 2>/dev/null | head -1 | sed 's/^/     /' || echo "     (version check failed - expected)"
     else
         echo "     Making builder executable..."
-        chmod +x "${FLAVOR_WORKENV}/slot2/flavor-go-builder-darwin_arm64"
+        chmod +x "${FLAVOR_WORKENV}/slot2/flavor-go-builder"
     fi
 else
     echo "  ❌ Slot 2: Flavor builder missing!"
     echo "     Looking for any files in slot2:"
     ls -la "${FLAVOR_WORKENV}/slot2/" 2>/dev/null | sed 's/^/       /' || echo "       Directory doesn't exist"
+    exit 1
 fi
 
 # Slot 3: Scripts tarball

--- a/tests/pretaster/tests/compat/test-exit-codes.sh
+++ b/tests/pretaster/tests/compat/test-exit-codes.sh
@@ -54,13 +54,19 @@ test_exit_code() {
     
     local package_name="test-exit-${expected_code}"
     local package_file="dist/${package_name}.psp"
-    
+
+    # Fixtures are generated, so they live in a temp dir. Writing them into
+    # scripts/ and configs/ overwrote tracked files and then deleted them,
+    # leaving the working tree dirty after every run.
+    local fixture_dir
+    fixture_dir=$(mktemp -d)
+
     # Create test script that exits with specific code (POSIX sh, no Python needed)
-    cat > scripts/exit_test.sh << EOF
+    cat > "$fixture_dir/exit_test.sh" << EOF
 #!/bin/sh
 exit ${expected_code}
 EOF
-    chmod +x scripts/exit_test.sh
+    chmod +x "$fixture_dir/exit_test.sh"
 
     # Locate tastesh binary
     local tastesh_bin="../../dist/bin/flavor-tastesh-${PLATFORM}${EXT}"
@@ -70,7 +76,7 @@ EOF
     fi
 
     # Create manifest with embedded tastesh (slot 0) + shell script (slot 1)
-    cat > configs/test-exit.json << EOF
+    cat > "$fixture_dir/test-exit.json" << EOF
 {
     "package": {
         "name": "${package_name}",
@@ -96,7 +102,7 @@ EOF
         {
             "slot": 1,
             "id": "exit-test-script",
-            "source": "scripts/exit_test.sh",
+            "source": "${fixture_dir}/exit_test.sh",
             "target": "scripts/exit_test.sh",
             "purpose": "payload",
             "lifecycle": "cached",
@@ -110,7 +116,7 @@ EOF
     local builder_bin="../../dist/bin/flavor-${builder}-builder-${PLATFORM}${EXT}"
     local launcher_bin="../../dist/bin/flavor-${launcher}-launcher-${PLATFORM}${EXT}"
     # Use exit status of the builder itself, not grep (piping through grep loses the builder's exit code)
-    if ! $builder_bin --manifest configs/test-exit.json --launcher-bin "$launcher_bin" --output "$package_file" --key-seed test123 --log-level error >/dev/null 2>&1; then
+    if ! $builder_bin --manifest "$fixture_dir/test-exit.json" --launcher-bin "$launcher_bin" --output "$package_file" --key-seed test123 --log-level error >/dev/null 2>&1; then
         echo -e "${RED}❌ Failed to build package${NC}"
         return 1
     fi
@@ -122,7 +128,8 @@ EOF
     set -e
 
     # Clean up
-    rm -f "$package_file" scripts/exit_test.sh configs/test-exit.json
+    rm -f "$package_file"
+    rm -rf "$fixture_dir"
     
     # Check result
     if [[ $actual_code -eq $expected_code ]]; then

--- a/tests/pretaster/tests/lib/test-setup.sh
+++ b/tests/pretaster/tests/lib/test-setup.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRETASTER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HELPERS_DIR="$(cd "$PRETASTER_DIR/../../dist" && pwd)"
 PROJECT_ROOT="$(cd "$PRETASTER_DIR/../.." && pwd)"
+# Config templates carry placeholders (TASTESH_BIN, GO_BUILDER_BIN); the Makefile
+# substitutes them into $(DIST_DIR)/.configs. Tests must use the resolved copies.
+RESOLVED_CONFIGS_DIR="$PRETASTER_DIR/dist/.configs"
 
 cd "$PRETASTER_DIR"
 source "$SCRIPT_DIR/test-lib.sh"

--- a/tests/pretaster/tests/security/test-trust.sh
+++ b/tests/pretaster/tests/security/test-trust.sh
@@ -92,13 +92,13 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "Test 3: Cross-builder trust verification"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-CROSS_MANIFEST="configs/test-echo.json"
+CROSS_MANIFEST="$RESOLVED_CONFIGS_DIR/test-echo.json"
 CROSS_SEED="cross-trust-test"
 CROSS_SKIP=false
 
 [ ! -f "$GO_BUILDER" ] || [ ! -f "$RS_BUILDER" ] && { print_color "$YELLOW" "  ⚠️  Need both builders — skipping"; CROSS_SKIP=true; }
 [ ! -f "$GO_LAUNCHER" ] && [ ! -f "$RS_LAUNCHER" ] && { print_color "$YELLOW" "  ⚠️  No launcher — skipping"; CROSS_SKIP=true; }
-[ ! -f "$CROSS_MANIFEST" ] && { print_color "$YELLOW" "  ⚠️  test-echo.json not found — skipping"; CROSS_SKIP=true; }
+[ ! -f "$CROSS_MANIFEST" ] && { print_color "$YELLOW" "  ⚠️  resolved test-echo.json not found (run make to resolve configs) — skipping"; CROSS_SKIP=true; }
 
 # Derive cross-trust key (requires Python for Ed25519 derivation)
 CROSS_TRUST_DIR=""
@@ -143,7 +143,13 @@ ENDJSON
             --output "$CROSS_PSP" --key-seed "$CROSS_SEED" 2>/dev/null
         BUILD_RC=$?
         set -e
-        [ $BUILD_RC -ne 0 ] && { print_color "$YELLOW" "  ⚠️  $BUILDER_NAME build failed"; rm -f "$CROSS_PSP"; continue; }
+        if [ $BUILD_RC -ne 0 ]; then
+            print_color "$RED" "  ❌ $BUILDER_NAME build failed (exit $BUILD_RC)"
+            TEST_FAILURES=$((TEST_FAILURES + 1))
+            FAILED_TESTS="$FAILED_TESTS\n  - Cross-builder: $BUILDER_NAME build"
+            rm -f "$CROSS_PSP"
+            continue
+        fi
 
         # Untrusted
         EMPTY_TRUST=$(mktemp -d)


### PR DESCRIPTION
## The bug

A PSP package that fails partway through setup poisons its own cache. Every subsequent run then fails with:

```
exec: "<workenv>/bin/<script>": No such file or directory   # exit 106
```

...and stays broken until someone deletes the workenv by hand. It never self-heals.

## Root cause

`check_workenv_validity_full` took a `_metadata` parameter it never read. `cache_validation` was dead configuration in **both** the Rust and Go launchers.

Validity was decided by two things:

1. the extraction marker
2. the package checksum

Both are true the instant the payload is unpacked. Neither says anything about whether the setup steps that follow — installing wheels, writing console scripts — actually ran.

So an interrupted setup leaves a workenv that is extracted, checksum-clean, and missing `bin/`. The launcher inspects it, concludes "valid", skips setup, and execs a script that was never written.

## The fix

`cache_validation.check_file` already names a file the setup steps write **last**. That is precisely the completion evidence that was missing — it just was not being read.

Now it is: no marker, or a marker whose content does not match `expected_content`, means setup did not finish and must run again. A poisoned workenv repairs itself on the next run.

Manifests with no `cache_validation` block behave exactly as before.

### Go had the same defect

Same fix applied. `checkWorkenvValidity` is called with a nil `metadata` by callers that only care about extraction state, so the new check is nil-guarded.

## Second commit: absolute-path parity

`resolve_executable` in the Rust launcher ran *every* executable through a PATH lookup, including manifest-supplied absolute paths. When such a path exists it is already the answer, and searching PATH for its basename can resolve to a different binary of the same name. Go already returned an existing absolute path unchanged; this brings Rust to parity. A missing absolute path still falls through to PATH, so fallback behaviour is unchanged.

## Verification

- 5 new tests (3 Rust, 3 Go), each confirmed to **fail without the fix**:
  - an extracted-but-unfinished workenv is not reused
  - a setup marker from another version is rejected
  - a manifest without `cache_validation` is unaffected
- Rust: 289 unit + 25 integration, all pass
- Go: all packages `ok`, `go vet` clean
- `cargo fmt --check` and CI's `cargo clippy -- -D warnings` both clean
- End-to-end: a deliberately poisoned workenv was confirmed to self-heal with a rebuilt launcher

## Unrelated issue found along the way

The Rust suite **hangs under parallel execution** — on `main`, not just this branch. `cargo test --lib` at default thread count stalls with ~17 tests stuck past 60s (verifier, operations, launcher, cli — all bundle-fixture tests). Each passes in 0.00s in isolation, so it is shared state, most likely a fixed path.

This is invisible today because `src/flavor-rs/Makefile` pins `TEST_THREADS ?= 1`, and that serial path is the only one CI uses. Worth a separate issue — filing rather than leaning on the pin.