### PR TITLE
ci: run the pretaster suite on pull requests

### DIFF
--- a/.github/workflows/pr-pretaster.yml
+++ b/.github/workflows/pr-pretaster.yml
@@ -1,0 +1,107 @@
+name: 06 🧪 PR Pretaster
+# ─────────────────────────────────────────────────────────────────────────────
+# Script policy: keep inline run: blocks to ≤ 3 lines.
+# Anything longer belongs in ci/ and should be called from here.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# End-to-end coverage for pull requests.
+#
+# The pretaster/taster pipelines cannot run on a PR: 01 Helper Prep is
+# workflow_dispatch-only, and 02/03/04 are workflow_run-gated to main/develop.
+# Before this workflow, the only PR check was 05 Code Quality, which runs
+# clippy/fmt/machete and no tests at all — so changes to the launcher, builder
+# and packaging paths merged with nothing exercising them.
+#
+# This builds the helpers from the PR's own source and runs the pretaster
+# suite against them: core, combo (all four builder×launcher combinations),
+# security, and compat.
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_target:
+        description: 'Pretaster make target (test, test-core, test-combo, test-security, test-compat)'
+        type: string
+        required: false
+        default: 'test'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.go'
+      - '**.rs'
+      - 'build.sh'
+      - 'ci/pr-pretaster.sh'
+      - 'src/flavor-go/**'
+      - 'src/flavor-rs/**'
+      - 'tests/pretaster/**'
+      - '.github/workflows/pr-pretaster.yml'
+
+concurrency:
+  group: pr-pretaster-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pretaster:
+    name: 🧪 Pretaster (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # Both platforms run: a hardcoded darwin_arm64 path in a test script is
+      # invisible on macOS and only fails on Linux, and vice versa.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            label: linux_amd64
+          - os: macos-14
+            label: darwin_arm64
+
+    steps:
+      # Source under test: the PR's own tree, helpers built from it below.
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Go toolchain, version pinned by the module itself.
+      - name: 🐹 Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: src/flavor-go/go.mod
+          cache: true
+          cache-dependency-path: src/flavor-go/go.sum
+
+      # Rust toolchain, with the cargo registry and target dir cached.
+      - name: 🦀 Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          workspaces: src/flavor-rs
+
+      # tastesh is built from autotools sources by build.sh; the compat
+      # exit-code suite fails outright when it is missing.
+      - name: 🔧 Install autotools for tastesh (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake
+
+      # Same prerequisite on macOS runners.
+      - name: 🔧 Install autotools for tastesh (macOS)
+        if: runner.os == 'macOS'
+        run: brew install autoconf automake
+
+      # Builds helpers from source, then runs the pretaster suite against them.
+      - name: 🧪 Build helpers and run pretaster
+        run: ci/pr-pretaster.sh "${{ inputs.test_target || 'test' }}"
+
+      # Suite logs are the only record of which combination failed.
+      - name: 📄 Upload pretaster logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pretaster-logs-${{ matrix.label }}
+          path: tests/pretaster/logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/pr-pretaster.yml
+++ b/.github/workflows/pr-pretaster.yml
@@ -82,10 +82,17 @@ jobs:
           workspaces: src/flavor-rs
 
       # tastesh is built from autotools sources by build.sh; the compat
-      # exit-code suite fails outright when it is missing.
-      - name: 🔧 Install autotools for tastesh (Linux)
+      # exit-code suite fails outright when it is missing. musl-tools provides
+      # the linker for the static Rust build below.
+      - name: 🔧 Install autotools and musl for tastesh (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y autoconf automake
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake musl-tools
+
+      # Linux helpers ship as musl static binaries -- src/flavor-rs's build-static
+      # is the default target there -- so the toolchain must carry that target.
+      - name: 🦀 Add musl target (Linux)
+        if: runner.os == 'Linux'
+        run: rustup target add x86_64-unknown-linux-musl
 
       # Same prerequisite on macOS runners.
       - name: 🔧 Install autotools for tastesh (macOS)

--- a/ci/pr-pretaster.sh
+++ b/ci/pr-pretaster.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# pr-pretaster.sh - Build helpers from source and run the pretaster suite.
+#
+# Pull requests never reach the pretaster/taster pipelines: 01 Helper Prep is
+# workflow_dispatch-only and 02/03/04 are workflow_run-gated to main/develop.
+# This script is the end-to-end coverage a PR gets, so it builds the helpers
+# under test rather than downloading them from a prior pipeline stage.
+#
+# Usage: pr-pretaster.sh [test_target]
+
+set -euo pipefail
+
+TEST_TARGET="${1:-test}"
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "🔨 Building Go and Rust helpers from source..."
+# tests/pretaster's build-helpers target no-ops whenever CI is set, assuming a
+# prior pipeline stage published the binaries. This job has no prior stage, so
+# invoke the build directly. For the same reason `make all` is not used here:
+# its build step would be skipped and the suite would test stale or absent
+# binaries.
+./build.sh
+
+echo "📦 Helpers built:"
+ls -la dist/bin/
+
+echo "🧪 Running pretaster suite (${TEST_TARGET})..."
+make -C tests/pretaster "${TEST_TARGET}"


### PR DESCRIPTION
Closes #24.

## The problem

Pull requests get no end-to-end coverage. The pipeline chain cannot reach a PR branch:

```
01 🥘 Helper Prep            on: workflow_dispatch    <- manual only
  ├─ 02 🔬 Pretaster         on: workflow_run, branches: [main, develop]
  └─ 03 🌶️ Flavor Pipeline   on: workflow_run, branches: [main, develop]
       └─ 04 🍰 Taster       on: workflow_run, branches: [main, develop]
```

The complete list of workflow runs for PR #22 was:

```
05 🎨 Code Quality   pull_request   success   2m37s
```

That job runs clippy, fmt and machete — no tests. `grep -rn "cargo test" .github/ ci/` returns nothing.

So the four defects fixed in #22 all merged on a green tick from a check that could not have seen any of them:

- a workenv cache-poisoning bug that made packages permanently unrunnable (exit 106)
- a cross-builder trust test that had never executed a single assertion
- a suite that overwrote and then deleted tracked source files on every run
- a version probe that worked with neither launcher

## The fix

A PR-triggered workflow that builds helpers from the PR's own source and runs the pretaster suite against them: core, combo (all four builder×launcher combinations), security, compat.

### Why `build.sh` and not `make -C tests/pretaster all`

The pretaster Makefile no-ops its own build whenever `CI` is set:

```make
else ifdef CI
	$(call print,"📦 Running in CI - helpers should be pre-downloaded",$(YELLOW))
```

That is correct for the pipeline, where a prior stage publishes helpers. This job has no prior stage, so `make all` would clean, skip the build, and test nothing. The script calls `./build.sh` explicitly instead.

Verified locally with `CI=true`:

```
line   1: 🔨 Building Go and Rust helpers from source...      <- explicit build.sh
line 539: 📦 Running in CI - helpers should be pre-downloaded  <- make's build no-op'd
EXIT=0
```

Suite result on that run: 4/4 builder×launcher combinations (twice), all security suites passed, 28/28 exit-code tests.

### Both platforms

Linux and macOS both run, `fail-fast: false`. The slot-2 defect fixed in #22 was a hardcoded `darwin_arm64` path — invisible on macOS, broken on Linux. Single-platform coverage would miss that class entirely.

### Script policy

The `run:` blocks stay within the ≤3-line policy; the work lives in `ci/pr-pretaster.sh`.

## Self-test

This PR is itself the first to exercise the new workflow, so its own checks are the verification.

## Follow-up, not addressed here

While tracing this I found that the existing quality checks are structurally incapable of failing. `🔍 Rust Linting` carries `continue-on-error: true`, *and* wraps every check as `if cargo clippy ...; then ✅ else ⚠️ fi`, so the step exits 0 either way. The same shape appears in the Go and Python steps. `🦀 Rust Quality  pass` therefore does not mean clippy passed — it means the job ran.

That is a separate defect from this one and needs its own decision about which checks should become blocking, so I have not changed it here.