### PR TITLE
fix(logger): stop holding the log mutex while writing to stderr

### DIFF
--- a/src/flavor-rs/Makefile
+++ b/src/flavor-rs/Makefile
@@ -90,11 +90,15 @@ security:
 # --test-threads=1 is the fix rather than a workaround: the whole suite finishes
 # in about half a second serially, so the parallel harness was buying nothing and
 # costing correctness.
-TEST_THREADS ?= 1
+# Parallel by default. The suite used to deadlock above one thread -- a
+# lock-order inversion in JsonLogger, fixed since -- and this was pinned to 1
+# to hide it. Set TEST_THREADS=1 to force serial execution if ever needed.
+TEST_THREADS ?=
+TEST_THREAD_ARGS := $(if $(TEST_THREADS),-- --test-threads=$(TEST_THREADS),)
 
 test:
 	@echo "🧪 Running Rust tests..."
-	@cargo test --all-features -- --test-threads=$(TEST_THREADS)
+	@cargo test --all-features $(TEST_THREAD_ARGS)
 	@echo "✅ Tests passed"
 
 coverage:
@@ -107,7 +111,7 @@ coverage:
 		export LLVM_COV=/opt/homebrew/opt/llvm/bin/llvm-cov; \
 		export LLVM_PROFDATA=/opt/homebrew/opt/llvm/bin/llvm-profdata; \
 	fi; \
-	cargo llvm-cov --all-features --workspace --lcov --output-path coverage.lcov -- --test-threads=$(TEST_THREADS); \
+	cargo llvm-cov --all-features --workspace --lcov --output-path coverage.lcov $(TEST_THREAD_ARGS); \
 	cargo llvm-cov report --summary-only | tee coverage.txt; \
 	total="$$(awk '/^TOTAL/{gsub(/%/,"",$$10); print $$10}' coverage.txt | tail -1)"; \
 	min="$${QUALITY_RUST_COV_MIN}"; \
@@ -123,7 +127,7 @@ coverage:
 
 proptest:
 	@echo "🧪 Running Rust property tests..."
-	@cargo test prop_ --all-features -- --test-threads=$(TEST_THREADS)
+	@cargo test prop_ --all-features $(TEST_THREAD_ARGS)
 	@echo "✅ Proptests passed"
 
 mutation:

--- a/src/flavor-rs/src/logger.rs
+++ b/src/flavor-rs/src/logger.rs
@@ -135,24 +135,35 @@ impl Log for JsonLogger {
             serde_json::to_string(&log_entry).unwrap_or_default()
         );
 
-        // Write to file or stderr
-        if let Ok(mut file_guard) = self.target_file.lock() {
-            if let Some(ref mut file) = *file_guard {
-                let _ = file.write_all(json_string.as_bytes());
-                let _ = file.flush();
-            } else {
-                // Write to stderr
-                let _ = io::stderr().write_all(json_string.as_bytes());
-                let _ = io::stderr().flush();
-            }
-        } else {
-            // Fallback to stderr if lock fails
-            let _ = io::stderr().write_all(json_string.as_bytes());
-            let _ = io::stderr().flush();
+        // Write to the target file, holding the lock only for that write.
+        //
+        // ⚠️ Never write to stderr while this lock is held. stderr has a lock of
+        // its own, so doing so takes (target_file -> stderr) while any writer
+        // that already holds stderr -- libtest's output capture, for one --
+        // wants target_file next. That inversion deadlocked the whole test
+        // suite: one thread stuck in Stderr::write_all holding target_file,
+        // every other thread stuck waiting for target_file, forever.
+        let wrote_to_file = match self.target_file.lock() {
+            Ok(mut file_guard) => match file_guard.as_mut() {
+                Some(file) => {
+                    let _ = file.write_all(json_string.as_bytes());
+                    let _ = file.flush();
+                    true
+                }
+                None => false,
+            },
+            Err(_) => false,
+        };
+
+        if !wrote_to_file {
+            let mut stderr = io::stderr().lock();
+            let _ = stderr.write_all(json_string.as_bytes());
+            let _ = stderr.flush();
         }
     }
 
     fn flush(&self) {
+        // Same ordering rule as log(): release target_file before touching stderr.
         if let Ok(mut file_guard) = self.target_file.lock() {
             if let Some(ref mut file) = *file_guard {
                 let _ = file.flush();


### PR DESCRIPTION
Closes #23.

## Symptom

`cargo test --lib` at the default thread count never finishes. It reaches ~250 tests, then sits forever with tests that each pass in **0.00s in isolation** stuck past 60 seconds.

## Root cause

Sampling the hung process. Every blocked thread is in the same place:

```
flavor::psp::detect_format
  → log::__private_api::log_impl
    → flavor::logger::JsonLogger::log
      → std::sync::Mutex<Option<File>>::lock
        → __psynch_mutexwait          ← 24 of 25 threads here
```

And the thread *holding* that mutex is blocked one frame further on:

```
JsonLogger::log
  → [holds target_file]
    → std::io::stdio::Stderr::write_all
      → __psynch_mutexwait            ← waiting on stderr's own lock
```

A **lock-order inversion**. `JsonLogger` took `target_file` → `stderr`, while libtest's output capture holds `stderr` and wants to write. One thread wedges inside `Stderr::write_all` still holding `target_file`; every other logging thread queues behind `target_file`. Permanent.

It is not fixture state or a shared path — my first hypothesis, and wrong.

## Fix

The lock only ever needed to cover the file write. stderr has a lock of its own and never needed ours.

```rust
let wrote_to_file = match self.target_file.lock() {
    Ok(mut guard) => match guard.as_mut() {
        Some(file) => { /* write + flush */ true }
        None => false,
    },
    Err(_) => false,
};

if !wrote_to_file {
    let mut stderr = io::stderr().lock();   // outside our lock
    ...
}
```

`flush()` follows the same ordering rule.

## This is not test-only

Any process that configures a file log target and logs from more than one thread can wedge identically. The launcher does both.

## The workaround is removed too

`TEST_THREADS ?= 1` in `src/flavor-rs/Makefile` existed to hide this, and every CI path inherited it — which is why the deadlock could never surface there. Removed. The variable remains for anyone who wants to force serial execution:

```console
$ make test                  # parallel (default)
$ make test TEST_THREADS=1   # serial, still works
```

Running the suite in parallel is now the regression guard: a reintroduced inversion wedges it again, in CI this time.

## Result

| | |
|---|---|
| before | hangs indefinitely, ~17 tests stuck past 60s |
| after | **289 passed in 0.15s**, 0 stuck |

Verified both ways: `make test` (parallel) and `make test TEST_THREADS=1` (serial) both green.