### PR TITLE
Make License Compliance able to fire, read its own policy, and fail

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -16,19 +16,33 @@ on:
         type: boolean
         default: true
   
+  # These paths are the ones the jobs below actually scan. They used to be bare
+  # basenames -- 'go.mod', 'Cargo.toml' -- which match only at the repository
+  # root, and this repo keeps none of them there. Of the eleven patterns, two
+  # could ever match: four named files that do not exist here, four pointed at
+  # the wrong directory, and uv.lock, which is what pins the Python versions,
+  # was not listed at all. A Rust or Go dependency change never reached this
+  # workflow at PR time.
   pull_request:
     paths:
-      - 'requirements*.txt'
+      # Python: the job runs `uv sync` from the repository root.
       - 'pyproject.toml'
-      - 'poetry.lock'
-      - 'Pipfile*'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'package.json'
+      - 'uv.lock'
+      # Go: the job scans src/flavor-go.
+      - 'src/flavor-go/go.mod'
+      - 'src/flavor-go/go.sum'
+      # Rust: the job scans src/flavor-rs, against its committed policy.
+      - 'src/flavor-rs/Cargo.toml'
+      - 'src/flavor-rs/Cargo.lock'
+      - 'src/flavor-rs/deny.toml'
+      # The licence and notice text this repo ships under.
       - 'LICENSE*'
       - 'NOTICE*'
+      - 'LICENSES/**'
+      # This workflow and the scripts it calls, so a change to the checking
+      # itself is checked by the PR that makes it.
+      - '.github/workflows/license-compliance.yml'
+      - 'ci/license-*.sh'
   
   schedule:
     # Run monthly on the 1st at 5 AM UTC
@@ -441,85 +455,16 @@ jobs:
           cargo install cargo-license
           cargo install cargo-deny
       
-      - name: 📋 Generate License Report
-        run: |
-          echo "## 🦀 Rust License Compliance" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          cd src/flavor-rs
-          
-          # Generate license report
-          cargo license --json > rust-licenses.json 2>&1 || true
-          cargo license > rust-licenses.txt 2>&1 || true
-          
-          echo "### Rust Crate Licenses" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          head -50 rust-licenses.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-      
-      - name: 🔍 Check Compliance with cargo-deny
+      # Reports every crate's licence, then enforces src/flavor-rs/deny.toml.
+      # Script policy: this used to be 74 lines of inline YAML that wrote its
+      # own deny.toml over the committed one and tested tee's exit status
+      # instead of cargo-deny's. Keep it in ci/.
+      - name: 🔍 Report and check Rust licences
         id: check
-        run: |
-          echo "### Rust License Compliance Check" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          cd src/flavor-rs
-          
-          # Create cargo-deny config for license checking (cargo-deny v0.14+ syntax)
-          cat > deny.toml << 'DENYEOF'
-          [licenses]
-          version = 2
-          unlicensed = "deny"
-          allow = [
-              "MIT",
-              "Apache-2.0",
-              "Apache-2.0 WITH LLVM-exception",
-              "BSD-2-Clause",
-              "BSD-3-Clause",
-              "ISC",
-              "Unicode-3.0",
-              "Unicode-DFS-2016",
-              "CC0-1.0",
-              "OpenSSL",
-              "Zlib",
-          ]
-          deny = [
-              "GPL-2.0",
-              "GPL-3.0",
-              "AGPL-3.0",
-          ]
+        env:
+          STRICT_MODE: ${{ inputs.strict_mode }}
+        run: ./ci/license-check-rust.sh
 
-          [[licenses.exceptions]]
-          allow = ["Unicode-DFS-2016", "Unicode-3.0"]
-          name = "unicode-ident"
-
-          [bans]
-          multiple-versions = "warn"
-          wildcards = "allow"
-
-          [sources]
-          unknown-registry = "warn"
-          unknown-git = "warn"
-          DENYEOF
-          
-          # Run cargo-deny check
-          if cargo deny check licenses 2>&1 | tee cargo-deny-licenses.log; then
-            echo "compliant=true" >> $GITHUB_OUTPUT
-            echo "✅ All Rust dependencies are license compliant" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "compliant=false" >> $GITHUB_OUTPUT
-            
-            if [ "${{ inputs.strict_mode }}" = "true" ]; then
-              echo "❌ Rust license compliance failed (strict mode)" >> $GITHUB_STEP_SUMMARY
-              exit 1
-            else
-              echo "⚠️ Rust license compliance issues detected:" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              grep -E "error\[|warning\[" cargo-deny-licenses.log | head -20 >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
-      
       - name: 📤 Upload Rust License Reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,10 @@ coverage.xml
 src/flavor-go/coverage_*.out
 src/flavor-go/coverage.out
 src/flavor-go/coverage.txt
+# Written by ci/license-check-rust.sh
+src/flavor-rs/rust-licenses.json
+src/flavor-rs/rust-licenses.txt
+src/flavor-rs/cargo-deny-licenses.log
 tests/pretaster/logs/
 # Written by ci/run-tests.sh, ci/pr-tests.sh and ci/quality-checks.sh, which
 # are worth running locally -- see the 03b notes in docs/development/ci-cd.md.

--- a/ci/license-check-rust.sh
+++ b/ci/license-check-rust.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# license-check-rust.sh - Report and enforce Rust dependency licenses.
+#
+# Three things were wrong with the inline version of this:
+#
+#  1. It wrote its own deny.toml over the committed src/flavor-rs/deny.toml, so
+#     the policy the repo declares was never the policy CI enforced. The inline
+#     copy allowed CC0-1.0 and OpenSSL, dropped 0BSD, MPL-2.0 and Unlicense, and
+#     turned wildcards from deny to allow and unknown-registry/unknown-git from
+#     deny to warn. The committed file is the policy; this reads it.
+#
+#  2. It tested the wrong exit status: `if cargo deny ... | tee log; then` reads
+#     tee's status, which is all but always 0, so the failure branch was
+#     unreachable and the job reported compliant no matter what cargo-deny said.
+#
+#  3. None of it ran on a pull request that changed a Rust dependency -- the
+#     workflow's paths filter listed a bare 'Cargo.toml', which matches only at
+#     the repository root, and this repo's is at src/flavor-rs/Cargo.toml.
+#
+# STRICT_MODE=true turns a policy violation into a failed job. Otherwise the
+# violation is reported in the step summary and the job goes green, which is the
+# behaviour the workflow input has always described.
+#
+# Usage: license-check-rust.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRATE_DIR="${REPO_ROOT}/src/flavor-rs"
+STRICT_MODE="${STRICT_MODE:-false}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+cd "${CRATE_DIR}" || exit 1
+
+if [ ! -f deny.toml ]; then
+  echo "❌ ${CRATE_DIR}/deny.toml is missing; refusing to check against an unknown policy" >&2
+  exit 1
+fi
+
+{
+  echo "## 🦀 Rust License Compliance"
+  echo ""
+} >> "${SUMMARY}"
+
+# Inventory first: what every crate in the tree is licensed under.
+cargo license --json > rust-licenses.json 2>&1 || true
+cargo license > rust-licenses.txt 2>&1 || true
+
+{
+  echo "### Rust Crate Licenses"
+  echo '```'
+  head -50 rust-licenses.txt
+  echo '```'
+  echo ""
+} >> "${SUMMARY}"
+
+# Then the policy in deny.toml, whose verdict is the one that counts.
+cargo deny check licenses > cargo-deny-licenses.log 2>&1
+status=$?
+cat cargo-deny-licenses.log
+
+{
+  echo "### Rust License Compliance Check"
+  echo ""
+} >> "${SUMMARY}"
+
+if [ "${status}" -eq 0 ]; then
+  echo "compliant=true" >> "${OUTPUT}"
+  echo "✅ All Rust dependencies are license compliant" >> "${SUMMARY}"
+  exit 0
+fi
+
+echo "compliant=false" >> "${OUTPUT}"
+
+if [ "${STRICT_MODE}" = "true" ]; then
+  {
+    echo "❌ Rust license compliance failed (strict mode)"
+    echo '```'
+    grep -E "error\[|warning\[" cargo-deny-licenses.log | head -20
+    echo '```'
+  } >> "${SUMMARY}"
+  exit 1
+fi
+
+{
+  echo "⚠️ Rust license compliance issues detected:"
+  echo '```'
+  grep -E "error\[|warning\[" cargo-deny-licenses.log | head -20
+  echo '```'
+} >> "${SUMMARY}"


### PR DESCRIPTION
Closes #44.

Three independent faults in the Rust half of workflow 08. Each alone made the job's verdict meaningless.

## 1. It could not be triggered

The `pull_request` `paths:` filter used bare basenames, which in Actions match only at the repository root. Of eleven patterns, **two could ever match**:

| pattern | why |
|---|---|
| `pyproject.toml`, `LICENSE*` | ✅ at root |
| `requirements*.txt`, `poetry.lock`, `Pipfile*`, `package.json` | no such file in this repo |
| `go.mod`, `go.sum` | actually at `src/flavor-go/` |
| `Cargo.toml`, `Cargo.lock` | actually at `src/flavor-rs/` |
| `uv.lock` | **not listed** — and it's what pins the Python versions |

Run history confirms it — one `pull_request` run ever, on a branch that touched `pyproject.toml`:

```
  1 pull_request      ci/blocking-quality-gates   success
  5 schedule          main                        success
  1 workflow_dispatch main                        success
```

PR #34 changed `src/flavor-rs/Cargo.toml` and `Cargo.lock` — the eight Rust dependency majors from #27 — and got no licence check.

The filter now lists what the jobs actually scan (`cd src/flavor-go`, `cd src/flavor-rs`, `uv sync` at root), plus the workflow and its scripts, so a change to the checking is checked by the PR making it. **This PR triggers 08 — that's the proof the fix works.**

## 2. It enforced a policy the repo does not declare

The job wrote its own `deny.toml` over the committed `src/flavor-rs/deny.toml`:

| | committed | inline (what CI used) |
|---|---|---|
| `wildcards` | `deny` | `allow` |
| `unknown-registry` | `deny` | `warn` |
| `unknown-git` | `deny` | `warn` |
| extra allowed | — | `CC0-1.0`, `OpenSSL` |
| dropped | — | `0BSD`, `MPL-2.0`, `Unlicense` |

A dependency pulled from an arbitrary git remote passed CI while violating the checked-in policy. The committed file is now what's read, and the script refuses to run if it's missing rather than inventing a policy.

## 3. It could not report a failure

```bash
if cargo deny check licenses 2>&1 | tee cargo-deny-licenses.log; then
```

Tests **tee's** exit status. `compliant=false` was unreachable, and `strict_mode`'s `exit 1` with it. Same fault fixed in `ci/pr-tests.sh` in #40.

## Verification

79 lines of inline YAML → `ci/license-check-rust.sh`, 10 lines of workflow (repo script policy). Tested against the real crate on all three paths:

| scenario | exit | output |
|---|---|---|
| clean tree | 0 | `compliant=true` |
| MIT removed from allow list | 0 | `compliant=false`, reported |
| same, `STRICT_MODE=true` | 1 | `compliant=false` |

The last two states did not previously exist. `shellcheck` clean; YAML parses.

## Noted, not changed

`cargo deny check` passes for `licenses`, `bans` **and** `sources` against the committed policy, but the job still runs `licenses` only — so `[bans]` and `[sources]` in `deny.toml` remain unenforced. Enabling them is a policy call, left for you.