### PR TITLE
Stop a stray os.Exit from hiding which test failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ coverage.json
 coverage.xml
 src/flavor-go/coverage_*.out
 src/flavor-go/coverage.out
+src/flavor-go/coverage.txt
 tests/pretaster/logs/
 # Written by ci/run-tests.sh, ci/pr-tests.sh and ci/quality-checks.sh, which
 # are worth running locally -- see the 03b notes in docs/development/ci-cd.md.

--- a/src/flavor-go/pkg/psp/format_2025/coverage_remaining_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/coverage_remaining_test.go
@@ -32,7 +32,7 @@ func TestShowBundleInfoBadMagicTrailer(t *testing.T) {
 	// It will exit if ReadIndex fails due to a version mismatch from the bad trailer.
 	// So we call it and verify it either exits or doesn't — we just want line 73-75 hit.
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo(bundlePath, logger)
+		showBundleInfo(io.Discard, bundlePath, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showBundleInfo")

--- a/src/flavor-go/pkg/psp/format_2025/launcher.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher.go
@@ -100,7 +100,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 		logger.Debug("💻 Running in CLI mode")
 		if len(args) < 1 {
 			// Default to info command when no args provided
-			showBundleInfo(exePath, logger)
+			showBundleInfo(os.Stdout, exePath, logger)
 			return
 		}
 
@@ -110,18 +110,18 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 		case "version":
 			fmt.Println(LauncherVersion)
 		case "info":
-			showBundleInfo(exePath, logger)
+			showBundleInfo(os.Stdout, exePath, logger)
 		case "verify":
-			verifyBundle(exePath, logger)
+			verifyBundle(os.Stdout, exePath, logger)
 		case "metadata":
-			showMetadata(exePath, logger)
+			showMetadata(os.Stdout, exePath, logger)
 		case "extract":
 			if len(args) < 3 {
 				fmt.Fprintf(os.Stderr, "Error: extract requires slot index and output directory\n")
 				fmt.Fprintf(os.Stderr, "Usage: extract <slot_index> <output_dir>\n")
 				osExitFn(ExitInvalidArgs)
 			}
-			extractSlot(exePath, args[1], args[2], logger)
+			extractSlot(os.Stdout, exePath, args[1], args[2], logger)
 		case "run":
 			// Run with remaining arguments
 			if err := execBundle(exePath, args[1:], userCwd, logger); err != nil {

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli.go
@@ -3,6 +3,7 @@ package format_2025
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -15,7 +16,7 @@ var readerCloseFn = (*Reader).Close
 var verifyMagicTrailerFn = (*Reader).VerifyMagicTrailer
 
 // showBundleInfo displays bundle information in human-readable format
-func showBundleInfo(exePath string, logger *slog.Logger) {
+func showBundleInfo(out io.Writer, exePath string, logger *slog.Logger) {
 	// Prepare bundle path (may extract from PE resources on Windows)
 	bundlePath, cleanup, err := prepareBundlePath(exePath, logger)
 	if err != nil {
@@ -77,27 +78,27 @@ func showBundleInfo(exePath string, logger *slog.Logger) {
 		verifyStatus = "✗"
 	}
 
-	fmt.Printf("%s v%s [PSPF/%s]\n",
+	fmt.Fprintf(out, "%s v%s [PSPF/%s]\n",
 		metadata.Package.Name,
 		metadata.Package.Version,
 		strings.TrimPrefix(metadata.Format, "PSPF/"))
 
-	fmt.Printf("Built with: %s | Launcher: %s | Size: %.1fMB\n",
+	fmt.Fprintf(out, "Built with: %s | Launcher: %s | Size: %.1fMB\n",
 		builderType,
 		launcherType,
 		float64(index.PackageSize)/(1024*1024))
 
-	fmt.Printf("Slots: %d (%s) | Verified: %s\n",
+	fmt.Fprintf(out, "Slots: %d (%s) | Verified: %s\n",
 		len(metadata.Slots),
 		codecInfo,
 		verifyStatus)
 
-	fmt.Printf("\nRun with: %s\n", metadata.Execution.Command)
-	fmt.Printf("CLI Mode: Use 'run' to execute, 'extract' to unpack\n")
+	fmt.Fprintf(out, "\nRun with: %s\n", metadata.Execution.Command)
+	fmt.Fprintf(out, "CLI Mode: Use 'run' to execute, 'extract' to unpack\n")
 }
 
 // extractSlot extracts a specific slot to an output directory
-func extractSlot(exePath, slotStr, outputDir string, logger *slog.Logger) {
+func extractSlot(out io.Writer, exePath, slotStr, outputDir string, logger *slog.Logger) {
 	slotIndex, err := strconv.Atoi(slotStr)
 	if err != nil {
 		logger.Error("Invalid slot index", "slot", slotStr)
@@ -143,7 +144,7 @@ func extractSlot(exePath, slotStr, outputDir string, logger *slog.Logger) {
 		osExitFn(1)
 	}
 
-	fmt.Printf("Extracted slot %d (%s) to %s\n", slotIndex, slot.ID, outputPath)
+	fmt.Fprintf(out, "Extracted slot %d (%s) to %s\n", slotIndex, slot.ID, outputPath)
 }
 
 // detectLauncherType attempts to determine the launcher implementation language
@@ -193,7 +194,7 @@ func detectLauncherType(exePath string) string {
 }
 
 // showMetadata outputs the raw JSON metadata
-func showMetadata(exePath string, logger *slog.Logger) {
+func showMetadata(out io.Writer, exePath string, logger *slog.Logger) {
 	// Prepare bundle path (may extract from PE resources on Windows)
 	bundlePath, cleanup, err := prepareBundlePath(exePath, logger)
 	if err != nil {
@@ -222,7 +223,7 @@ func showMetadata(exePath string, logger *slog.Logger) {
 	}
 
 	// Output raw JSON metadata
-	encoder := json.NewEncoder(os.Stdout)
+	encoder := json.NewEncoder(out)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(metadata); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to encode metadata: %v\n", err)
@@ -242,7 +243,7 @@ func showMetadata(exePath string, logger *slog.Logger) {
 //
 // The set below matches the Rust verifier's conjunction, so the same package
 // gets the same verdict from either implementation.
-func verifyBundle(exePath string, logger *slog.Logger) {
+func verifyBundle(out io.Writer, exePath string, logger *slog.Logger) {
 	// Prepare bundle path (may extract from PE resources on Windows)
 	bundlePath, cleanup, err := prepareBundlePath(exePath, logger)
 	if err != nil {
@@ -264,7 +265,7 @@ func verifyBundle(exePath string, logger *slog.Logger) {
 		}
 	}()
 
-	fmt.Println("Verifying bundle integrity...")
+	fmt.Fprintln(out, "Verifying bundle integrity...")
 
 	errors := []string{}
 
@@ -278,7 +279,7 @@ func verifyBundle(exePath string, logger *slog.Logger) {
 		case !ok:
 			errors = append(errors, fmt.Sprintf("%s verification failed", label))
 		default:
-			fmt.Printf("✓ %s valid\n", label)
+			fmt.Fprintf(out, "✓ %s valid\n", label)
 		}
 	}
 
@@ -307,7 +308,7 @@ func verifyBundle(exePath string, logger *slog.Logger) {
 			if _, err := reader.ReadSlot(i); err != nil {
 				errors = append(errors, fmt.Sprintf("Slot %d (%s) read failed: %v", i, slot.ID, err))
 			} else {
-				fmt.Printf("✓ Slot %d (%s) checksum valid\n", i, slot.ID)
+				fmt.Fprintf(out, "✓ Slot %d (%s) checksum valid\n", i, slot.ID)
 			}
 		}
 	}
@@ -317,11 +318,11 @@ func verifyBundle(exePath string, logger *slog.Logger) {
 	record("Attestation policy hash", true, reader.VerifyAttestationPolicyHash())
 
 	if len(errors) == 0 {
-		fmt.Println("\n✓ Bundle verification passed")
+		fmt.Fprintln(out, "\n✓ Bundle verification passed")
 	} else {
-		fmt.Println("\n✗ Bundle verification failed:")
+		fmt.Fprintln(out, "\n✗ Bundle verification failed:")
 		for _, err := range errors {
-			fmt.Printf("  - %s\n", err)
+			fmt.Fprintf(out, "  - %s\n", err)
 		}
 		osExitFn(1)
 	}

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_additional_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_additional_test.go
@@ -40,20 +40,22 @@ func TestLauncherCLIAdditionalHelper(t *testing.T) {
 	}
 
 	logger := logging.NewNullLogger()
+	// This process is standing in for the launcher. Its stdout is what the
+	// parent reads back with CombinedOutput, so these write to the real one.
 	switch os.Getenv(EnvLauncherMode) {
 	case "launch":
 		LaunchWithLogLevel(bundle, args, "", "")
 	case "show-metadata":
-		showMetadata(bundle, logger)
+		showMetadata(os.Stdout, bundle, logger)
 	case "verify":
-		verifyBundle(bundle, logger)
+		verifyBundle(os.Stdout, bundle, logger)
 	case "show-info":
-		showBundleInfo(bundle, logger)
+		showBundleInfo(os.Stdout, bundle, logger)
 	case "extract":
 		if len(args) < 2 {
 			t.Fatal("missing extract arguments")
 		}
-		extractSlot(bundle, args[0], args[1], logger)
+		extractSlot(os.Stdout, bundle, args[0], args[1], logger)
 	default:
 		t.Fatalf("unsupported launcher CLI helper mode %q", os.Getenv(EnvLauncherMode))
 	}

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_capture_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_capture_test.go
@@ -1,0 +1,133 @@
+package format_2025
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+	"testing"
+)
+
+// TestCaptureCLIOutputIsolatesConcurrentCaptures pins the property that made
+// captureCLIOutput replace the old os.Stdout-swapping helper.
+//
+// The interleave below is the one a save/restore of a process global cannot
+// survive: A opens its capture first and closes it first, while B's capture is
+// still open. Restoring "the previous os.Stdout" then hands B's writes to the
+// real terminal, and B reads back an empty string. Under the old helper this
+// test fails with outB == "" and a stray BBB on stdout.
+func TestCaptureCLIOutputIsolatesConcurrentCaptures(t *testing.T) {
+	t.Parallel()
+
+	bOpened := make(chan struct{})
+	aClosed := make(chan struct{})
+
+	var outA, outB string
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		outA = captureCLIOutput(func(out io.Writer) {
+			fmt.Fprintln(out, "AAA")
+			<-bOpened // hold A's window open until B's has started
+		})
+		close(aClosed)
+	}()
+
+	go func() {
+		defer wg.Done()
+		outB = captureCLIOutput(func(out io.Writer) {
+			close(bOpened)
+			<-aClosed // write only after A has finished and "restored"
+			fmt.Fprintln(out, "BBB")
+		})
+	}()
+
+	wg.Wait()
+
+	for _, tc := range []struct {
+		name, got, want, unwanted string
+	}{
+		{"A", outA, "AAA", "BBB"},
+		{"B", outB, "BBB", "AAA"},
+	} {
+		if !strings.Contains(tc.got, tc.want) {
+			t.Errorf("capture %s lost its own output: got %q, want it to contain %q", tc.name, tc.got, tc.want)
+		}
+		if strings.Contains(tc.got, tc.unwanted) {
+			t.Errorf("capture %s stole the other capture's output: got %q", tc.name, tc.got)
+		}
+	}
+}
+
+// TestCLIFunctionsWriteOnlyToTheWriterTheyAreGiven is the other half: the CLI
+// functions must not reach for os.Stdout on their own, or threading a writer
+// through them buys nothing.
+func TestCLIFunctionsWriteOnlyToTheWriterTheyAreGiven(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.NewNullLogger()
+	bundle := buildSingleSlotBundleForTests(t, []byte("cli file content"), []byte("cli file content"), nil, SlotMetadata{
+		ID:     "cli-slot",
+		Target: "{workenv}/bin/app.txt",
+	}, 0, false)
+
+	for _, tc := range []struct {
+		name string
+		call func(io.Writer)
+	}{
+		{"info", func(w io.Writer) { showBundleInfo(w, bundle, logger) }},
+		{"verify", func(w io.Writer) { verifyBundle(w, bundle, logger) }},
+		{"metadata", func(w io.Writer) { showMetadata(w, bundle, logger) }},
+		{"extract", func(w io.Writer) { extractSlot(w, bundle, "0", t.TempDir(), logger) }},
+	} {
+		got := captureCLIOutput(func(w io.Writer) {
+			// Some of these exit on this fixture -- it is unsigned, so verify
+			// fails. They write their output before doing so, and the exit is
+			// not what is under test here.
+			defer func() { _ = recover() }()
+			tc.call(w)
+		})
+		if got == "" {
+			t.Errorf("%s wrote nothing to the writer it was given", tc.name)
+		}
+	}
+}
+
+// TestLauncherCLIHasNoProcessGlobalWrites is the guard that makes the two tests
+// above meaningful. They only detect the fault when the writer resolves
+// os.Stdout lazily -- which is exactly what fmt.Printf does. So rather than try
+// to catch that dynamically, refuse it at the source: launcher_cli.go must route
+// everything it prints through the writer it was handed.
+//
+// The one permitted os.Stdout is the child process's, in spawnBundle. That has
+// to be a real file descriptor and cannot be a buffer.
+func TestLauncherCLIHasNoProcessGlobalWrites(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("launcher_cli.go")
+	if err != nil {
+		t.Fatalf("read launcher_cli.go: %v", err)
+	}
+
+	const allowed = "cmd.Stdout = os.Stdout"
+	banned := []string{"fmt.Print(", "fmt.Printf(", "fmt.Println("}
+
+	for i, line := range strings.Split(string(src), "\n") {
+		code, _, _ := strings.Cut(line, "//")
+		for _, b := range banned {
+			if strings.Contains(code, b) {
+				t.Errorf("launcher_cli.go:%d writes to process stdout via %s -- write to the out writer instead:\n\t%s",
+					i+1, b, strings.TrimSpace(line))
+			}
+		}
+		if strings.Contains(code, "os.Stdout") && !strings.Contains(code, allowed) {
+			t.Errorf("launcher_cli.go:%d reaches for os.Stdout -- write to the out writer instead:\n\t%s",
+				i+1, strings.TrimSpace(line))
+		}
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_errors_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_errors_test.go
@@ -3,6 +3,7 @@ package format_2025
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -189,7 +190,7 @@ func TestShowBundleInfoReadIndexErrorPath(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo(bundlePath, logger)
+		showBundleInfo(io.Discard, bundlePath, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -206,7 +207,7 @@ func TestShowBundleInfoReadMetadataErrorPath(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo(bundlePath, logger)
+		showBundleInfo(io.Discard, bundlePath, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -216,8 +217,8 @@ func TestShowBundleInfoReadMetadataErrorPath(t *testing.T) {
 	}
 }
 
-// TestShowBundleInfoVerifyStatusFail verifies that showBundleInfo displays
-// "Verified: ✗" when the magic trailer is corrupted.
+// TestShowBundleInfoVerifyStatusFail covers showBundleInfo against a bundle
+// whose magic trailer has been zeroed: it exits 1 without printing a report.
 func TestShowBundleInfoVerifyStatusFail(t *testing.T) {
 	// Build a valid bundle first, then corrupt it so VerifyMagicTrailer fails.
 	bundle := buildSingleSlotBundleForTests(t,
@@ -228,24 +229,31 @@ func TestShowBundleInfoVerifyStatusFail(t *testing.T) {
 	corruptMagicTrailerBytes(t, bundle)
 	logger := logging.NewNullLogger()
 
-	// The bundle now has a corrupt magic trailer. showBundleInfo should still
-	// display info but set verifyStatus = "✗". However, ReadIndex/ReadMetadata
-	// may also fail since the trailer is zeroed — in that case it will just call
-	// osExitFn(1) on index read failure. Either way, no panic.
-	output := captureStdout(t, func() {
+	// Zeroing the trailer takes the index with it, so showBundleInfo never
+	// reaches the report -- it exits 1 on the index read. The "Verified: ✗"
+	// display is covered by TestShowBundleInfoVerifyMagicTrailerFails, which
+	// fails the trailer check while leaving the index readable.
+	//
+	// The assertion here used to read `if output != "" && ...`, which passed
+	// whenever nothing was captured -- and nothing ever is.
+	var exitCode int
+	output := captureCLIOutput(func(out io.Writer) {
 		old := osExitFn
 		osExitFn = func(code int) {
+			exitCode = code
 			panic(launcherExitCode{code: code})
 		}
 		defer func() {
 			osExitFn = old
 			recover() // swallow exit panic
 		}()
-		showBundleInfo(bundle, logger)
+		showBundleInfo(out, bundle, logger)
 	})
-	// If it printed output, it should have included "✗".
-	if output != "" && !strings.Contains(output, "✗") {
-		t.Fatalf("expected '✗' in showBundleInfo output for corrupted bundle, got: %q", output)
+	if output != "" {
+		t.Errorf("expected no report from a bundle whose index cannot be read, got %q", output)
+	}
+	if exitCode != 1 {
+		t.Errorf("exit code = %d, want 1", exitCode)
 	}
 }
 
@@ -257,7 +265,7 @@ func TestExtractSlotExtractionFailure(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot(bundlePath, "0", outputDir, logger)
+		extractSlot(io.Discard, bundlePath, "0", outputDir, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -274,7 +282,7 @@ func TestShowMetadataReadMetadataErrorPath(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata(bundlePath, logger)
+		showMetadata(io.Discard, bundlePath, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -295,7 +303,7 @@ func TestVerifyBundleSlotReadFailure(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	// verifyBundle calls osExitFn(1) when errors are found; stub it.
-	output := captureStdout(t, func() {
+	output := captureCLIOutput(func(out io.Writer) {
 		old := osExitFn
 		osExitFn = func(code int) {
 			panic(launcherExitCode{code: code})
@@ -304,7 +312,7 @@ func TestVerifyBundleSlotReadFailure(t *testing.T) {
 			osExitFn = old
 			recover()
 		}()
-		verifyBundle(bundlePath, logger)
+		verifyBundle(out, bundlePath, logger)
 	})
 
 	if !strings.Contains(output, "read failed") && !strings.Contains(output, "verification failed") {
@@ -321,7 +329,7 @@ func TestShowBundleInfoWithCleanupAndReaderFailure(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo("/fake/exe", logging.NewNullLogger())
+		showBundleInfo(io.Discard, "/fake/exe", logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -338,7 +346,7 @@ func TestExtractSlotWithCleanupAndReaderFailure(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot("/fake/exe", "0", t.TempDir(), logging.NewNullLogger())
+		extractSlot(io.Discard, "/fake/exe", "0", t.TempDir(), logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -355,7 +363,7 @@ func TestShowMetadataWithCleanupAndReaderFailure(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata("/fake/exe", logging.NewNullLogger())
+		showMetadata(io.Discard, "/fake/exe", logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")
@@ -371,7 +379,7 @@ func TestVerifyBundleWithCleanupAndReaderFailure(t *testing.T) {
 	restore := stubPEResourceWithInvalidBundle(t)
 	defer restore()
 
-	output := captureStdout(t, func() {
+	output := captureCLIOutput(func(out io.Writer) {
 		old := osExitFn
 		osExitFn = func(code int) {
 			panic(launcherExitCode{code: code})
@@ -380,7 +388,7 @@ func TestVerifyBundleWithCleanupAndReaderFailure(t *testing.T) {
 			osExitFn = old
 			recover()
 		}()
-		verifyBundle("/fake/exe", logging.NewNullLogger())
+		verifyBundle(out, "/fake/exe", logging.NewNullLogger())
 	})
 	// verifyBundle may print verification failure info or exit with code 1.
 	_ = output

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_extra_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_extra_test.go
@@ -1,6 +1,7 @@
 package format_2025
 
 import (
+	"io"
 	"testing"
 
 	"github.com/provide-io/flavor/go/flavor/pkg/logging"
@@ -19,7 +20,7 @@ func TestShowMetadataSuccess(t *testing.T) {
 		t.Fatalf("unexpected osExitFn(%d) called during showMetadata success path", code)
 	}
 
-	showMetadata(bundle, logger)
+	showMetadata(io.Discard, bundle, logger)
 }
 
 // TestShowBundleInfoSuccess covers the happy path of showBundleInfo with a valid bundle.
@@ -33,7 +34,7 @@ func TestShowBundleInfoSuccess(t *testing.T) {
 		t.Fatalf("unexpected osExitFn(%d) called during showBundleInfo success path", code)
 	}
 
-	showBundleInfo(bundle, logger)
+	showBundleInfo(io.Discard, bundle, logger)
 }
 
 // TestLaunchWithLogLevelMetadataCommand exercises the "metadata" CLI command path.

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_reader_error_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_reader_error_test.go
@@ -1,6 +1,7 @@
 package format_2025
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func TestShowMetadataNewReaderError(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata(nonExistent, logger)
+		showMetadata(io.Discard, nonExistent, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showMetadata")
@@ -70,7 +71,7 @@ func TestShowMetadataReadMetadataError(t *testing.T) {
 
 	logger := logging.NewNullLogger()
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata(bundle, logger)
+		showMetadata(io.Discard, bundle, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showMetadata")
@@ -87,7 +88,7 @@ func TestShowBundleInfoNewReaderError(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo(nonExistent, logger)
+		showBundleInfo(io.Discard, nonExistent, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showBundleInfo")
@@ -104,7 +105,7 @@ func TestExtractSlotNewReaderError(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot(nonExistent, "0", t.TempDir(), logger)
+		extractSlot(io.Discard, nonExistent, "0", t.TempDir(), logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in extractSlot")
@@ -121,7 +122,7 @@ func TestVerifyBundleNewReaderError(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		verifyBundle(nonExistent, logger)
+		verifyBundle(io.Discard, nonExistent, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in verifyBundle")

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_readerclose_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_readerclose_test.go
@@ -2,6 +2,7 @@ package format_2025
 
 import (
 	"errors"
+	"io"
 	"os"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestShowBundleInfoReaderCloseLogs(t *testing.T) {
 	// showBundleInfo always calls the deferred reader close, so the error path is exercised
 	func() {
 		defer func() { _ = recover() }()
-		showBundleInfo(bundle, logging.NewNullLogger())
+		showBundleInfo(io.Discard, bundle, logging.NewNullLogger())
 	}()
 
 	_ = exitCalled
@@ -75,7 +76,7 @@ func TestShowBundleInfoVerifyMagicTrailerFailsViaNonPSPFFile(t *testing.T) {
 
 	func() {
 		defer func() { _ = recover() }()
-		showBundleInfo(notBundle, logging.NewNullLogger())
+		showBundleInfo(io.Discard, notBundle, logging.NewNullLogger())
 	}()
 
 	if !exitCalled {
@@ -106,7 +107,7 @@ func TestExtractSlotReaderCloseLogs(t *testing.T) {
 
 	func() {
 		defer func() { _ = recover() }()
-		extractSlot(bundle, "0", outputDir, logging.NewNullLogger())
+		extractSlot(io.Discard, bundle, "0", outputDir, logging.NewNullLogger())
 	}()
 
 	_ = exitCalled
@@ -134,7 +135,7 @@ func TestShowMetadataReaderCloseLogs(t *testing.T) {
 
 	func() {
 		defer func() { _ = recover() }()
-		showMetadata(bundle, logging.NewNullLogger())
+		showMetadata(io.Discard, bundle, logging.NewNullLogger())
 	}()
 
 	_ = exitCalled
@@ -162,7 +163,7 @@ func TestVerifyBundleReaderCloseLogs(t *testing.T) {
 
 	func() {
 		defer func() { _ = recover() }()
-		verifyBundle(bundle, logging.NewNullLogger())
+		verifyBundle(io.Discard, bundle, logging.NewNullLogger())
 	}()
 
 	_ = exitCalled

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_test.go
@@ -86,36 +86,23 @@ func TestDetectLauncherTypeSpecialCases(t *testing.T) {
 	}
 }
 
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe() error = %v", err)
-	}
-	os.Stdout = w
-	defer func() {
-		os.Stdout = oldStdout
-	}()
-
-	outC := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close(writer) error = %v", err)
-	}
-	out := <-outC
-	if err := r.Close(); err != nil {
-		t.Fatalf("Close(reader) error = %v", err)
-	}
-	return out
+// captureCLIOutput runs fn with a private buffer and returns what fn wrote to
+// it.
+//
+// It replaces a helper that swapped the process-global os.Stdout for a pipe.
+// That helper restored the previous value on the way out, which is only correct
+// when capture windows nest. They do not: TestVerifyBundleDirectSuccess calls
+// t.Parallel(), so its window overlaps the other parallel tests in this package,
+// and an overlapping-but-not-nested pair restores a stale os.Stdout. The loser
+// captured an empty string while its output went to the terminal -- which turned
+// "assert the output contains X" into a flake, and the one assertion written as
+// "if output != \"\" && ..." into a check that passed on having captured nothing.
+//
+// Nothing here is process-global, so concurrent captures cannot interact.
+func captureCLIOutput(fn func(out io.Writer)) string {
+	var buf bytes.Buffer
+	fn(&buf)
+	return buf.String()
 }
 
 func TestCLIMetadataAndVerificationPaths(t *testing.T) {
@@ -125,23 +112,23 @@ func TestCLIMetadataAndVerificationPaths(t *testing.T) {
 		Target: "{workenv}/bin/app.txt",
 	}, 0, false)
 
-	infoOutput := captureStdout(t, func() {
-		showBundleInfo(bundle, logger)
+	infoOutput := captureCLIOutput(func(out io.Writer) {
+		showBundleInfo(out, bundle, logger)
 	})
 	if !strings.Contains(infoOutput, "demo v1.0.0") || !strings.Contains(infoOutput, "Slots: 1 (none) | Verified: ✓") {
 		t.Fatalf("showBundleInfo() output = %q", infoOutput)
 	}
 
-	metadataOutput := captureStdout(t, func() {
-		showMetadata(bundle, logger)
+	metadataOutput := captureCLIOutput(func(out io.Writer) {
+		showMetadata(out, bundle, logger)
 	})
 	if !strings.Contains(metadataOutput, "\"name\": \"demo\"") {
 		t.Fatalf("showMetadata() output = %q", metadataOutput)
 	}
 
 	extractDest := filepath.Join(t.TempDir(), "extract")
-	extractOutput := captureStdout(t, func() {
-		extractSlot(bundle, "0", extractDest, logger)
+	extractOutput := captureCLIOutput(func(out io.Writer) {
+		extractSlot(out, bundle, "0", extractDest, logger)
 	})
 	if !strings.Contains(extractOutput, "Extracted slot 0 (cli-slot) to") {
 		t.Fatalf("extractSlot() output = %q", extractOutput)
@@ -159,8 +146,8 @@ func TestShowBundleInfoReportsCodecInfo(t *testing.T) {
 		Operations: "gzip",
 	}, 0, false)
 
-	output := captureStdout(t, func() {
-		showBundleInfo(bundle, logger)
+	output := captureCLIOutput(func(out io.Writer) {
+		showBundleInfo(out, bundle, logger)
 	})
 
 	if !strings.Contains(output, "demo v1.0.0") {
@@ -180,8 +167,8 @@ func TestVerifyBundleDirectSuccess(t *testing.T) {
 	// which a real verifier is supposed to reject.
 	bundle, _, _, _ := buildSealedBundle(t)
 
-	output := captureStdout(t, func() {
-		verifyBundle(bundle, logger)
+	output := captureCLIOutput(func(out io.Writer) {
+		verifyBundle(out, bundle, logger)
 	})
 	if !strings.Contains(output, "✓ Magic sequence valid") || !strings.Contains(output, "✓ Bundle verification passed") {
 		t.Fatalf("verifyBundle() output = %q", output)
@@ -204,35 +191,35 @@ func TestCLIHelpersExitOnInvalidInputs(t *testing.T) {
 		{
 			name: "show info invalid bundle",
 			fn: func() {
-				showBundleInfo(filepath.Join(t.TempDir(), "missing.psp"), logger)
+				showBundleInfo(io.Discard, filepath.Join(t.TempDir(), "missing.psp"), logger)
 			},
 			wantCode: 1,
 		},
 		{
 			name: "show metadata invalid bundle",
 			fn: func() {
-				showMetadata(filepath.Join(t.TempDir(), "missing.psp"), logger)
+				showMetadata(io.Discard, filepath.Join(t.TempDir(), "missing.psp"), logger)
 			},
 			wantCode: 1,
 		},
 		{
 			name: "verify invalid bundle",
 			fn: func() {
-				verifyBundle(filepath.Join(t.TempDir(), "missing.psp"), logger)
+				verifyBundle(io.Discard, filepath.Join(t.TempDir(), "missing.psp"), logger)
 			},
 			wantCode: 1,
 		},
 		{
 			name: "extract invalid index",
 			fn: func() {
-				extractSlot(bundle, "nope", t.TempDir(), logger)
+				extractSlot(io.Discard, bundle, "nope", t.TempDir(), logger)
 			},
 			wantCode: 1,
 		},
 		{
 			name: "extract out of range",
 			fn: func() {
-				extractSlot(bundle, "9", t.TempDir(), logger)
+				extractSlot(io.Discard, bundle, "9", t.TempDir(), logger)
 			},
 			wantCode: 1,
 		},
@@ -283,7 +270,7 @@ func TestVerifyBundleDirectFailure(t *testing.T) {
 		osExitFn = oldExitFn
 	})
 
-	output := captureStdout(t, func() {
+	output := captureCLIOutput(func(out io.Writer) {
 		defer func() {
 			r := recover()
 			if r == nil {
@@ -297,7 +284,7 @@ func TestVerifyBundleDirectFailure(t *testing.T) {
 				t.Fatalf("exit code = %d, want 1", got.code)
 			}
 		}()
-		verifyBundle(bundle, logger)
+		verifyBundle(out, bundle, logger)
 	})
 
 	if !strings.Contains(output, "Bundle verification failed") {

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_contract_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_contract_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"hash/adler32"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,9 +137,9 @@ func runVerify(t *testing.T, path string) (code int, output string) {
 	osExitFn = func(c int) { code = c; panic(launcherExitCode{code: c}) }
 	t.Cleanup(func() { osExitFn = oldExit })
 
-	output = captureStdout(t, func() {
+	output = captureCLIOutput(func(out io.Writer) {
 		defer func() { _ = recover() }()
-		verifyBundle(path, logging.NewNullLogger())
+		verifyBundle(out, path, logging.NewNullLogger())
 	})
 	return code, output
 }

--- a/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_cli_verify_test.go
@@ -2,6 +2,8 @@ package format_2025
 
 import (
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/provide-io/flavor/go/flavor/pkg/logging"
@@ -28,11 +30,18 @@ func TestShowBundleInfoVerifyMagicTrailerFails(t *testing.T) {
 	}
 
 	// showBundleInfo should complete normally (✗ is just displayed, not fatal)
-	func() {
+	output := captureCLIOutput(func(out io.Writer) {
 		defer func() { _ = recover() }()
-		showBundleInfo(bundle, logging.NewNullLogger())
-	}()
+		showBundleInfo(out, bundle, logging.NewNullLogger())
+	})
 
-	// exitCalled should be false — VerifyMagicTrailer failure is non-fatal (just changes display)
-	_ = exitCalled
+	// This used to end at "_ = exitCalled", so the branch it names was set up
+	// and then never checked -- showBundleInfo could have printed anything, or
+	// nothing. Asserting on the report is what makes it a test.
+	if exitCalled {
+		t.Error("a failed magic trailer is non-fatal to info; showBundleInfo must not exit")
+	}
+	if !strings.Contains(output, "Verified: ✗") {
+		t.Errorf("expected the report to mark the bundle unverified, got %q", output)
+	}
 }

--- a/src/flavor-go/pkg/psp/format_2025/launcher_missingpaths_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_missingpaths_test.go
@@ -1,6 +1,8 @@
 package format_2025
 
 import (
+	"errors"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -200,9 +202,18 @@ func TestLaunchWithLogLevelRunCommandPostExitFn(t *testing.T) {
 	_ = capturedCode
 }
 
-// TestShowMetadataEncodeFailure covers the encoder.Encode failure path
-// at lines 224-227 in showMetadata. By replacing os.Stdout with a closed pipe,
-// json.NewEncoder(os.Stdout).Encode(...) will fail.
+// failingWriter fails every write. It is how showMetadata's encoder.Encode
+// error path is reached now that showMetadata writes to the writer it is given
+// rather than to os.Stdout -- the test used to point the process-global
+// os.Stdout at a closed pipe, which broke any concurrent test that was writing.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestShowMetadataEncodeFailure covers the encoder.Encode failure path in
+// showMetadata.
 func TestShowMetadataEncodeFailure(t *testing.T) {
 	bundle := buildLauncherTestBundle(t)
 	logger := logging.NewNullLogger()
@@ -215,23 +226,9 @@ func TestShowMetadataEncodeFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { osExitFn = oldExit })
 
-	oldStdout := os.Stdout
-	// Create a pipe and close the write-end so writes to os.Stdout fail.
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe(): %v", err)
-	}
-	os.Stdout = w
-	if err := w.Close(); err != nil {
-		t.Fatalf("w.Close(): %v", err)
-	}
-	r.Close() //nolint:errcheck
-
-	defer func() { os.Stdout = oldStdout }()
-
 	func() {
 		defer func() { _ = recover() }()
-		showMetadata(bundle, logger)
+		showMetadata(failingWriter{}, bundle, logger)
 	}()
 
 	if capturedCode != 1 {
@@ -247,7 +244,7 @@ func TestShowMetadataNewReaderFailure(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata(bundle, logger)
+		showMetadata(io.Discard, bundle, logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic")

--- a/src/flavor-go/pkg/psp/format_2025/main_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/main_test.go
@@ -1,0 +1,50 @@
+package format_2025
+
+import (
+	"os"
+	"testing"
+)
+
+// helperSubprocessMarkers are the environment variables the tests in this
+// package use to mark their own re-executions of the test binary. A process
+// carrying one of these is standing in for the real launcher, and its exit code
+// is what the parent is measuring -- so it keeps the real os.Exit.
+//
+// A new re-exec harness that forgets to list its marker here will see its
+// expected exit code arrive as 2 (Go's code for an unrecovered panic).
+var helperSubprocessMarkers = []string{
+	EnvLauncherHelper,
+	EnvLauncherSubprocess,
+	EnvLauncherSpawnExitHelper,
+}
+
+func isHelperSubprocess() bool {
+	for _, name := range helperSubprocessMarkers {
+		if os.Getenv(name) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMain stops a stray exit from taking the test binary with it.
+//
+// The CLI entry points call osExitFn on their error paths, and osExitFn is
+// os.Exit in production. Left as os.Exit in the parent test process, a single
+// test that reaches one of those paths terminates the whole binary mid-run: the
+// framework never prints --- FAIL:, `go test -json` reports no failing test, and
+// every test that had already finished is recorded as PASS. The package goes red
+// with nothing to point at, which is how a real regression in verifyBundle went
+// unattributed until it was bisected by hand with -run.
+//
+// Panicking instead keeps the failure attached to the test that caused it. Tests
+// that assert on exit codes still install their own osExitFn; this only changes
+// what happens to the ones that never expected to exit at all.
+func TestMain(m *testing.M) {
+	if !isHelperSubprocess() {
+		osExitFn = func(code int) {
+			panic(launcherExitCode{code: code})
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/src/flavor-go/pkg/psp/format_2025/pe_resource_error_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/pe_resource_error_test.go
@@ -2,6 +2,7 @@ package format_2025
 
 import (
 	"errors"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestShowBundleInfoPrepareBundlePathError(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showBundleInfo("/fake/exe", logging.NewNullLogger())
+		showBundleInfo(io.Discard, "/fake/exe", logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showBundleInfo")
@@ -63,7 +64,7 @@ func TestShowMetadataPrepareBundlePathError(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		showMetadata("/fake/exe", logging.NewNullLogger())
+		showMetadata(io.Discard, "/fake/exe", logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in showMetadata")
@@ -80,7 +81,7 @@ func TestVerifyBundlePrepareBundlePathError(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		verifyBundle("/fake/exe", logging.NewNullLogger())
+		verifyBundle(io.Discard, "/fake/exe", logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in verifyBundle")
@@ -97,7 +98,7 @@ func TestExtractSlotPrepareBundlePathError(t *testing.T) {
 	defer restore()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot("/fake/exe", "0", t.TempDir(), logging.NewNullLogger())
+		extractSlot(io.Discard, "/fake/exe", "0", t.TempDir(), logging.NewNullLogger())
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in extractSlot")
@@ -152,7 +153,7 @@ func TestExtractSlotInvalidSlotIndex(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot(bundle, "not-an-int", t.TempDir(), logger)
+		extractSlot(io.Discard, bundle, "not-an-int", t.TempDir(), logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in extractSlot with invalid slot index")
@@ -169,7 +170,7 @@ func TestExtractSlotOutOfRange(t *testing.T) {
 	logger := logging.NewNullLogger()
 
 	exitCode, panicked := withStubbedExit(func() {
-		extractSlot(bundle, "999", t.TempDir(), logger)
+		extractSlot(io.Discard, bundle, "999", t.TempDir(), logger)
 	})
 	if panicked {
 		t.Fatal("unexpected non-exit panic in extractSlot with out-of-range slot")


### PR DESCRIPTION
Closes #41.

## The issue's premise was wrong

#41 blamed `captureStdout` for swallowing the framework's `--- FAIL:` lines. It does not. Go's `testing` captures `os.Stdout` into the root `common.w` when `runTests` starts, so later swaps of the global cannot reach it — verified on Go 1.26.6, where a deliberate failure prints its `--- FAIL:` line and `go test -json` names the test.

The symptom was real. The mechanism is `osExitFn`.

## What actually happened

`osExitFn` is `os.Exit` (launcher.go:25), and nothing replaced it for the test binary. Any test reaching a CLI error path called the **real** `os.Exit`, terminating the process mid-run — so the framework never printed `--- FAIL:`, `-json` listed no failing test, and everything already finished showed PASS.

Reproduced exactly:

```
$ go test . -run TestZZProof
FAIL	github.com/provide-io/flavor/go/flavor/pkg/psp/format_2025	0.018s
FAIL
```

That run contains `t.Fatal("THIS FAILURE SHOULD BE VISIBLE")`. It never reported. With the fix, the same test names itself and points at `launcher_cli.go:137`.

This is what happened to `TestVerifyBundleDirectSuccess` when #35 tightened `verifyBundle` — the stack trace tail in that session's log, `testing.go:2101 +0x3a8`, matches the one this reproduction produces.

**Fix:** `TestMain` installs a panicking `osExitFn`. The re-exec harnesses that measure real exit codes are exempt via their marker env vars; a new harness that forgets to list its marker sees exit code 2 instead of the code it expected.

## The stdout swap was still a real bug

Just a different one. `captureStdout` restored the previous `os.Stdout` on the way out, which is only correct when capture windows nest. They did not — `TestVerifyBundleDirectSuccess` calls `t.Parallel()`, so its window overlapped the other 253 parallel tests. On an overlapping-but-not-nested pair the loser captured `""` while its output went to the terminal:

```
BBB
--- FAIL: TestZZReproCaptureB (0.20s)
    B lost its own output — captured "", expected it to contain BBB
```

That made every `assert output contains X` a flake, and made `launcher_cli_errors_test.go`'s `if output != "" && ...` pass on having captured nothing.

**Fix:** the four CLI functions take an `io.Writer`. Production passes `os.Stdout` (output byte-identical); tests pass a buffer. `TestShowMetadataEncodeFailure` now reaches the encoder's error path with a failing writer instead of pointing the global `os.Stdout` at a closed pipe.

## Two tests that asserted nothing

Both on the `Verified: ✗` branch, which had **no** real coverage:

- `TestShowBundleInfoVerifyMagicTrailerFails` set up exactly the right conditions, then ended at `_ = exitCalled`. Now asserts the report says `Verified: ✗`. Breaking the branch fails it — before, breaking the branch passed.
- `TestShowBundleInfoVerifyStatusFail` zeroes the trailer, which takes the index with it, so nothing is ever printed. Now asserts the empty report and exit code 1, and its comment names the test that covers the display it was named for.

## Guards

- `TestCaptureCLIOutputIsolatesConcurrentCaptures` — fails under the old global-swap semantics, passes on the fix.
- `TestLauncherCLIHasNoProcessGlobalWrites` — refuses `fmt.Print*` and `os.Stdout` in `launcher_cli.go`, since a dynamic test only catches the fault when the writer resolves the global lazily. Verified to fail on a deliberate violation, naming the line.

## Verification

`ci/pr-tests.sh` green (Rust, Go, Python). `make check` green. Package green under `-race`. Coverage unchanged at 95.7%.