### PR TITLE
Make the three implementations agree on the execution block

### DIFF
--- a/scripts/gen_format_fixtures.py
+++ b/scripts/gen_format_fixtures.py
@@ -138,10 +138,11 @@ def build_with_python(payload: Path, launcher: Path, output: Path) -> None:
 
     result = (
         PSPFBuilder.create()
-        # The execution block has to be passed explicitly here. The Go and Rust
-        # builders derive it from the manifest, and the Rust reader treats
-        # primary_slot as required, so a fixture without it is one the Rust
-        # implementation cannot open at all.
+        # The execution block has to be passed explicitly here; the Go and Rust
+        # builders derive theirs from the manifest. primary_slot is spelled out
+        # to keep this generation's fixtures byte-identical to the committed
+        # ones. It is optional as of #36 -- Rust used to reject metadata without
+        # it, which is why this comment used to say the field was required.
         .metadata(
             name=PACKAGE_NAME,
             version=PACKAGE_VERSION,

--- a/src/flavor-go/pkg/psp/format_2025/builder_types.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_types.go
@@ -1,5 +1,7 @@
 package format_2025
 
+import "encoding/json"
+
 // BuildOptions represents the configuration for building a PSPF package.
 //
 // This struct defines the complete configuration needed to build a PSPF/2025
@@ -43,9 +45,31 @@ type PackageConfig struct {
 
 // ExecutionConfig defines how the package should be executed
 type ExecutionConfig struct {
-	PrimarySlot int               `json:"primary_slot,omitempty"`
-	Command     string            `json:"command"`
-	Environment map[string]string `json:"environment,omitempty"`
+	PrimarySlot int    `json:"primary_slot,omitempty"`
+	Command     string `json:"command"`
+	// Environment is read from "env", the key Python writes into the manifest
+	// it hands this builder. It was tagged "environment", so a caller's
+	// execution environment was dropped at build time before it ever reached a
+	// bundle (#36). "environment" is still accepted for older manifests.
+	Environment map[string]string `json:"env,omitempty"`
+}
+
+// UnmarshalJSON reads the execution environment from "env", falling back to the
+// "environment" key older manifests use. If both are present, "env" wins.
+func (c *ExecutionConfig) UnmarshalJSON(data []byte) error {
+	type executionConfigAlias ExecutionConfig
+	aux := struct {
+		*executionConfigAlias
+		Legacy map[string]string `json:"environment,omitempty"`
+	}{executionConfigAlias: (*executionConfigAlias)(c)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(c.Environment) == 0 {
+		c.Environment = aux.Legacy
+	}
+	return nil
 }
 
 // RuntimeConfig contains runtime environment configuration

--- a/src/flavor-go/pkg/psp/format_2025/format_compat_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/format_compat_test.go
@@ -258,3 +258,50 @@ func TestEveryProducerDerivesTheSameKey(t *testing.T) {
 		}
 	}
 }
+
+// TestExecutionBlockOmittingPrimarySlotIsReadable reads the one metadata
+// document every implementation has to agree on.
+//
+// primary_slot was required by Rust and optional here and in Python, so a
+// package without it was ordinary to two implementations and unopenable to the
+// third. The environment was worse: it is written under "env" by Rust and
+// Python, and this implementation read "environment", so an environment set by
+// either of them was dropped without a word. The fixture omits primary_slot and
+// carries a non-empty env; see tests/fixtures/format_compat/execution/README.md.
+func TestExecutionBlockOmittingPrimarySlotIsReadable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "tests", "fixtures", "format_compat", "execution", "omits-primary-slot.json")
+	raw, err := os.ReadFile(path) //nolint:gosec // fixture path built from the repo root
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	// The fixture is only worth anything while it keeps omitting the field.
+	var probe struct {
+		Execution map[string]json.RawMessage `json:"execution"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if _, present := probe.Execution["primary_slot"]; present {
+		t.Fatal("the fixture must keep omitting primary_slot")
+	}
+
+	var metadata Metadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("metadata must parse without primary_slot: %v", err)
+	}
+	if metadata.Execution == nil {
+		t.Fatal("execution block missing")
+	}
+	if metadata.Execution.PrimarySlot != 0 {
+		t.Errorf("PrimarySlot = %d, want 0", metadata.Execution.PrimarySlot)
+	}
+	if metadata.Execution.Command != "true" {
+		t.Errorf("Command = %q, want %q", metadata.Execution.Command, "true")
+	}
+	if got := metadata.Execution.Environment["MODE"]; got != "prod" {
+		t.Errorf("Environment[\"MODE\"] = %q, want %q — the environment must be read from the \"env\" key", got, "prod")
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/metadata.go
+++ b/src/flavor-go/pkg/psp/format_2025/metadata.go
@@ -80,9 +80,36 @@ type CacheValidationInfo struct {
 }
 
 type ExecutionInfo struct {
-	PrimarySlot int               `json:"primary_slot"`
-	Command     string            `json:"command"`
-	Environment map[string]string `json:"environment,omitempty"`
+	// PrimarySlot is what {primary} refers to. A missing field is 0, which is
+	// what Python's executor and the Rust reader also settle on (#36).
+	PrimarySlot int    `json:"primary_slot"`
+	Command     string `json:"command"`
+	// Environment is written under "env" -- the key the Rust and Python
+	// implementations both read and write. This used to be tagged
+	// "environment", so an env block from either of them was dropped in
+	// silence: a package setting MODE=prod ran here with no MODE and no error.
+	// UnmarshalJSON still accepts "environment" so packages Go built before it
+	// agreed with the others keep working.
+	Environment map[string]string `json:"env,omitempty"`
+}
+
+// UnmarshalJSON reads the package environment from "env", falling back to the
+// "environment" key this implementation used to write. If a package somehow
+// carries both, "env" wins -- it is the one the other implementations read.
+func (e *ExecutionInfo) UnmarshalJSON(data []byte) error {
+	type executionInfoAlias ExecutionInfo
+	aux := struct {
+		*executionInfoAlias
+		Legacy map[string]string `json:"environment,omitempty"`
+	}{executionInfoAlias: (*executionInfoAlias)(e)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(e.Environment) == 0 {
+		e.Environment = aux.Legacy
+	}
+	return nil
 }
 
 type RuntimeInfo struct {

--- a/src/flavor-go/pkg/psp/format_2025/metadata_execution_env_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/metadata_execution_env_test.go
@@ -134,3 +134,28 @@ func TestExecutionConfigReadsEnvKey(t *testing.T) {
 		})
 	}
 }
+
+// Both custom unmarshalers must still surface a malformed document rather than
+// swallowing the error and leaving a zero value behind.
+func TestExecutionUnmarshalRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		into json.Unmarshaler
+	}{
+		{"ExecutionInfo", &ExecutionInfo{}},
+		{"ExecutionConfig", &ExecutionConfig{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := tc.into.UnmarshalJSON([]byte(`{"command":`)); err == nil {
+				t.Error("expected an error from truncated JSON, got nil")
+			}
+			if err := tc.into.UnmarshalJSON([]byte(`{"env":"not-a-map"}`)); err == nil {
+				t.Error("expected an error when env is not an object, got nil")
+			}
+		})
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/metadata_execution_env_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/metadata_execution_env_test.go
@@ -1,0 +1,136 @@
+package format_2025
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The package environment is written under "env" by both the Rust and the
+// Python implementations, and Python's executor reads it from there. Go used to
+// declare the field as `json:"environment"`, so it silently dropped an env
+// block written by either of the others -- a package that sets MODE=prod ran
+// with no MODE at all under the Go launcher, with no error to say so. Worse,
+// Go re-emitted what it did read as "environment", converting a block the other
+// two could see into one they could not. See #36.
+func TestExecutionInfoReadsEnvKey(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{
+			name: "env is the key the other implementations write",
+			in:   `{"primary_slot":0,"command":"true","env":{"MODE":"prod"}}`,
+			want: map[string]string{"MODE": "prod"},
+		},
+		{
+			name: "environment is still accepted from packages Go built before",
+			in:   `{"primary_slot":0,"command":"true","environment":{"MODE":"prod"}}`,
+			want: map[string]string{"MODE": "prod"},
+		},
+		{
+			name: "env wins when a package somehow carries both",
+			in:   `{"command":"true","env":{"MODE":"new"},"environment":{"MODE":"old"}}`,
+			want: map[string]string{"MODE": "new"},
+		},
+		{
+			name: "neither key present",
+			in:   `{"command":"true"}`,
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got ExecutionInfo
+			if err := json.Unmarshal([]byte(tc.in), &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", tc.in, err)
+			}
+			if len(got.Environment) != len(tc.want) {
+				t.Fatalf("Environment = %v, want %v", got.Environment, tc.want)
+			}
+			for k, v := range tc.want {
+				if got.Environment[k] != v {
+					t.Errorf("Environment[%q] = %q, want %q", k, got.Environment[k], v)
+				}
+			}
+		})
+	}
+}
+
+// Whatever Go reads, it must write back under the key the others read.
+func TestExecutionInfoWritesEnvKey(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		`{"command":"true","env":{"MODE":"prod"}}`,
+		`{"command":"true","environment":{"MODE":"prod"}}`,
+	} {
+		var e ExecutionInfo
+		if err := json.Unmarshal([]byte(in), &e); err != nil {
+			t.Fatalf("Unmarshal(%s) error = %v", in, err)
+		}
+
+		out, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("Marshal error = %v", err)
+		}
+
+		var round struct {
+			Env    map[string]string `json:"env"`
+			Legacy map[string]string `json:"environment"`
+		}
+		if err := json.Unmarshal(out, &round); err != nil {
+			t.Fatalf("Unmarshal(%s) error = %v", out, err)
+		}
+		if round.Env["MODE"] != "prod" {
+			t.Errorf("re-emitted %s, want the environment under \"env\"", out)
+		}
+		if round.Legacy != nil {
+			t.Errorf("re-emitted %s, which the Rust and Python readers ignore", out)
+		}
+	}
+}
+
+// A missing primary_slot is valid -- Rust now defaults it too (#36).
+func TestExecutionInfoPrimarySlotDefaultsToZero(t *testing.T) {
+	t.Parallel()
+
+	var e ExecutionInfo
+	if err := json.Unmarshal([]byte(`{"command":"true"}`), &e); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	if e.PrimarySlot != 0 {
+		t.Errorf("PrimarySlot = %d, want 0", e.PrimarySlot)
+	}
+}
+
+// The same key disagreement existed one level up, in the manifest the builder
+// reads. Python writes "env" into the manifest it hands to flavor-go-builder,
+// and ExecutionConfig was tagged "environment" -- so an execution environment
+// set by the caller was dropped at build time, before it ever reached a bundle.
+func TestExecutionConfigReadsEnvKey(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"env, as Python writes it", `{"command":"true","env":{"MODE":"prod"}}`},
+		{"environment, as older manifests have it", `{"command":"true","environment":{"MODE":"prod"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got ExecutionConfig
+			if err := json.Unmarshal([]byte(tc.in), &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", tc.in, err)
+			}
+			if got.Environment["MODE"] != "prod" {
+				t.Errorf("Environment = %v, want MODE=prod", got.Environment)
+			}
+		})
+	}
+}

--- a/src/flavor-rs/src/psp/format_2025/metadata.rs
+++ b/src/flavor-rs/src/psp/format_2025/metadata.rs
@@ -65,6 +65,12 @@ pub struct SlotMetadata {
 /// Execution configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExecutionInfo {
+    /// Which slot `{primary}` refers to. Optional, defaulting to 0: Go leaves a
+    /// missing field at its zero value and Python's executor reads it with
+    /// `.get("primary_slot", 0)`, so packages built by either are valid without
+    /// it. Requiring it here made the same bytes readable by two
+    /// implementations and unopenable by the third (#36).
+    #[serde(default)]
     pub primary_slot: usize,
     pub command: String,
     #[serde(default)]
@@ -196,6 +202,29 @@ pub struct DirectorySpec {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A package whose metadata omits `execution.primary_slot` must still be
+    /// readable. Go leaves the field at 0 and Python's executor reads it with
+    /// `.get("primary_slot", 0)`, so a package built by either is valid without
+    /// it. Rust used to reject the whole document -- `missing field
+    /// primary_slot` -- which made the same bytes a package to two
+    /// implementations and unopenable to the third. See #36.
+    #[test]
+    fn metadata_without_primary_slot_defaults_to_zero() {
+        let json = br#"{
+            "format": "PSPF/2025",
+            "package": {"name": "demo", "version": "1.0.0"},
+            "slots": [],
+            "execution": {"command": "true"}
+        }"#;
+
+        let metadata: Metadata =
+            serde_json::from_slice(json).expect("metadata without primary_slot must parse");
+
+        assert_eq!(metadata.execution.primary_slot, 0);
+        assert_eq!(metadata.execution.command, "true");
+        assert!(metadata.execution.env.is_empty());
+    }
 
     fn sample_slot() -> SlotMetadata {
         SlotMetadata {

--- a/src/flavor-rs/tests/format_compat.rs
+++ b/src/flavor-rs/tests/format_compat.rs
@@ -12,7 +12,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use flavor::psp::format_2025::{self, Reader};
+use flavor::psp::format_2025::{self, Metadata, Reader};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -181,4 +181,36 @@ fn every_producer_derives_the_same_key() {
             "{name}: producers disagree on the key derived from the seed"
         );
     }
+}
+
+/// One metadata document that every implementation must read the same way.
+///
+/// `primary_slot` was required here and optional in Go and Python, so a package
+/// without it was ordinary to them and unopenable to this reader. The document
+/// omits the field and carries a non-empty `env`, which is the key Python and
+/// this implementation both use. See
+/// tests/fixtures/format_compat/execution/README.md.
+#[test]
+fn execution_block_omitting_primary_slot_is_readable() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/format_compat/execution/omits-primary-slot.json");
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    // The fixture has to keep exercising the missing field to be worth anything.
+    let document: Value = serde_json::from_str(&raw).expect("parse fixture");
+    assert!(
+        document["execution"].get("primary_slot").is_none(),
+        "the fixture must keep omitting primary_slot"
+    );
+
+    let metadata: Metadata =
+        serde_json::from_str(&raw).expect("metadata must parse without primary_slot");
+
+    assert_eq!(metadata.execution.primary_slot, 0);
+    assert_eq!(metadata.execution.command, "true");
+    assert_eq!(
+        metadata.execution.env.get("MODE").map(String::as_str),
+        Some("prod"),
+        "the environment must be read from the \"env\" key"
+    );
 }

--- a/tests/fixtures/format_compat/execution/README.md
+++ b/tests/fixtures/format_compat/execution/README.md
@@ -1,0 +1,36 @@
+# The execution block contract
+
+`omits-primary-slot.json` is one metadata document that all three
+implementations must read the same way. It exists because they did not.
+
+Two disagreements, both found in #36:
+
+**`primary_slot` was required by Rust and optional everywhere else.** Go leaves
+a missing field at its zero value and Python's executor reads it with
+`.get("primary_slot", 0)`, so a package without the field is ordinary to both.
+Rust rejected the whole document — `missing field primary_slot` — so the same
+bytes were a package to two implementations and unopenable to the third. The
+field is only ever read to resolve `{primary}` and to print a debug line, and
+every construction site in the Rust tree sets it to 0. It is optional, and Rust
+now defaults it.
+
+**The environment was written under two different keys.** Rust and Python both
+read and write `env`. Go declared the field as `environment`. So Go silently
+dropped an environment block written by either of the others — a package setting
+`MODE=prod` ran with no `MODE` under the Go launcher, with nothing said — and
+re-emitted anything it did read under a key the other two ignore. Go now uses
+`env`, and still accepts `environment` when reading, so packages it built before
+keep working.
+
+This document therefore omits `primary_slot` and sets a non-empty `env`. Every
+implementation must parse it, resolve `primary_slot` to 0, and see `MODE=prod`.
+
+The harnesses that read it:
+
+- `tests/format_2025/test_format_compat.py`
+- `src/flavor-go/pkg/psp/format_2025/format_compat_test.go`
+- `src/flavor-rs/tests/format_compat.rs`
+
+Unlike the `v1/` bundles, this is a plain JSON document rather than a built
+package: the disagreement was in how the metadata was parsed, so parsing it is
+the whole test. Nothing here needs a builder to reproduce.

--- a/tests/fixtures/format_compat/execution/omits-primary-slot.json
+++ b/tests/fixtures/format_compat/execution/omits-primary-slot.json
@@ -1,0 +1,14 @@
+{
+  "format": "PSPF/2025",
+  "package": {
+    "name": "execution-block-contract",
+    "version": "1.0.0"
+  },
+  "slots": [],
+  "execution": {
+    "command": "true",
+    "env": {
+      "MODE": "prod"
+    }
+  }
+}

--- a/tests/format_2025/test_format_compat.py
+++ b/tests/format_2025/test_format_compat.py
@@ -36,6 +36,7 @@ pytestmark = [
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "format_compat"
 GENERATION = "v1"
 FIXTURE_DIR = FIXTURE_ROOT / GENERATION
+EXECUTION_DIR = FIXTURE_ROOT / "execution"
 
 
 def _expected() -> dict[str, Any]:
@@ -129,6 +130,23 @@ def test_every_producer_derives_the_same_key() -> None:
     """
     keys = {name: EXPECTED["fixtures"][name]["public_key"] for name in FIXTURE_NAMES}
     assert len(set(keys.values())) == 1, f"producers disagree on the derived key: {keys}"
+
+
+def test_execution_block_omitting_primary_slot_is_readable() -> None:
+    """One metadata document, read the same way by all three implementations.
+
+    ``primary_slot`` was required by Rust and optional everywhere else, and the
+    environment was written under ``env`` by Rust and Python but read from
+    ``environment`` by Go. So the same bytes were a package to two
+    implementations and not to the third, and an environment set by any of them
+    was invisible to Go. See tests/fixtures/format_compat/execution/README.md.
+    """
+    document = json.loads((EXECUTION_DIR / "omits-primary-slot.json").read_text(encoding="utf-8"))
+    execution = document["execution"]
+
+    assert "primary_slot" not in execution, "the fixture must keep exercising the missing field"
+    assert execution.get("primary_slot", 0) == 0
+    assert execution["env"] == {"MODE": "prod"}
 
 
 # 🌶️📦🔚


### PR DESCRIPTION
Closes #36.

Two disagreements about the same struct, each making a package mean different things depending on which implementation opened it.

## `primary_slot` was required by Rust, optional everywhere else

Go leaves a missing field at its zero value; Python's executor reads it with `.get("primary_slot", 0)`. Rust rejected the whole document — `missing field primary_slot` — so the same bytes were a package to two implementations and unopenable to the third.

**Optional is the right answer**, and the evidence is one-sided:

- no spec document mentions the field
- Rust and Go both read it *only* to print a debug line — `debug!("🎯 Primary slot: {}", ...)`
- every construction site in the Rust tree sets it to `0`
- its one functional consumer, Python's `{primary}` substitution, already defaults it

Requiring it would invalidate existing packages to protect a value Rust never reads. Rust now defaults it.

## The environment was written under two different keys

Rust and Python both read and write `env`. Go declared the field `environment`. Given an env block from either of the others:

```
in  {"command":"true","env":{"MODE":"prod"}}
  -> err=<nil>  Environment=map[]
```

No error. A package setting `MODE=prod` ran with **no `MODE`** under the Go launcher. And what Go did read, it re-emitted as `environment` — converting a block the other two could see into one they could not.

The same tag was on `ExecutionConfig`, the manifest struct `flavor-go-builder` unmarshals — and Python writes `"env"` into that manifest. So a caller's execution environment was dropped at **build** time, before reaching a bundle.

Both now use `env` and both still accept `environment` when reading, so packages and manifests produced before this keep working. Where a document carries both, `env` wins.

## Pinned across all three

`tests/fixtures/format_compat/execution/omits-primary-slot.json` — one metadata document, omitting `primary_slot` and carrying a non-empty `env`, read by all three harnesses (Python, Go, Rust).

It holds both halves. Against the old Go tag:

```
--- FAIL: TestExecutionBlockOmittingPrimarySlotIsReadable
    Environment["MODE"] = "", want "prod" — the environment must be read from the "env" key
```

and against the old Rust struct, a parse error.

## End-to-end

With rebuilt binaries, the Go and Rust builders given a manifest with `"env": {"MODE": "prod"}` now both write:

```json
{"primary_slot": 0, "command": "true", "env": {"MODE": "prod"}}
```

read back identically by the Python reader.

The v1 fixtures are untouched and still verify. The generator comment describing the old Rust requirement is corrected.

## Verification

`ci/pr-tests.sh` green (Rust, Go, Python). `ci/quality-checks.sh` green for all three languages. Lib clippy `-D warnings` clean.

## Found while tracing, deliberately left alone

- **`{primary}` substitution exists only in Python.** Rust and Go pass the literal string `{primary}` to the shell.
- **The execution block itself** is required by Rust and nullable in Go, so a package without one cannot even be *inspected* by Rust, while Go reads it and refuses at run time.

Both are separate divergences — filing separately rather than widening this.