### PR TITLE
test(pretaster): count skips so a green suite means something ran

### DIFF
--- a/.github/workflows/pr-pretaster.yml
+++ b/.github/workflows/pr-pretaster.yml
@@ -69,7 +69,7 @@ jobs:
 
       # The security suites need the flavor CLI; ci/pr-pretaster.sh uv syncs it.
       - name: 📦 Setup uv + Python
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/pr-pretaster.yml
+++ b/.github/workflows/pr-pretaster.yml
@@ -67,6 +67,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # The security suites need the flavor CLI; ci/pr-pretaster.sh uv syncs it.
+      - name: 📦 Setup uv + Python
+        uses: astral-sh/setup-uv@v10
+        with:
+          enable-cache: true
+
       # Go toolchain, version pinned by the module itself.
       - name: 🐹 Setup Go
         uses: actions/setup-go@v7
@@ -101,6 +107,11 @@ jobs:
 
       # Builds helpers from source, then runs the pretaster suite against them.
       - name: 🧪 Build helpers and run pretaster
+        # Strict: every prerequisite exists in CI, so a skipped check is a setup
+        # bug, not "not applicable here". Without it a suite can report success
+        # having asserted nothing.
+        env:
+          PRETASTER_STRICT: "1"
         run: ci/pr-pretaster.sh "${{ inputs.test_target || 'test' }}"
 
       # Suite logs are the only record of which combination failed.

--- a/ci/pr-pretaster.sh
+++ b/ci/pr-pretaster.sh
@@ -27,5 +27,10 @@ echo "🔨 Building Go and Rust helpers from source..."
 echo "📦 Helpers built:"
 ls -la dist/bin/
 
+# The security suites need the flavor CLI for the policy tests. Without a venv
+# they skipped it silently, so CI was not running those checks at all.
+echo "🐍 Installing the flavor CLI..."
+uv sync --quiet
+
 echo "🧪 Running pretaster suite (${TEST_TARGET})..."
 make -C tests/pretaster "${TEST_TARGET}"

--- a/tests/pretaster/scripts/build_policy_blocked_psp.py
+++ b/tests/pretaster/scripts/build_policy_blocked_psp.py
@@ -27,7 +27,7 @@ import tempfile
 
 
 def _find_launcher() -> Path | None:
-    """Try to locate a launcher binary without relying on dist/bin/."""
+    """Locate a launcher binary."""
     # 1. Environment override
     env_bin = os.environ.get("FLAVOR_LAUNCHER_BIN")
     if env_bin:
@@ -35,16 +35,27 @@ def _find_launcher() -> Path | None:
         if p.exists():
             return p
 
-    # 2. Local Go/Rust source build
     script_dir = Path(__file__).parent
     # Walk up from scripts/ to find the project root (scripts/ → pretaster/ → tests/ → project)
     # Try both 3 and 4 levels to support different checkout structures.
     for levels in (3, 4):
-        p = script_dir
+        root = script_dir
         for _ in range(levels):
-            p = p.parent
-        candidate_go = p / "src" / "flavor-go" / "flavor-go-launcher"
-        candidate_rs = p / "src" / "flavor-rs" / "target" / "release" / "flavor-rs-launcher"
+            root = root.parent
+
+        # 2. dist/bin/, where build.sh actually puts the helpers. This is the
+        # canonical location and the only platform-independent one: on Linux
+        # the Rust helpers are built for a musl target, so they land in
+        # target/<triple>/release/ rather than target/release/, and the
+        # source-tree probe below silently misses them. That is why the policy
+        # suite ran on macOS and skipped on Linux.
+        for candidate in sorted((root / "dist" / "bin").glob("flavor-*-launcher*")):
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
+
+        # 3. Local Go/Rust source build
+        candidate_go = root / "src" / "flavor-go" / "flavor-go-launcher"
+        candidate_rs = root / "src" / "flavor-rs" / "target" / "release" / "flavor-rs-launcher"
         for c in (candidate_go, candidate_rs):
             if c.exists() and os.access(c, os.X_OK):
                 return c

--- a/tests/pretaster/tests/combo/test-combinations.sh
+++ b/tests/pretaster/tests/combo/test-combinations.sh
@@ -306,6 +306,9 @@ for combo in "${combinations[@]}"; do
     # Run test and track result (don't exit on failure)
     if test_combination "$builder" "$launcher" "$builder_bin" "$launcher_bin" "$emoji"; then
         PASSED_COMBOS+=("$emoji $builder+$launcher")
+        # Also record it with the shared counter, so print_test_summary
+        # reports a real tally instead of "No checks ran".
+        pass_test
     else
         FAILED_COMBOS+=("$emoji $builder+$launcher")
     fi

--- a/tests/pretaster/tests/compat/test-json-manifests.sh
+++ b/tests/pretaster/tests/compat/test-json-manifests.sh
@@ -290,6 +290,9 @@ for combo in "${combinations[@]}"; do
 
     if test_json_manifest_combination "$builder" "$launcher" "$builder_bin" "$launcher_bin" "$emoji"; then
         PASSED_COMBOS+=("$emoji $builder+$launcher")
+        # Also record it with the shared counter, so print_test_summary
+        # reports a real tally instead of "No checks ran".
+        pass_test
     else
         FAILED_COMBOS+=("$emoji $builder+$launcher")
     fi

--- a/tests/pretaster/tests/lib/test-lib.sh
+++ b/tests/pretaster/tests/lib/test-lib.sh
@@ -11,8 +11,47 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Test result tracking
+#
+# Passes and skips are both counted so the summary can distinguish a suite that
+# verified something from one whose prerequisites were all missing. Previously
+# only failures were tracked, so a suite that asserted nothing at all printed
+# the same "✅ All tests passed!" as one that asserted everything.
 TEST_FAILURES=0
+TEST_PASSES=0
+TEST_SKIPS=0
 FAILED_TESTS=""
+SKIPPED_TESTS=""
+
+# PRETASTER_STRICT=1 turns a skipped prerequisite into a failure. CI is meant to
+# have every prerequisite present, so a skip there is a setup bug, not a
+# legitimate "not applicable on this machine".
+PRETASTER_STRICT="${PRETASTER_STRICT:-0}"
+
+# Record a skipped check and why. Use this instead of a bare echo so the skip
+# reaches the summary.
+skip_test() {
+    local test_name="$1"
+    local reason="$2"
+
+    if [ "$PRETASTER_STRICT" = "1" ]; then
+        print_color "$RED" "  ❌ ${test_name}: ${reason} (strict mode: skips are failures)"
+        TEST_FAILURES=$((TEST_FAILURES + 1))
+        FAILED_TESTS="$FAILED_TESTS\n  - ${test_name} (skipped: ${reason})"
+        return 1
+    fi
+
+    print_color "$YELLOW" "  ⚠️  ${test_name}: ${reason} — skipping"
+    TEST_SKIPS=$((TEST_SKIPS + 1))
+    SKIPPED_TESTS="$SKIPPED_TESTS\n  - ${test_name}: ${reason}"
+    return 0
+}
+
+# Record a check that ran and passed.
+pass_test() {
+    TEST_PASSES=$((TEST_PASSES + 1))
+    [ -n "${1:-}" ] && print_color "$GREEN" "  ✅ $1"
+    return 0
+}
 
 # Print colored message
 print_color() {
@@ -39,6 +78,7 @@ run_test() {
     
     if eval "$test_cmd"; then
         print_color "$GREEN" "✅ Test passed"
+        TEST_PASSES=$((TEST_PASSES + 1))
         return 0
     else
         local exit_code=$?
@@ -112,16 +152,32 @@ test_with_exit_code() {
 print_test_summary() {
     echo ""
     echo "═══════════════════════════════════"
-    if [ $TEST_FAILURES -eq 0 ]; then
-        print_color "$GREEN" "✅ All tests passed!"
-        return 0
-    else
-        print_color "$RED" "❌ $TEST_FAILURES test(s) failed!"
-        if [ -n "$FAILED_TESTS" ]; then
-            echo -e "\nFailed tests:$FAILED_TESTS"
-        fi
+
+    local tally="${TEST_PASSES} passed, ${TEST_SKIPS} skipped, ${TEST_FAILURES} failed"
+
+    if [ $TEST_FAILURES -ne 0 ]; then
+        print_color "$RED" "❌ $TEST_FAILURES check(s) failed!  (${tally})"
+        [ -n "$FAILED_TESTS" ] && echo -e "\nFailed:$FAILED_TESTS"
+        [ -n "$SKIPPED_TESTS" ] && echo -e "\nSkipped:$SKIPPED_TESTS"
         return 1
     fi
+
+    # Nothing failed -- but say plainly whether anything actually ran. A suite
+    # that asserted nothing is not the same result as one that asserted plenty.
+    if [ "$TEST_PASSES" -eq 0 ]; then
+        print_color "$YELLOW" "⚠️  No checks ran!  (${tally})"
+        [ -n "$SKIPPED_TESTS" ] && echo -e "\nSkipped:$SKIPPED_TESTS"
+        return 0
+    fi
+
+    if [ "$TEST_SKIPS" -ne 0 ]; then
+        print_color "$GREEN" "✅ All checks passed  (${tally})"
+        echo -e "\nSkipped:$SKIPPED_TESTS"
+        return 0
+    fi
+
+    print_color "$GREEN" "✅ All checks passed  (${tally})"
+    return 0
 }
 
 # Check PE header for Windows compatibility issues

--- a/tests/pretaster/tests/lib/test-setup.sh
+++ b/tests/pretaster/tests/lib/test-setup.sh
@@ -30,7 +30,11 @@ PLATFORM="${OS}_${ARCH}"
 EXT=""
 [[ "$OS" == "windows" ]] && EXT=".exe"
 
-# Locate flavor CLI
+# Locate flavor CLI.
+# This is flavorpack's own entry point ([project.scripts] flavor = flavor.cli:main),
+# so its absence means the package under test is not installed -- not that some
+# optional extra is unavailable. Suites that need it should say so plainly; in
+# CI, PRETASTER_STRICT makes that a failure rather than a silent skip.
 FLAVOR_BIN=""
 if [ -f "$PROJECT_ROOT/.venv/bin/flavor" ]; then
     FLAVOR_BIN="$PROJECT_ROOT/.venv/bin/flavor"

--- a/tests/pretaster/tests/security/test-integrity.sh
+++ b/tests/pretaster/tests/security/test-integrity.sh
@@ -34,7 +34,7 @@ if [ -n "$TRUST_PSP" ]; then
     set -e
 
     if [ $TAMPER_EXIT -ne 0 ]; then
-        print_color "$GREEN" "  ✅ Tampered PSP rejected by launcher (exit $TAMPER_EXIT)"
+        pass_test "Tampered PSP rejected by launcher (exit $TAMPER_EXIT)"
     else
         print_color "$RED" "  ❌ FAIL: Tampered PSP should be rejected"
         TEST_FAILURES=$((TEST_FAILURES + 1))
@@ -49,7 +49,7 @@ if [ -n "$TRUST_PSP" ]; then
         set -e
 
         if [ $TAMPER_CLI_EXIT -ne 0 ]; then
-            print_color "$GREEN" "  ✅ Tampered PSP rejected by flavor CLI (exit $TAMPER_CLI_EXIT)"
+            pass_test "Tampered PSP rejected by flavor CLI (exit $TAMPER_CLI_EXIT)"
         else
             print_color "$RED" "  ❌ FAIL: Tampered PSP should be rejected by CLI"
             TEST_FAILURES=$((TEST_FAILURES + 1))
@@ -59,7 +59,7 @@ if [ -n "$TRUST_PSP" ]; then
 
     rm -f "$TAMPERED_PSP"
 else
-    print_color "$YELLOW" "  ⚠️  No PSP available — skipping"
+    skip_test "Checksum tampering detected" "no PSP available"
 fi
 
 echo ""
@@ -78,7 +78,7 @@ if [ -n "$TRUST_PSP" ]; then
     set -e
 
     if [ $VERIFY_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Valid PSP verified (exit 0)"
+        pass_test "Valid PSP verified (exit 0)"
     else
         print_color "$RED" "  ❌ FAIL: Valid PSP should verify (exit $VERIFY_EXIT)"
         echo "     Output: $VERIFY_OUTPUT"
@@ -86,7 +86,7 @@ if [ -n "$TRUST_PSP" ]; then
         FAILED_TESTS="$FAILED_TESTS\n  - Verify: valid PSP"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  No PSP available — skipping"
+    skip_test "Signature tampering detected" "no PSP available"
 fi
 
 echo ""
@@ -111,7 +111,7 @@ ENDJSON
     rm -rf "$POLICY_DIR"
 
     if [ $AGE_OK_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Fresh package accepted with max_age_days=9999"
+        pass_test "Fresh package accepted with max_age_days=9999"
     else
         print_color "$RED" "  ❌ FAIL: Fresh package should pass (exit $AGE_OK_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
@@ -130,14 +130,14 @@ ENDJSON
     rm -rf "$POLICY_DIR"
 
     if [ $AGE_WARN_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Age check with warn mode did not block"
+        pass_test "Age check with warn mode did not block"
     else
         print_color "$RED" "  ❌ FAIL: Warn mode should not block (exit $AGE_WARN_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Age: warn mode"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipping (no flavor CLI or PSP)"
+    skip_test "Policy enforcement" "no flavor CLI or PSP"
 fi
 
 echo ""
@@ -166,14 +166,14 @@ ENDJSON
     rm -rf "$POLICY_DIR" "$TRUST_DIR"
 
     if [ $ALLOW_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Allow mode passed all checks silently"
+        pass_test "Allow mode passed all checks silently"
     else
         print_color "$RED" "  ❌ FAIL: Allow mode should pass (exit $ALLOW_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Enforcement: allow"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipping (no flavor CLI or policy-block PSP)"
+    skip_test "Policy-block enforcement" "no flavor CLI or policy-block PSP"
 fi
 
 echo ""
@@ -197,14 +197,14 @@ ENDJSON
     rm -rf "$POLICY_DIR"
 
     if [ $FWD_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Future version policy accepted gracefully"
+        pass_test "Future version policy accepted gracefully"
     else
         print_color "$RED" "  ❌ FAIL: Future version should be accepted (exit $FWD_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Forward-version"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipping (no flavor CLI or PSP)"
+    skip_test "Integrity enforcement" "no flavor CLI or PSP"
 fi
 
 echo ""
@@ -224,12 +224,12 @@ if [ -f "dist/env-test.psp" ]; then
     set -e
 
     if [ $ENV_OK_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Execution with env vars succeeded"
+        pass_test "Execution with env vars succeeded"
     else
         print_color "$YELLOW" "  ⚠️  env-test.psp failed (exit $ENV_OK_EXIT) — may be unrelated to env vars"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  env-test.psp not found — run test-pretaster.sh first"
+    skip_test "Environment variable handling" "env-test.psp not found (run test-pretaster.sh first)"
 fi
 
 echo ""

--- a/tests/pretaster/tests/security/test-policy.sh
+++ b/tests/pretaster/tests/security/test-policy.sh
@@ -17,13 +17,13 @@ BUILD_HELPER="$PRETASTER_DIR/scripts/build_policy_blocked_psp.py"
 # Build the policy-blocked PSP (platforms: ["mars_amd64"])
 # ---------------------------------------------------------------------------
 if [ -z "$FLAVOR_BIN" ]; then
-    print_color "$YELLOW" "  ⚠️  flavor CLI not found — skipping policy tests"
+    skip_test "Policy tests" "flavor CLI not found — flavorpack is not installed (run: uv sync)"
     POLICY_TEST_SKIPPED=true
 elif [ -z "$PYTHON_BIN" ]; then
-    print_color "$YELLOW" "  ⚠️  python3 not found — skipping policy tests"
+    skip_test "Policy tests" "python3 not found"
     POLICY_TEST_SKIPPED=true
 elif [ ! -f "$BUILD_HELPER" ]; then
-    print_color "$YELLOW" "  ⚠️  Build helper not found: $BUILD_HELPER"
+    skip_test "Policy tests" "build helper not found"
     POLICY_TEST_SKIPPED=true
 else
     set +e
@@ -56,7 +56,7 @@ if [ "$POLICY_TEST_SKIPPED" = false ] && [ -f "$POLICY_PSP" ]; then
     rm -rf "$DENY_POLICY_DIR"
 
     if [ $CHECK_EXIT -ne 0 ] && echo "$CHECK_OUTPUT" | grep -qiE 'not permitted|not in|platform.*not|mars_amd64'; then
-        print_color "$GREEN" "  ✅ Platform deny correctly rejected mars_amd64 (exit $CHECK_EXIT)"
+        pass_test "Platform deny correctly rejected mars_amd64 (exit $CHECK_EXIT)"
     else
         print_color "$RED" "  ❌ FAIL: Should have rejected mars_amd64 package"
         echo "     Output: $CHECK_OUTPUT"
@@ -64,7 +64,7 @@ if [ "$POLICY_TEST_SKIPPED" = false ] && [ -f "$POLICY_PSP" ]; then
         FAILED_TESTS="$FAILED_TESTS\n  - Platform deny"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipped"
+    skip_test "Platform deny enforcement" "prerequisites missing"
 fi
 
 echo ""
@@ -88,14 +88,14 @@ ENDJSON
     rm -rf "$POLICY_DIR"
 
     if [ $WARN_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Warn mode allowed the blocked package"
+        pass_test "Warn mode allowed the blocked package"
     else
         print_color "$RED" "  ❌ FAIL: Warn mode should allow (exit $WARN_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Warn mode"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipped"
+    skip_test "Warn mode allows" "prerequisites missing"
 fi
 
 echo ""
@@ -121,14 +121,14 @@ ENDJSON
     rm -rf "$POLICY_DIR" "$TRUST_DIR"
 
     if [ $ALLOW_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Allow mode passed all checks silently"
+        pass_test "Allow mode passed all checks silently"
     else
         print_color "$RED" "  ❌ FAIL: Allow mode should pass (exit $ALLOW_EXIT)"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Allow mode"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipped"
+    skip_test "Allow mode passes" "prerequisites missing"
 fi
 
 echo ""
@@ -152,9 +152,9 @@ if [ -n "$FLAVOR_BIN" ] && [ -n "$INSPECT_PSP" ]; then
         set -e
 
         if [ $SBOM_EXIT -eq 0 ] && echo "$SBOM_OUTPUT" | grep -qiE 'CycloneDX|bomFormat'; then
-            print_color "$GREEN" "  ✅ SBOM inspection returned CycloneDX"
+            pass_test "SBOM inspection returned CycloneDX"
         elif echo "$SBOM_OUTPUT" | grep -qiE 'no sbom|sbom not found|no attestation|not present'; then
-            print_color "$GREEN" "  ✅ SBOM inspection: no SBOM in package (correct)"
+            pass_test "SBOM inspection: no SBOM in package (correct)"
         else
             print_color "$RED" "  ❌ Unexpected SBOM output (exit $SBOM_EXIT)"
             TEST_FAILURES=$((TEST_FAILURES + 1))
@@ -164,7 +164,7 @@ if [ -n "$FLAVOR_BIN" ] && [ -n "$INSPECT_PSP" ]; then
         print_color "$YELLOW" "  ⚠️  flavor inspect --sbom not supported in this version"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  Skipping (no flavor CLI or PSP)"
+    skip_test "SBOM inspection" "no flavor CLI or PSP"
 fi
 
 echo ""

--- a/tests/pretaster/tests/security/test-policy.sh
+++ b/tests/pretaster/tests/security/test-policy.sh
@@ -27,7 +27,11 @@ elif [ ! -f "$BUILD_HELPER" ]; then
     POLICY_TEST_SKIPPED=true
 else
     set +e
-    BUILD_OUTPUT=$(cd "$PROJECT_ROOT" && "$PYTHON_BIN" "$BUILD_HELPER" "$PRETASTER_DIR/$POLICY_PSP" 2>&1)
+    # Pass the launcher explicitly: test-setup.sh already resolved it for this
+    # platform, and the helper's own probe cannot see the Linux musl build.
+    POLICY_LAUNCHER="$RS_LAUNCHER"
+    [ ! -f "$POLICY_LAUNCHER" ] && POLICY_LAUNCHER="$GO_LAUNCHER"
+    BUILD_OUTPUT=$(cd "$PROJECT_ROOT" && FLAVOR_LAUNCHER_BIN="$POLICY_LAUNCHER" "$PYTHON_BIN" "$BUILD_HELPER" "$PRETASTER_DIR/$POLICY_PSP" 2>&1)
     BUILD_EXIT=$?
     set -e
     if [ $BUILD_EXIT -ne 0 ]; then

--- a/tests/pretaster/tests/security/test-trust.sh
+++ b/tests/pretaster/tests/security/test-trust.sh
@@ -29,10 +29,10 @@ ENDJSON
     rm -rf "$TRUST_DIR" "$POLICY_DIR"
 
     if [ $UNTRUST_EXIT -ne 0 ]; then
-        print_color "$GREEN" "  ✅ Untrusted key correctly rejected (exit $UNTRUST_EXIT)"
+        pass_test "Untrusted key correctly rejected (exit $UNTRUST_EXIT)"
     elif [ "$TRUST_CHECK_MODE" = "launcher" ]; then
         if echo "$TRUST_CHECK_OUTPUT" | grep -qiE 'not in.*trusted|signing key'; then
-            print_color "$GREEN" "  ✅ Launcher warned about untrusted key (enforcement not yet wired)"
+            pass_test "Launcher warned about untrusted key (enforcement not yet wired)"
         else
             print_color "$YELLOW" "  ⚠️  Launcher did not enforce require_trusted_key (may need rebuild)"
         fi
@@ -43,7 +43,7 @@ ENDJSON
         FAILED_TESTS="$FAILED_TESTS\n  - Untrusted key rejected"
     fi
 else
-    print_color "$YELLOW" "  ⚠️  echo-test.psp not found — run test-pretaster.sh first"
+    skip_test "Untrusted key rejected" "echo-test.psp not found (run test-pretaster.sh first)"
 fi
 
 echo ""
@@ -68,19 +68,19 @@ ENDJSON
     set +e; _run_trust_check "$POLICY_DIR" "$TRUST_DIR" "$TRUST_PSP"; TRUST_EXIT=$?; set -e
 
     if [ $TRUST_EXIT -eq 0 ]; then
-        print_color "$GREEN" "  ✅ Trusted key accepted (exit 0, fp: ${TRUST_TEST_FINGERPRINT:0:16}...)"
+        pass_test "Trusted key accepted (exit 0, fp: ${TRUST_TEST_FINGERPRINT:0:16}...)"
     elif echo "$TRUST_CHECK_OUTPUT" | grep -qiE 'trusted.*key|not.*trusted'; then
         print_color "$RED" "  ❌ FAIL: Trusted key should have been accepted (exit $TRUST_EXIT)"
         echo "     Output: $TRUST_CHECK_OUTPUT"
         TEST_FAILURES=$((TEST_FAILURES + 1))
         FAILED_TESTS="$FAILED_TESTS\n  - Trusted key accepted"
     else
-        print_color "$GREEN" "  ✅ Trusted key accepted (exit $TRUST_EXIT — trust OK, payload may fail)"
+        pass_test "Trusted key accepted (exit $TRUST_EXIT — trust OK, payload may fail)"
     fi
 
     rm -rf "$TRUST_DIR" "$POLICY_DIR"
 else
-    print_color "$YELLOW" "  ⚠️  echo-test.psp not found — run test-pretaster.sh first"
+    skip_test "Untrusted key rejected" "echo-test.psp not found (run test-pretaster.sh first)"
 fi
 
 echo ""
@@ -96,9 +96,9 @@ CROSS_MANIFEST="$RESOLVED_CONFIGS_DIR/test-echo.json"
 CROSS_SEED="cross-trust-test"
 CROSS_SKIP=false
 
-[ ! -f "$GO_BUILDER" ] || [ ! -f "$RS_BUILDER" ] && { print_color "$YELLOW" "  ⚠️  Need both builders — skipping"; CROSS_SKIP=true; }
-[ ! -f "$GO_LAUNCHER" ] && [ ! -f "$RS_LAUNCHER" ] && { print_color "$YELLOW" "  ⚠️  No launcher — skipping"; CROSS_SKIP=true; }
-[ ! -f "$CROSS_MANIFEST" ] && { print_color "$YELLOW" "  ⚠️  resolved test-echo.json not found (run make to resolve configs) — skipping"; CROSS_SKIP=true; }
+[ ! -f "$GO_BUILDER" ] || [ ! -f "$RS_BUILDER" ] && { skip_test "Cross-builder trust" "need both builders"; CROSS_SKIP=true; }
+[ ! -f "$GO_LAUNCHER" ] && [ ! -f "$RS_LAUNCHER" ] && { skip_test "Cross-builder trust" "no launcher available"; CROSS_SKIP=true; }
+[ ! -f "$CROSS_MANIFEST" ] && { skip_test "Cross-builder trust" "resolved test-echo.json not found (run make to resolve configs)"; CROSS_SKIP=true; }
 
 # Derive cross-trust key (requires Python for Ed25519 derivation)
 CROSS_TRUST_DIR=""
@@ -115,10 +115,10 @@ r=p.public_bytes(Encoding.Raw,PublicFormat.Raw)
 fp=hashlib.sha256(r).hexdigest()
 open('$CROSS_TRUST_DIR/'+fp[:16]+'.pub','w').write('# Name: cross\n'+p.public_bytes(Encoding.PEM,PublicFormat.SubjectPublicKeyInfo).decode())
 print(fp)" 2>&1)
-    [ $? -ne 0 ] && { print_color "$YELLOW" "  ⚠️  Key derivation failed — skipping"; CROSS_SKIP=true; }
+    [ $? -ne 0 ] && { skip_test "Cross-builder trust" "key derivation failed"; CROSS_SKIP=true; }
     set -e
 elif [ "$CROSS_SKIP" = false ]; then
-    print_color "$YELLOW" "  ⚠️  Python not available for key derivation — skipping"
+    skip_test "Cross-builder trust" "python3 not available for key derivation"
     CROSS_SKIP=true
 fi
 
@@ -135,7 +135,7 @@ ENDJSON
     for BUILDER_NAME in "Go" "Rust"; do
         BUILDER_BIN="$GO_BUILDER"
         [ "$BUILDER_NAME" = "Rust" ] && BUILDER_BIN="$RS_BUILDER"
-        [ ! -f "$BUILDER_BIN" ] && { print_color "$YELLOW" "  ⚠️  $BUILDER_NAME builder not found"; continue; }
+        [ ! -f "$BUILDER_BIN" ] && { skip_test "Cross-builder trust ($BUILDER_NAME)" "builder not found"; continue; }
 
         CROSS_PSP=$(mktemp "${TMPDIR:-/tmp}/cross-${BUILDER_NAME}-XXXXXX.psp")
         set +e
@@ -156,7 +156,7 @@ ENDJSON
         set +e; _run_trust_check "$CROSS_POLICY_DIR" "$EMPTY_TRUST" "$CROSS_PSP"; CROSS_RC=$?; set -e
         rm -rf "$EMPTY_TRUST"
         if [ $CROSS_RC -ne 0 ]; then
-            print_color "$GREEN" "  ✅ $BUILDER_NAME-built: untrusted rejected (exit $CROSS_RC)"
+            pass_test "$BUILDER_NAME-built: untrusted rejected (exit $CROSS_RC)"
         else
             print_color "$RED" "  ❌ $BUILDER_NAME-built: should reject untrusted"
             TEST_FAILURES=$((TEST_FAILURES + 1))
@@ -166,13 +166,13 @@ ENDJSON
         # Trusted
         set +e; _run_trust_check "$CROSS_POLICY_DIR" "$CROSS_TRUST_DIR" "$CROSS_PSP"; CROSS_RC=$?; set -e
         if [ $CROSS_RC -eq 0 ]; then
-            print_color "$GREEN" "  ✅ $BUILDER_NAME-built: trusted accepted (exit 0)"
+            pass_test "$BUILDER_NAME-built: trusted accepted (exit 0)"
         elif echo "$TRUST_CHECK_OUTPUT" | grep -qiE 'trusted.*key|not.*trusted'; then
             print_color "$RED" "  ❌ $BUILDER_NAME-built: should accept trusted"
             TEST_FAILURES=$((TEST_FAILURES + 1))
             FAILED_TESTS="$FAILED_TESTS\n  - Cross-builder: $BUILDER_NAME trusted"
         else
-            print_color "$GREEN" "  ✅ $BUILDER_NAME-built: trusted accepted (exit $CROSS_RC — payload may fail)"
+            pass_test "$BUILDER_NAME-built: trusted accepted (exit $CROSS_RC — payload may fail)"
         fi
 
         rm -f "$CROSS_PSP"


### PR DESCRIPTION
Closes #25.

## The problem

A suite whose prerequisites were all missing printed exactly the same `✅ All tests passed!` as one that verified everything. Only failures were tracked, so **asserting nothing was indistinguishable from asserting everything**.

## It was already happening

CI has been skipping the entire policy suite on every run:

```
⚠️  flavor CLI not found — skipping policy tests
```

`flavor` is this project's own console script:

```toml
[project.scripts]
flavor = "flavor.cli:main"
```

So its absence does not mean an optional extra is unavailable — it means **flavorpack was never installed**. `ci/pr-pretaster.sh` built the helpers but never ran `uv sync`, so the package under test was missing and the suite reported success anyway.

Two bugs stacked: CI not installing the thing under test, and a skip that could not be told apart from a pass. Both are fixed here — the job now installs it, and those checks run for the first time.

## The change

Passes and skips are both counted. The summary states the tally, and says plainly when nothing ran:

```
✅ All checks passed  (8 passed, 0 skipped, 0 failed)

⚠️  No checks ran!    (0 passed, 3 skipped, 0 failed)
Skipped:
  - Untrusted key rejected: echo-test.psp not found (run test-pretaster.sh first)
  - Cross-builder trust: resolved test-echo.json not found
```

`PRETASTER_STRICT=1` turns a skip into a failure, and CI sets it. Every prerequisite exists in CI, so a skip there is a setup bug rather than a legitimate "not applicable on this machine".

## Scope

- 21 skip sites across the integrity, policy and trust suites now go through `skip_test`
- 20 assertion sites go through `pass_test`
- `test-combinations.sh` and `test-json-manifests.sh` keep their own combination counters and also record through `pass_test`, so their summaries report a real tally rather than claiming nothing ran

## Verification

Normal run — real counts, where before every one of these printed the same bare "All tests passed":

```
✅ All checks passed  (4 passed, 0 skipped, 0 failed)
✅ All checks passed  (4 passed, 0 skipped, 0 failed)
✅ All checks passed  (6 passed, 0 skipped, 0 failed)
✅ All checks passed  (8 passed, 0 skipped, 0 failed)
✅ All checks passed  (4 passed, 0 skipped, 0 failed)
```

Prerequisites removed — the case that motivated the issue:

```
⚠️  No checks ran!  (0 passed, 3 skipped, 0 failed)
```

Strict mode on the same state:

```
STRICT_EXIT=1
❌ 3 check(s) failed!  (0 passed, 0 skipped, 3 failed)
```

Full suite under `PRETASTER_STRICT=1 CI=true ci/pr-pretaster.sh`: `EXIT=0`.