### PR TITLE
Make Go's verify command check what it says it checked

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli.go
@@ -230,7 +230,18 @@ func showMetadata(exePath string, logger *slog.Logger) {
 	}
 }
 
-// verifyBundle performs integrity verification on the bundle
+// verifyBundle performs integrity verification on the bundle.
+//
+// Every line this prints is a check that was actually made. It did not used to
+// be: "Index checksum valid" was printed whenever the index parsed, "Metadata
+// checksum valid" whenever it gunzipped, and the Ed25519 seal was not consulted
+// at all. The checks that were real -- the magic bookends and the slot digests
+// -- are unkeyed, so anyone able to rewrite the file could recompute them. The
+// signature is the only check that needs the signing key, and it was the one
+// being skipped.
+//
+// The set below matches the Rust verifier's conjunction, so the same package
+// gets the same verdict from either implementation.
 func verifyBundle(exePath string, logger *slog.Logger) {
 	// Prepare bundle path (may extract from PE resources on Windows)
 	bundlePath, cleanup, err := prepareBundlePath(exePath, logger)
@@ -257,35 +268,53 @@ func verifyBundle(exePath string, logger *slog.Logger) {
 
 	errors := []string{}
 
-	_, err = verifyMagicTrailerFn(reader)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Magic verification failed: %v", err))
-	} else {
-		fmt.Println("✓ Magic sequence valid")
+	// record one result. A check that could not run is a failure: "could not
+	// tell" is not the same as "fine", and reporting it as a pass is how this
+	// command came to vouch for things it had never looked at.
+	record := func(label string, ok bool, err error) {
+		switch {
+		case err != nil:
+			errors = append(errors, fmt.Sprintf("%s verification failed: %v", label, err))
+		case !ok:
+			errors = append(errors, fmt.Sprintf("%s verification failed", label))
+		default:
+			fmt.Printf("✓ %s valid\n", label)
+		}
 	}
 
-	_, err = reader.ReadIndex()
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Index verification failed: %v", err))
-	} else {
-		fmt.Println("✓ Index checksum valid")
-	}
+	magicOK, err := verifyMagicTrailerFn(reader)
+	record("Magic sequence", magicOK, err)
+
+	indexOK, err := reader.VerifyIndexChecksum()
+	record("Index checksum", indexOK, err)
+
+	metadataOK, err := reader.VerifyMetadataChecksum()
+	record("Metadata checksum", metadataOK, err)
+
+	sizeOK, err := reader.VerifyPackageSize()
+	record("Package size", sizeOK, err)
+
+	// An absent seal counts as a failure, not an exemption -- an unsigned
+	// package is exactly what an attacker would hand you.
+	sealOK, err := reader.VerifyIntegritySeal()
+	record("Integrity seal", sealOK, err)
 
 	metadata, err := reader.ReadMetadata()
 	if err != nil {
-		errors = append(errors, fmt.Sprintf("Metadata verification failed: %v", err))
+		errors = append(errors, fmt.Sprintf("Metadata read failed: %v", err))
 	} else {
-		fmt.Println("✓ Metadata checksum valid")
-
 		for i, slot := range metadata.Slots {
-			_, err := reader.ReadSlot(i)
-			if err != nil {
+			if _, err := reader.ReadSlot(i); err != nil {
 				errors = append(errors, fmt.Sprintf("Slot %d (%s) read failed: %v", i, slot.ID, err))
 			} else {
 				fmt.Printf("✓ Slot %d (%s) checksum valid\n", i, slot.ID)
 			}
 		}
 	}
+
+	// Both are fail-closed and no-ops on a package without attestation.
+	record("Attestation SBOM digest", true, reader.VerifyAttestationSbomDigest())
+	record("Attestation policy hash", true, reader.VerifyAttestationPolicyHash())
 
 	if len(errors) == 0 {
 		fmt.Println("\n✓ Bundle verification passed")

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_test.go
@@ -175,10 +175,10 @@ func TestVerifyBundleDirectSuccess(t *testing.T) {
 	t.Parallel()
 
 	logger := logging.NewNullLogger()
-	bundle := buildSingleSlotBundleForTests(t, []byte("verify file content"), []byte("verify file content"), nil, SlotMetadata{
-		ID:     "verify-slot",
-		Target: "{workenv}/bin/app.txt",
-	}, 0, false)
+	// A sealed bundle, not the shared helper's: that one leaves the signature
+	// and index checksum unset, which the *BadSeal execution tests rely on, and
+	// which a real verifier is supposed to reject.
+	bundle, _, _, _ := buildSealedBundle(t)
 
 	output := captureStdout(t, func() {
 		verifyBundle(bundle, logger)

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_contract_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_contract_test.go
@@ -1,0 +1,286 @@
+package format_2025
+
+// What `verify` actually verifies.
+//
+// The command printed "✓ Index checksum valid", "✓ Metadata checksum valid"
+// and "✓ Bundle verification passed" for a package whose Ed25519 seal was
+// never checked, whose index Adler-32 was never computed, and whose metadata
+// SHA-256 was never compared. Only the magic bookends and the slot checksums
+// were real, and both of those are unkeyed -- anyone who can rewrite the file
+// can recompute them.
+//
+// Each test below tampers with exactly one thing and asserts the command says
+// no. They fail against the implementation that shipped before this file.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"hash/adler32"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+// A committed seed, so a failure is reproducible rather than a new key each run.
+var verifyTestSeed = bytes.Repeat([]byte{0x2a}, ed25519.SeedSize)
+
+// sealIndex fills in the two fields a real builder computes last: the Ed25519
+// signature over the raw metadata JSON, and the Adler-32 over the index itself.
+//
+// The checksum has to be computed over the packed bytes with its own field
+// zeroed, which is the order the builder uses -- get it backwards and the
+// index never validates.
+func sealIndex(index *PSPFIndex, metaJSON []byte, priv ed25519.PrivateKey) {
+	copy(index.IntegritySignature[:], ed25519.Sign(priv, metaJSON))
+	copy(index.PublicKey[:], priv.Public().(ed25519.PublicKey))
+	index.IndexChecksum = 0
+	packed := index.Pack()
+	binary.LittleEndian.PutUint32(packed[4:8], 0)
+	index.IndexChecksum = adler32.Checksum(packed)
+}
+
+// buildSealedBundle writes a bundle that passes every check a verifier can make.
+// Each test then breaks one thing.
+func buildSealedBundle(t *testing.T) (path string, index *PSPFIndex, metaJSON []byte, priv ed25519.PrivateKey) {
+	t.Helper()
+
+	priv = ed25519.NewKeyFromSeed(verifyTestSeed)
+
+	slotData := []byte("sealed payload")
+	slotHash := sha256.Sum256(slotData)
+	desc := SlotDescriptor{
+		ID:           1,
+		NameHash:     HashName("payload"),
+		Offset:       0,
+		Size:         uint64(len(slotData)),
+		OriginalSize: uint64(len(slotData)),
+		Checksum:     binary.LittleEndian.Uint64(slotHash[:8]),
+		Purpose:      PurposeData,
+		Lifecycle:    LifecycleRuntime,
+	}
+
+	metadata := Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "sealed", Version: "1.0.0"},
+		Slots:         []SlotMetadata{{ID: "payload", Target: "{workenv}/payload", Slot: 0}},
+		Execution:     &ExecutionInfo{PrimarySlot: 0, Command: "/bin/true"},
+		Build:         &BuildInfo{Tool: "verify-test"},
+	}
+	var err error
+	metaJSON, err = json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("Marshal(metadata): %v", err)
+	}
+	gzMeta := gzipData(t, metaJSON)
+
+	slotTableOffset := uint64(len(slotData))
+	metadataOffset := slotTableOffset + SlotDescriptorSize
+
+	index = &PSPFIndex{
+		FormatVersion:   PSPFVersion,
+		PackageSize:     uint64(len(slotData) + SlotDescriptorSize + len(gzMeta) + MagicTrailerSize),
+		MetadataOffset:  metadataOffset,
+		MetadataSize:    uint64(len(gzMeta)),
+		SlotTableOffset: slotTableOffset,
+		SlotTableSize:   SlotDescriptorSize,
+		SlotCount:       1,
+	}
+	metaHash := sha256.Sum256(gzMeta)
+	copy(index.MetadataChecksum[:], metaHash[:])
+	sealIndex(index, metaJSON, priv)
+
+	path = testBundlePath(t, ".psp")
+	body := append(append(append([]byte{}, slotData...), desc.Pack()...), gzMeta...)
+	if err := os.WriteFile(path, append(body, packTrailer(index)...), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path, index, metaJSON, priv
+}
+
+// packTrailer wraps an index in the 📦 / 🪄 bookends.
+func packTrailer(index *PSPFIndex) []byte {
+	trailer := make([]byte, MagicTrailerSize)
+	copy(trailer[0:4], PackageEmojiBytes)
+	copy(trailer[4:4+IndexSize], index.Pack())
+	copy(trailer[4+IndexSize:], MagicWandEmojiBytes)
+	return trailer
+}
+
+// rewriteTrailer swaps in a modified index, leaving the rest of the file alone.
+func rewriteTrailer(t *testing.T, path string, index *PSPFIndex) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	copy(data[len(data)-MagicTrailerSize:], packTrailer(index))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// runVerify returns the exit code verifyBundle asked for, and what it printed.
+func runVerify(t *testing.T, path string) (code int, output string) {
+	t.Helper()
+
+	oldExit := osExitFn
+	code = 0
+	osExitFn = func(c int) { code = c; panic(launcherExitCode{code: c}) }
+	t.Cleanup(func() { osExitFn = oldExit })
+
+	output = captureStdout(t, func() {
+		defer func() { _ = recover() }()
+		verifyBundle(path, logging.NewNullLogger())
+	})
+	return code, output
+}
+
+func TestVerifyAcceptsASealedBundle(t *testing.T) {
+	path, _, _, _ := buildSealedBundle(t)
+
+	code, output := runVerify(t, path)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; output:\n%s", code, output)
+	}
+	if !strings.Contains(output, "Bundle verification passed") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+// The one #35 was filed for: an attacker who rewrites a package recomputes
+// every unkeyed checksum trivially. The signature is the only check that needs
+// the signing key, and it was the only one not being made.
+func TestVerifyRejectsATamperedSignature(t *testing.T) {
+	path, index, metaJSON, priv := buildSealedBundle(t)
+
+	index.IntegritySignature[0] ^= 0xFF
+	// Re-seal everything *except* the signature, so the only thing wrong with
+	// this package is the one thing that used to go unchecked.
+	copy(index.PublicKey[:], priv.Public().(ed25519.PublicKey))
+	index.IndexChecksum = 0
+	packed := index.Pack()
+	binary.LittleEndian.PutUint32(packed[4:8], 0)
+	index.IndexChecksum = adler32.Checksum(packed)
+	rewriteTrailer(t, path, index)
+	_ = metaJSON
+
+	code, output := runVerify(t, path)
+	if code != 1 {
+		t.Fatalf("a package with a broken seal verified: exit = %d; output:\n%s", code, output)
+	}
+}
+
+// Parity with Rust, whose verify_integrity_seal returns false when the
+// signature field is all zeros, making the package invalid overall.
+func TestVerifyRejectsAnUnsignedBundle(t *testing.T) {
+	path, index, metaJSON, priv := buildSealedBundle(t)
+
+	index.IntegritySignature = [512]byte{}
+	sealIndexKeepingSignature(index, metaJSON, priv)
+	rewriteTrailer(t, path, index)
+
+	code, output := runVerify(t, path)
+	if code != 1 {
+		t.Fatalf("an unsigned package verified: exit = %d; output:\n%s", code, output)
+	}
+}
+
+// sealIndexKeepingSignature recomputes only the index checksum, leaving
+// whatever the caller put in the signature field.
+func sealIndexKeepingSignature(index *PSPFIndex, _ []byte, priv ed25519.PrivateKey) {
+	copy(index.PublicKey[:], priv.Public().(ed25519.PublicKey))
+	index.IndexChecksum = 0
+	packed := index.Pack()
+	binary.LittleEndian.PutUint32(packed[4:8], 0)
+	index.IndexChecksum = adler32.Checksum(packed)
+}
+
+// "✓ Index checksum valid" was printed whenever the index merely parsed.
+func TestVerifyRejectsACorruptIndexChecksum(t *testing.T) {
+	path, index, _, _ := buildSealedBundle(t)
+
+	index.IndexChecksum ^= 0xFFFF
+	rewriteTrailer(t, path, index)
+
+	code, output := runVerify(t, path)
+	if code != 1 {
+		t.Fatalf("a package with a bad index checksum verified: exit = %d; output:\n%s", code, output)
+	}
+}
+
+// "✓ Metadata checksum valid" was printed whenever the metadata gunzipped and
+// parsed, without ever comparing it to index.MetadataChecksum.
+func TestVerifyRejectsTamperedMetadata(t *testing.T) {
+	path, index, _, priv := buildSealedBundle(t)
+
+	// Swap in different metadata, re-sign it and fix the index checksum, but
+	// leave MetadataChecksum describing the original bytes.
+	altered := Metadata{
+		Format:        "PSPF/2025",
+		FormatVersion: "2025.0",
+		Package:       PackageInfo{Name: "altered", Version: "9.9.9"},
+		Slots:         []SlotMetadata{{ID: "payload", Target: "{workenv}/payload", Slot: 0}},
+		Execution:     &ExecutionInfo{PrimarySlot: 0, Command: "/bin/false"},
+		Build:         &BuildInfo{Tool: "verify-test"},
+	}
+	alteredJSON, err := json.Marshal(altered)
+	if err != nil {
+		t.Fatalf("Marshal(altered): %v", err)
+	}
+	alteredGz := gzipData(t, alteredJSON)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	head := data[:index.MetadataOffset]
+	rebuilt := append(append([]byte{}, head...), alteredGz...)
+
+	index.MetadataSize = uint64(len(alteredGz))
+	index.PackageSize = uint64(len(rebuilt) + MagicTrailerSize)
+	sealIndex(index, alteredJSON, priv)
+
+	if err := os.WriteFile(path, append(rebuilt, packTrailer(index)...), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	code, output := runVerify(t, path)
+	if code != 1 {
+		t.Fatalf("a package whose metadata does not match its recorded digest verified: exit = %d; output:\n%s", code, output)
+	}
+}
+
+// The committed format-compatibility fixtures are real packages, signed by the
+// Go, Rust and Python builders. If the tightened checks rejected any of them,
+// the new conjunction would be wrong rather than the old one being too loose.
+func TestVerifyAcceptsEveryCommittedFixture(t *testing.T) {
+	_, names, dir := loadPinned(t)
+
+	for _, name := range names {
+		code, output := runVerify(t, filepath.Join(dir, name))
+		if code != 0 {
+			t.Errorf("%s no longer verifies: exit = %d; output:\n%s", name, code, output)
+			continue
+		}
+		for _, want := range []string{
+			"Magic sequence valid",
+			"Index checksum valid",
+			"Metadata checksum valid",
+			"Package size valid",
+			"Integrity seal valid",
+			"Bundle verification passed",
+		} {
+			if !strings.Contains(output, want) {
+				t.Errorf("%s: output missing %q:\n%s", name, want, output)
+			}
+		}
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/reader_verify.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_verify.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash/adler32"
 	"io"
 )
 
@@ -39,6 +40,75 @@ func (r *Reader) VerifyMagicTrailer() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// VerifyIndexChecksum recomputes the Adler-32 over the index block and compares
+// it to the value the index carries.
+//
+// ReadIndex deliberately does not do this -- it validates only the format
+// version -- so anything that wants the guarantee has to ask for it. The
+// checksum covers the index with its own four bytes zeroed, which is the order
+// the builder writes it in.
+func (r *Reader) VerifyIndexChecksum() (bool, error) {
+	index, err := r.ReadIndex()
+	if err != nil {
+		return false, err
+	}
+
+	// Compare against the bytes on disk rather than a re-Pack of the parsed
+	// struct: a round trip that dropped a field would otherwise agree with
+	// itself and report a valid index.
+	raw, err := r.ReadMagicTrailer()
+	if err != nil {
+		return false, err
+	}
+	if len(raw) != IndexSize {
+		return false, fmt.Errorf("invalid index size: %d", len(raw))
+	}
+
+	zeroed := make([]byte, IndexSize)
+	copy(zeroed, raw)
+	binary.LittleEndian.PutUint32(zeroed[4:8], 0)
+
+	return adler32.Checksum(zeroed) == index.IndexChecksum, nil
+}
+
+// VerifyMetadataChecksum compares the SHA-256 of the metadata archive against
+// the digest recorded in the index.
+//
+// ReadMetadata gunzips and decodes but never checks this, so metadata could be
+// replaced wholesale and still parse.
+func (r *Reader) VerifyMetadataChecksum() (bool, error) {
+	index, err := r.ReadIndex()
+	if err != nil {
+		return false, err
+	}
+
+	archive, err := r.ReadMetadataArchive()
+	if err != nil {
+		return false, err
+	}
+
+	digest := sha256.Sum256(archive)
+	return bytes.Equal(digest[:], index.MetadataChecksum[:]), nil
+}
+
+// VerifyPackageSize checks that the index agrees with the file it describes.
+func (r *Reader) VerifyPackageSize() (bool, error) {
+	index, err := r.ReadIndex()
+	if err != nil {
+		return false, err
+	}
+	if err := r.Open(); err != nil {
+		return false, err
+	}
+
+	info, err := r.file.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	return index.PackageSize == uint64(info.Size()), nil
 }
 
 // VerifyAllChecksums verifies all slot checksums

--- a/src/flavor-rs/tests/verify_rejects_tampering.rs
+++ b/src/flavor-rs/tests/verify_rejects_tampering.rs
@@ -1,0 +1,104 @@
+//! The verification contract, asserted against the committed fixtures.
+//!
+//! This mirrors the Go tests in `launcher_cli_verify_test.go`. Both
+//! implementations must give the same verdict on the same bytes, and the
+//! interesting case is a package where every unkeyed checksum still adds up and
+//! only the Ed25519 seal is wrong -- which is exactly what an attacker who can
+//! rewrite the file produces, and what Go's `verify` used to accept.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use adler2::Adler32;
+use flavor::psp::format_2025;
+use serde_json::Value;
+use tempfile::tempdir;
+
+/// Byte layout of the trailer, from constants.rs: 📦 + 8192-byte index + 🪄.
+const MAGIC_TRAILER_SIZE: usize = 8200;
+const HEADER_SIZE: usize = 8192;
+/// Offsets within the index block.
+const CHECKSUM_RANGE: std::ops::Range<usize> = 4..8;
+const SIGNATURE_START: usize = 128;
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/format_compat/v1")
+}
+
+/// Names of the committed fixtures, read from the file that pins them.
+fn fixture_names() -> Vec<String> {
+    let raw = fs::read_to_string(fixture_dir().join("expected.json")).expect("read expected.json");
+    let expected: Value = serde_json::from_str(&raw).expect("parse expected.json");
+    let mut names: Vec<String> = expected["fixtures"]
+        .as_object()
+        .expect("fixtures object")
+        .keys()
+        .cloned()
+        .collect();
+    names.sort();
+    names
+}
+
+/// Copy a fixture, corrupt one byte of its Ed25519 signature, and repair the
+/// index checksum so that every *unkeyed* check still passes.
+fn tamper_with_the_seal(source: &Path, destination: &Path) {
+    let mut bytes = fs::read(source).expect("read fixture");
+    let trailer_start = bytes.len() - MAGIC_TRAILER_SIZE;
+    let index_start = trailer_start + 4;
+
+    bytes[index_start + SIGNATURE_START] ^= 0xFF;
+
+    // Recompute the Adler-32 over the index with its own checksum field zeroed,
+    // the order the builder writes it in. Without this the package would fail
+    // on the index instead, and the test would prove nothing about the seal.
+    let mut index = bytes[index_start..index_start + HEADER_SIZE].to_vec();
+    index[CHECKSUM_RANGE].copy_from_slice(&[0u8; 4]);
+    let mut adler = Adler32::new();
+    adler.write_slice(&index);
+    let checksum = adler.checksum();
+    bytes[index_start + CHECKSUM_RANGE.start..index_start + CHECKSUM_RANGE.end]
+        .copy_from_slice(&checksum.to_le_bytes());
+
+    fs::write(destination, bytes).expect("write tampered fixture");
+}
+
+#[test]
+fn a_tampered_seal_is_rejected_on_every_fixture() {
+    let temp = tempdir().expect("tempdir");
+
+    for name in fixture_names() {
+        let tampered = temp.path().join(&name);
+        tamper_with_the_seal(&fixture_dir().join(&name), &tampered);
+
+        let result = format_2025::verify(&tampered)
+            .unwrap_or_else(|e| panic!("{name}: verification errored: {e}"));
+
+        assert!(
+            !result.signature_valid,
+            "{name}: a corrupted Ed25519 signature was reported as valid"
+        );
+        assert!(
+            !result.valid,
+            "{name}: a package with a broken seal was reported as verified, even though \
+             every unkeyed checksum in it still adds up"
+        );
+        assert!(
+            result.checksums_valid,
+            "{name}: the tampering was supposed to leave the checksums intact, so this \
+             test is no longer isolating the signature"
+        );
+    }
+}
+
+#[test]
+fn an_untouched_fixture_still_verifies() {
+    // The control: whatever the test above rejects, it rejects for the reason
+    // stated and not because the fixtures stopped verifying.
+    for name in fixture_names() {
+        let result = format_2025::verify(&fixture_dir().join(&name))
+            .unwrap_or_else(|e| panic!("{name}: verification errored: {e}"));
+
+        assert!(result.valid, "{name} no longer verifies");
+        assert!(result.signature_valid, "{name}: seal no longer verifies");
+    }
+}

--- a/tests/security/test_verify_rejects_tampering.py
+++ b/tests/security/test_verify_rejects_tampering.py
@@ -1,0 +1,115 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""The verification contract, asserted against the committed fixtures.
+
+Mirrors `src/flavor-rs/tests/verify_rejects_tampering.rs` and the Go tests in
+`launcher_cli_verify_test.go`. All three implementations must give the same
+verdict on the same bytes.
+
+The interesting case is a package where every unkeyed checksum still adds up
+and only the Ed25519 seal is wrong — which is exactly what someone who can
+rewrite the file produces, and what Go's `verify` used to accept.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import zlib
+
+import pytest
+
+from flavor.verification import FlavorVerifier
+
+pytestmark = [
+    pytest.mark.security,
+    pytest.mark.adversarial,
+    pytest.mark.cross_language,
+    pytest.mark.ci,
+]
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "format_compat" / "v1"
+
+# Trailer layout, from the format constants: 📦 + 8192-byte index + 🪄.
+MAGIC_TRAILER_SIZE = 8200
+HEADER_SIZE = 8192
+CHECKSUM_OFFSET = 4
+SIGNATURE_OFFSET = 128
+
+
+def _fixture_names() -> list[str]:
+    """Names of the committed fixtures, from the file that pins them."""
+    expected = json.loads((FIXTURE_DIR / "expected.json").read_text(encoding="utf-8"))
+    return sorted(expected["fixtures"])
+
+
+def _tamper_with_the_seal(source: Path, destination: Path) -> None:
+    """Flip a signature bit, then repair the index checksum.
+
+    Repairing the checksum is the point: without it the package would fail on
+    the index instead, and the test would prove nothing about the seal.
+    """
+    data = bytearray(source.read_bytes())
+    index_start = len(data) - MAGIC_TRAILER_SIZE + 4
+
+    data[index_start + SIGNATURE_OFFSET] ^= 0xFF
+
+    index = bytearray(data[index_start : index_start + HEADER_SIZE])
+    index[CHECKSUM_OFFSET : CHECKSUM_OFFSET + 4] = b"\x00\x00\x00\x00"
+    checksum = zlib.adler32(bytes(index)) & 0xFFFFFFFF
+    data[index_start + CHECKSUM_OFFSET : index_start + CHECKSUM_OFFSET + 4] = checksum.to_bytes(4, "little")
+
+    destination.write_bytes(bytes(data))
+
+
+@pytest.fixture(params=_fixture_names())
+def fixture_name(request: pytest.FixtureRequest) -> str:
+    """Each committed fixture in turn."""
+    return str(request.param)
+
+
+def test_an_untouched_fixture_still_verifies(fixture_name: str) -> None:
+    """The control: the fixtures verify before anything is done to them."""
+    result = FlavorVerifier.verify_package(FIXTURE_DIR / fixture_name)
+
+    assert result["valid"], f"{fixture_name} no longer verifies"
+    assert result["signature_valid"], f"{fixture_name}: seal no longer verifies"
+
+
+def test_a_tampered_seal_is_rejected(fixture_name: str, tmp_path: Path) -> None:
+    """A broken signature is refused even though every checksum still matches."""
+    tampered = tmp_path / fixture_name
+    _tamper_with_the_seal(FIXTURE_DIR / fixture_name, tampered)
+
+    result = FlavorVerifier.verify_package(tampered)
+
+    assert not result["signature_valid"], (
+        f"{fixture_name}: a corrupted Ed25519 signature was reported as valid"
+    )
+    assert not result["valid"], (
+        f"{fixture_name}: a package with a broken seal was reported as verified, "
+        "even though every unkeyed checksum in it still adds up"
+    )
+    assert result["checksums_valid"], (
+        f"{fixture_name}: the tampering was supposed to leave the checksums intact, "
+        "so this test is no longer isolating the signature"
+    )
+
+
+def test_a_truncated_package_is_rejected(fixture_name: str, tmp_path: Path) -> None:
+    """Losing the trailer is refused rather than read as an unsigned package."""
+    truncated = tmp_path / fixture_name
+    shutil.copyfile(FIXTURE_DIR / fixture_name, truncated)
+    data = truncated.read_bytes()
+    truncated.write_bytes(data[: -MAGIC_TRAILER_SIZE // 2])
+
+    with pytest.raises(Exception):  # noqa: B017 - any refusal is acceptable, silence is not
+        result = FlavorVerifier.verify_package(truncated)
+        assert not result["valid"], f"{fixture_name}: a truncated package verified"
+
+
+# 🌶️📦🔚


### PR DESCRIPTION
Closes #35.

## What the command was reporting

`FLAVOR_LAUNCHER_CLI=1 ./package.psp verify` printed `✓ Bundle verification passed` on a package whose Ed25519 seal was never consulted. Tracing it found two more claims with nothing behind them:

| Printed | Reality |
|---|---|
| `✓ Magic sequence valid` | real |
| `✓ Index checksum valid` | **never computed** — `ReadIndex` validates the format version, not the Adler-32 |
| `✓ Metadata checksum valid` | **never compared** — `ReadMetadata` gunzips and decodes, and never looks at `MetadataChecksum` |
| `✓ Slot N checksum valid` | real |
| the signature | **never consulted** |

Both real checks are unkeyed. Anyone able to rewrite the file recomputes them without effort. The signature is the only check that needs the signing key, and it was the one being skipped — while `VerifyIntegritySeal` existed the whole time and was called on the run path. A package that would be refused at launch was pronounced sound by the command whose job is to say so.

The red test run says it plainly. Against a package with a **deliberately corrupted index checksum**:

```
✓ Magic sequence valid
✓ Index checksum valid      ← the byte was flipped
✓ Metadata checksum valid
✓ Slot 0 (payload) checksum valid

✓ Bundle verification passed
```

## The fix

Three new `Reader` methods — `VerifyIndexChecksum`, `VerifyMetadataChecksum`, `VerifyPackageSize` — folded into `verifyBundle` with the seal and both attestation digests. That is the same conjunction the Rust verifier uses, so both give the same verdict on the same bytes.

Two decisions worth naming:

- **A check that errors is a failure.** "Could not tell" is not "fine", and reporting it as a pass is how this command came to vouch for things it had never looked at.
- **An absent seal fails**, matching Rust, whose `verify_integrity_seal` returns false on an all-zero signature. An unsigned package is exactly what an attacker would hand you.

`VerifyIndexChecksum` compares against the bytes on disk rather than a re-`Pack` of the parsed struct — a round trip that dropped a field would otherwise agree with itself and report a valid index.

## Parity, asserted rather than assumed

The contract is now tested in all three languages against the committed fixtures. Each tampers with the seal alone and **repairs the index checksum**, so every unkeyed check still adds up and only the signature is wrong — precisely what someone who can rewrite the file produces, and precisely what Go used to accept.

| | |
|---|---|
| Go | `launcher_cli_verify_contract_test.go` — 6 tests |
| Rust | `tests/verify_rejects_tampering.rs` — 2 tests |
| Python | `tests/security/test_verify_rejects_tampering.py` — 9 tests |

Python and Rust already refused; Go was the outlier. All three fixtures still verify with every new check reporting valid — that's the evidence the tightened conjunction is correct rather than merely stricter.

## One existing test was asserting the bug

`TestVerifyBundleDirectSuccess` claimed verification passes on a bundle with no signature and no index checksum. That only held while nothing looked. It now builds a sealed bundle. The shared helper is deliberately left unsigned, because the `*BadSeal` execution tests depend on that.

## Verified

`ci/pr-tests.sh all` locally, exit 0: Rust ✅, Go ✅ (with `-race`, coverage 95.7%), Python ✅ — 2759 passed at 99.47%. `golangci-lint` still reports exactly 20 issues, so this adds none. `go vet`, `gofmt`, `cargo fmt`, `clippy`, `ruff` and `mypy` all clean.

## Filed along the way

[#41](https://github.com/provide-io/flavorpack/issues/41) — `captureStdout` swaps the process-global `os.Stdout` while parallel tests run, so the framework's `--- FAIL:` lines vanish. A failing test in this package can report no failure at all; finding the one this PR broke took a bisect.