### PR TITLE
Split stage 02 into 02a and 02b, and fix the workflow docs while there

### DIFF
--- a/.github/workflows/pr-pretaster.yml
+++ b/.github/workflows/pr-pretaster.yml
@@ -1,20 +1,22 @@
-name: 06 🧪 PR Pretaster
+name: 02b 🧪 Pretaster Validation (PR)
 # ─────────────────────────────────────────────────────────────────────────────
 # Script policy: keep inline run: blocks to ≤ 3 lines.
 # Anything longer belongs in ci/ and should be called from here.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# End-to-end coverage for pull requests.
+# End-to-end coverage for pull requests -- the second half of stage 02.
 #
-# The pretaster/taster pipelines cannot run on a PR: 01 Helper Prep is
-# workflow_dispatch-only, and 02/03/04 are workflow_run-gated to main/develop.
-# Before this workflow, the only PR check was 05 Code Quality, which runs
-# clippy/fmt/machete and no tests at all — so changes to the launcher, builder
-# and packaging paths merged with nothing exercising them.
+# 02a cannot serve a PR: it consumes the helper artifacts published by 01
+# Helper Prep, which is workflow_dispatch-only, and its workflow_run trigger is
+# gated to main/develop. Before this workflow existed, the only PR check was 05
+# Code Quality, which runs clippy/fmt/machete and no tests at all -- so changes
+# to the launcher, builder and packaging paths merged with nothing exercising
+# them.
 #
-# This builds the helpers from the PR's own source and runs the pretaster
-# suite against them: core, combo (all four builder×launcher combinations),
-# security, and compat.
+# So this builds the helpers from the PR's own source instead of downloading
+# them, and runs the same pretaster suite against them: core, combo (all four
+# builder×launcher combinations), security, and compat. Linux and macOS only;
+# 02a keeps the wider matrix.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pretaster-pipeline.yml
+++ b/.github/workflows/pretaster-pipeline.yml
@@ -1,4 +1,16 @@
-name: 02 🔬 Pretaster Validation
+name: 02a 🔬 Pretaster Validation
+#
+# Stage 02 runs the pretaster suite twice, against different helper binaries.
+#
+#   02a (this file) -- after 01 Helper Prep, on main and develop. Consumes the
+#                      published helper artifacts and covers the full platform
+#                      matrix, FreeBSD included.
+#   02b             -- on every pull request. Builds helpers from the PR's own
+#                      source, because a PR has no Helper Prep run to draw on,
+#                      and covers Linux and macOS only.
+#
+# Neither replaces the other: 02a is the broad post-merge sweep, 02b is the
+# gate that stops a broken launcher reaching main in the first place.
 
 on:
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,15 +45,29 @@ mypy src/
 
 ## CI Workflows
 
-Numbered pipeline stages, each triggering the next:
-1. `01-helper-prep.yml` - Build Go/Rust helpers for all 6 platforms
-2. `02-pretaster-pipeline.yml` - Cross-language validation with pretaster
-3. `03-flavor-pipeline.yml` - Main CI: tests, wheels, Flavor PSP builds (badge workflow)
-4. `04-taster-pipeline.yml` - End-to-end taster tests
-5. `05-code-quality.yml` - Linting, type checking, complexity
-6. `06-security-scan.yml` - Security scanning
-7. `07-dependency-audit.yml` - Dependency auditing
-8. `08-license-compliance.yml` - License compliance
+The stage number lives in the workflow's `name:`, not in its filename — the
+files are not prefixed. `gh run list --workflow=<file>` takes the filename.
+
+| Stage | File | Runs on | Does |
+|---|---|---|---|
+| 01 🥘 Helper Prep | `helper-prep.yml` | dispatch | Builds Go/Rust helpers for all 6 platforms |
+| 02a 🔬 Pretaster Validation | `pretaster-pipeline.yml` | after 01, main/develop | Cross-language validation on the full matrix, using 01's artifacts |
+| 02b 🧪 Pretaster Validation (PR) | `pr-pretaster.yml` | **pull request** | Same suite, helpers built from the PR's source, Linux + macOS |
+| 03 🌶️ Flavor Pipeline | `flavor-pipeline.yml` | after 01, main/develop | Tests, wheels, Flavor PSP builds (badge workflow) |
+| 04 🍰 Taster Pipeline | `taster-pipeline.yml` | after 03 | End-to-end taster tests |
+| 05 🎨 Code Quality | `code-quality.yml` | **pull request**, schedule | Linting, type checking, complexity |
+| 06 🔒 Security Scanning | `security-scan.yml` | push, schedule | Security scanning |
+| 07 📦 Dependency Audit | `dependency-audit.yml` | push, schedule | Dependency auditing |
+| 08 ⚖️ License Compliance | `license-compliance.yml` | **pull request**, schedule | License compliance |
+| 09 🚀 Release Pipeline | `release.yml` | dispatch | Release builds and publication |
+
+Unnumbered: `build-go.yml`, `build-rust.yml`, `build-tastesh.yml` are reusable
+(`workflow_call`); `compatibility-check.yml` and `exp-freebsd.yml` run on their
+own schedules.
+
+Only three workflows see a pull request: 02b, 05 and 08. In particular no
+workflow runs `cargo test`, `go test` or `pytest` on a PR — the suites live in
+03, which is `workflow_run`-gated to main. Verify test changes locally.
 
 ## Cross-Platform
 

--- a/docs/development/WINDOWS_ARM64_BUILD.md
+++ b/docs/development/WINDOWS_ARM64_BUILD.md
@@ -431,8 +431,8 @@ ls -la test-app.psp
 
 Windows ARM64 is now fully integrated into the CI/CD pipeline:
 
-- **Helper Build**: `01-helper-prep.yml` - builds on `windows-2022-arm` runner
-- **Wheel Build**: `03-flavor-pipeline.yml` - builds on `windows-2022-arm` runner
+- **Helper Build**: `helper-prep.yml` - builds on `windows-2022-arm` runner
+- **Wheel Build**: `flavor-pipeline.yml` - builds on `windows-2022-arm` runner
 - **Release**: `release.yml` - includes `win_arm64.whl` in releases
 
 To trigger a build:

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -8,10 +8,14 @@ The Flavorpack CI/CD system consists of multiple independent GitHub Actions work
 
 ```mermaid
 graph LR
-    A[01-helper-prep] --> B[Helper Artifacts]
-    B --> C[02-pretaster]
-    B --> D[03-flavor]
-    B --> E[04-taster]
+    A[01 helper-prep] --> B[Helper Artifacts]
+    B --> C[02a pretaster-pipeline]
+    B --> D[03 flavor-pipeline]
+    D --> E[04 taster-pipeline]
+
+    P[Pull request] --> Q[02b pr-pretaster]
+    Q --> R[Helpers built from PR source]
+    R --> F
 
     C --> F[Cross-Language Tests]
     D --> G[Python API Tests]
@@ -25,17 +29,28 @@ graph LR
     I -->|No| K[❌ Fix Issues]
 
     style A fill:#e3f2fd
+    style P fill:#e3f2fd
     style C fill:#fff3e0
     style D fill:#fff3e0
     style E fill:#fff3e0
+    style Q fill:#fff3e0
     style J fill:#e8f5e9
     style K fill:#ffebee
 ```
 
+Stage 02 exists twice on purpose. 02a runs after Helper Prep on main and
+develop, consuming its published artifacts across the full platform matrix.
+02b runs on every pull request, where those artifacts do not exist, so it
+builds helpers from the PR's own source instead. 02a is the broad post-merge
+sweep; 02b is the gate that stops a broken launcher reaching main.
+
 ### Design Principles
 
-1. **Manual Triggering**: All workflows use `workflow_dispatch` for manual control
-2. **Script Delegation**: Complex logic lives in `.github/scripts/`, not in workflow YAML
+1. **Explicit Triggering**: The numbered pipeline stages are `workflow_dispatch`
+   plus `workflow_run` chaining; the PR-facing workflows (02b, 05, 08) add
+   `pull_request`
+2. **Script Delegation**: Complex logic lives in `ci/`, not in workflow YAML —
+   inline `run:` blocks are capped at three lines
 3. **Artifact Sharing**: Workflows share build artifacts rather than calling each other
 4. **Platform Coverage**: Multi-platform support (Linux, macOS, Windows*)
 
@@ -45,7 +60,7 @@ graph LR
 
 ### 01 - Helper Prep
 
-**File**: `.github/workflows/01-helper-prep.yml`
+**File**: `.github/workflows/helper-prep.yml`
 
 **Purpose**: Build and validate Go/Rust helpers for all platforms
 
@@ -65,11 +80,11 @@ graph LR
 ]
 ```
 
-### 02 - Pretaster Pipeline
+### 02a - Pretaster Validation
 
-**File**: `.github/workflows/02-pretaster-pipeline.yml`
+**File**: `.github/workflows/pretaster-pipeline.yml`
 
-**Purpose**: Validate cross-language compatibility
+**Purpose**: Validate cross-language compatibility after merge, on the full platform matrix
 
 **Key Features**:
 - Tests all builder/launcher combinations (4 total)
@@ -83,9 +98,31 @@ graph LR
 - Rust builder + Go launcher
 - Rust builder + Rust launcher
 
+### 02b - Pretaster Validation (PR)
+
+**File**: `.github/workflows/pr-pretaster.yml`
+
+**Purpose**: Run the same suite on a pull request, before anything merges
+
+**Why it is separate**: 02a downloads the helper artifacts published by 01, and
+01 is `workflow_dispatch`-only, so a PR branch has nothing to download. This
+workflow calls `ci/pr-pretaster.sh`, which runs `./build.sh` to compile helpers
+from the PR's own tree, `uv sync` to install the `flavor` CLI the security
+suite needs, and then the same `make -C tests/pretaster test` target.
+
+**Key Features**:
+- Matrix over ubuntu-24.04 and macos-14, `fail-fast: false` — a hardcoded
+  platform path is invisible on one and fatal on the other
+- `PRETASTER_STRICT=1`, which turns a skipped check into a failure: every
+  prerequisite exists in CI, so a skip is a setup bug rather than "not
+  applicable here"
+- Uploads `tests/pretaster/logs/` on failure
+
+**Scope**: Linux and macOS only. 02a keeps the wider matrix, FreeBSD included.
+
 ### 03 - Flavor Pipeline
 
-**File**: `.github/workflows/03-flavor-pipeline.yml`
+**File**: `.github/workflows/flavor-pipeline.yml`
 
 **Purpose**: Test the main Flavorpack Python package
 
@@ -97,7 +134,7 @@ graph LR
 
 ### 04 - Taster Pipeline
 
-**File**: `.github/workflows/04-taster-pipeline.yml`
+**File**: `.github/workflows/taster-pipeline.yml`
 
 **Purpose**: Test the Taster comprehensive test package
 
@@ -109,7 +146,7 @@ graph LR
 
 ### 05 - Code Quality
 
-**File**: `.github/workflows/05-code-quality.yml`
+**File**: `.github/workflows/code-quality.yml`
 
 **Purpose**: Enforce code quality standards
 
@@ -121,7 +158,7 @@ graph LR
 
 ### 06 - Security Scan
 
-**File**: `.github/workflows/06-security-scan.yml`
+**File**: `.github/workflows/security-scan.yml`
 
 **Purpose**: Security vulnerability scanning
 
@@ -133,7 +170,7 @@ graph LR
 
 ### 07 - Dependency Audit
 
-**File**: `.github/workflows/07-dependency-audit.yml`
+**File**: `.github/workflows/dependency-audit.yml`
 
 **Purpose**: Audit and validate dependencies
 
@@ -145,7 +182,7 @@ graph LR
 
 ### 08 - License Compliance
 
-**File**: `.github/workflows/08-license-compliance.yml`
+**File**: `.github/workflows/license-compliance.yml`
 
 **Purpose**: Ensure license compatibility
 
@@ -155,51 +192,65 @@ graph LR
 - NOTICE file accuracy
 - Third-party attribution
 
+### 09 - Release Pipeline
+
+**File**: `.github/workflows/release.yml`
+
+**Purpose**: Build and publish a release
+
+### Unnumbered workflows
+
+- `build-go.yml`, `build-rust.yml`, `build-tastesh.yml` — reusable
+  (`workflow_call`), invoked by the stages above rather than triggered directly
+- `compatibility-check.yml` — daily container compatibility sweep
+- `exp-freebsd.yml` — experimental FreeBSD builds, dispatch only
+
 ## Supporting Scripts
+
+Workflow logic lives in `ci/`, which holds considerably more than the entries
+below; these are the ones the numbered stages call directly.
 
 ### Build Scripts
 
-**`.github/scripts/build-platform-helpers.sh`**
-- Builds Go and Rust helpers for a specific platform
-- Handles cross-compilation settings
-- Creates platform-specific binaries
+**`ci/build-go-helpers.sh`**, **`ci/build-rust-helpers.sh`**
+- Build the Go and Rust helpers for a target platform
+- Handle cross-compilation settings, including the musl static build on Linux
 
-**`.github/scripts/build-pretaster.sh`**
+**`ci/build-pretaster.sh`**
 - Builds pretaster PSP package
 - Creates test manifests dynamically
 - Packages test scripts and configurations
 
-**`.github/scripts/build-crosslang-tests.sh`**
-- Creates test packages for cross-language validation
-- Generates manifests for all builder/launcher combinations
-- Uses PSPF/2025 nested format
-
 ### Test Scripts
 
-**`.github/scripts/run-tests.sh`**
+**`ci/run-tests.sh`**
 - Main test runner for Python tests
 - Handles pytest configuration
 - Collects test metadata and coverage
 
-**`.github/scripts/run-pretaster-tests.sh`**
+**`ci/run-pretaster-tests.sh`**
 - Executes pretaster test suite
 - Detects PSP execution context (FLAVOR_WORKENV)
 - Provides honest validation output
 
-**`.github/scripts/test-metadata.py`**
+**`ci/pr-pretaster.sh`**
+- The entry point for 02b: builds helpers from the PR's own source, installs
+  the `flavor` CLI, then runs the pretaster make target
+- Exists because a PR has no Helper Prep artifacts to download
+
+**`ci/test-metadata.py`**
 - Collects and formats test metadata
 - Handles Windows UTF-8 encoding
 - Generates JSON reports for CI
 
 ### Utility Scripts
 
-**`.github/scripts/validate-psp-package.sh`**
-- Validates PSP package structure
-- Checks signature verification
-- Tests basic execution
+**`ci/quality-checks.sh`**
+- The 05 gate: blocking checks (format, lint, types, clippy) exit non-zero;
+  advisory ones report without failing the build
 
-**`.github/scripts/get-version.sh`**
-- Extracts version from pyproject.toml
+**`ci/get-version.sh`**
+- Reads the version from the `VERSION` file, the single source of truth
 - Used for artifact naming
 
 ## Artifact Management
@@ -219,7 +270,7 @@ flavor-helpers-{version}-all
 ```yaml
 - uses: dawidd6/action-download-artifact@v6
   with:
-    workflow: 01-helper-prep.yml
+    workflow: helper-prep.yml
     name: flavor-helpers-0.3.0-linux_amd64
     path: ./helpers
     workflow_conclusion: success
@@ -248,10 +299,10 @@ brew install act  # macOS
 curl https://raw.githubusercontent.com/nektos/act/master/install.sh | bash
 
 # Run a specific workflow
-act -W .github/workflows/03-flavor-pipeline.yml
+act -W .github/workflows/flavor-pipeline.yml
 
 # Run with specific event
-act workflow_dispatch -W .github/workflows/01-helper-prep.yml
+act workflow_dispatch -W .github/workflows/helper-prep.yml
 
 # Run with secrets
 act -s GITHUB_TOKEN=$GITHUB_TOKEN
@@ -292,10 +343,12 @@ Currently disabled due to UTF-8 encoding issues with emoji characters in test sc
 ## Best Practices
 
 ### Workflow Design
-1. Keep workflow YAML minimal
-2. Delegate to scripts in `.github/scripts/`
-3. Use matrix strategies for multi-platform builds
-4. Always use manual triggers (`workflow_dispatch`)
+1. Keep workflow YAML minimal — inline `run:` blocks are capped at three lines
+2. Delegate to scripts in `ci/`
+3. Use matrix strategies for multi-platform builds, with `fail-fast: false` so
+   one platform's failure does not hide another's
+4. Anything that must gate a merge needs a `pull_request` trigger; a
+   `workflow_run` filtered to main can never fire on a PR branch
 
 ### Error Handling
 1. Provide clear error messages
@@ -348,7 +401,8 @@ Currently disabled due to UTF-8 encoding issues with emoji characters in test sc
 
 4. **Test locally before CI**:
    ```bash
-   .github/scripts/build-platform-helpers.sh darwin_arm64
+   ./build.sh                    # helpers for the host platform
+   make -C tests/pretaster test  # the suite 02a and 02b both run
    ```
 
 ## Future Improvements

--- a/docs/development/helpers.md
+++ b/docs/development/helpers.md
@@ -299,7 +299,7 @@ The helper build is automated in CI:
 
 {% raw %}
 ```yaml
-# .github/workflows/01-helper-prep.yml
+# .github/workflows/helper-prep.yml
 name: Build Helpers
 
 on:

--- a/tests/pretaster/KNOWN_ISSUES.md
+++ b/tests/pretaster/KNOWN_ISSUES.md
@@ -23,14 +23,14 @@
 **Rust launcher status:** ❌ Not supported on Windows — use Go launcher
 
 **What stays in CI:**
-- `01-helper-prep.yml` still builds Rust launcher binaries for Windows (preserved for
+- `helper-prep.yml` still builds Rust launcher binaries for Windows (preserved for
   future use and cross-platform wheel distribution). They are built but never used as
   the launcher on Windows.
 - `build-pretaster.sh` selects Go launcher when `$PLATFORM` contains "windows".
-- `04-taster-pipeline.yml` build step selects Go launcher on `windows_*` platforms.
-- `build-pretaster` job in `02-pretaster-pipeline.yml` selects Go launcher for the
+- `taster-pipeline.yml` (04) build step selects Go launcher on `windows_*` platforms.
+- `build-pretaster` job in `pretaster-pipeline.yml` (02a) selects Go launcher for the
   Go-builder combo on Windows.
-- `test-crosslang` in `02-pretaster-pipeline.yml` runs with `continue-on-error: true`
+- `test-crosslang` in `pretaster-pipeline.yml` (02a) runs with `continue-on-error: true`
   on all Windows platforms because Rust-launcher-embedded packages cannot run on Windows.
 
 **Future fix path:** Investigate the Rust launcher Windows crash to determine whether


### PR DESCRIPTION
The PR pretaster workflow was numbered `06`, which collided with Security Scanning and made it read as an unrelated late stage. It is not — it runs the same suite as `02`, at a different point, against differently-sourced helpers.

## The split

| | Trigger | Helpers | Platforms |
|---|---|---|---|
| **02a** 🔬 Pretaster Validation | after 01 Helper Prep, main/develop | downloaded from 01's artifacts | full matrix, FreeBSD included |
| **02b** 🧪 Pretaster Validation (PR) | every pull request | built from the PR's own source | Linux + macOS |

02b exists because 02a structurally cannot serve a PR: it consumes artifacts published by 01 Helper Prep, which is `workflow_dispatch`-only, and its `workflow_run` trigger is gated to main/develop. Neither replaces the other — 02a is the broad post-merge sweep, 02b is the gate that stops a broken launcher reaching main. Both files now carry a header comment saying so.

Nothing references a workflow by display name except the `workflow_run` chain, which names 01 and 03 only, so the rename touches no trigger. Scripts address workflows by filename, which is unchanged.

Numbering is now unique: 01, 02a, 02b, 03–09.

## The docs needed more than a renumber

Three things were wrong independent of this change, all in the files I was already editing:

- **Every workflow was documented with an `NN-` filename prefix that has never existed.** The number lives in the `name:` field; the files are `helper-prep.yml`, `pretaster-pipeline.yml` and so on. So `gh run list --workflow=02-pretaster-pipeline.yml` — the form the docs implied — was never going to work.
- **`.github/scripts/` does not exist.** Of the eight scripts documented under it, five live in `ci/` and three are gone entirely. Corrected the five, dropped the three, added `ci/pr-pretaster.sh` and `ci/quality-checks.sh`.
- **The workflow list stopped at 08**, missing 09 Release, the three reusable `workflow_call` builds, and the two scheduled ones.

Two Design Principles were also stale: "All workflows use `workflow_dispatch` for manual control" stopped being true when PR triggers arrived, and the script-delegation rule pointed at the wrong directory.

## One thing the table now records

The CI table in `CLAUDE.md` states which workflows a pull request actually reaches. It is three: 02b, 05, 08 — and none of them runs `cargo test`, `go test` or `pytest`. That is [#38](https://github.com/provide-io/flavorpack/issues/38); documenting it here means the next person reading `CLAUDE.md` knows to verify test changes locally rather than trusting a green PR.

## Checks

`mkdocs build` succeeds. The 540 `--strict` warnings are pre-existing relative-link issues in `cookbook/` and `tutorials/`; none touch the files changed here. Both workflow YAMLs parse.