### PR TITLE
Specify the metadata document the implementations read

### DIFF
--- a/docs/reference/spec/fep-0002-json-metadata-format.md
+++ b/docs/reference/spec/fep-0002-json-metadata-format.md
@@ -3,572 +3,682 @@
 **Status**: Standards Track  
 **Type**: Core Protocol  
 **Created**: 2025-01-08  
-**Version**: v0.1  
+**Updated**: 2026-09-01  
+**Version**: v0.2  
 **Category**: Standards Track  
 
 ## Abstract
 
-This document specifies the JSON-based metadata format for PSPF/2025 packages. The metadata provides structured information about package contents, slot definitions, execution parameters, and build provenance. This specification defines the exact JSON schema, validation rules, encoding requirements, and parsing algorithms to ensure cross-language compatibility between Python, Go, and Rust implementations.
+This document specifies the JSON metadata document carried by PSPF/2025 packages. The metadata names the package, describes each data slot, states how the package is executed, and records how it was built and how it is verified. It is the structure the Python, Go and Rust implementations read to answer what a package is and what it contains.
+
+This specification defines the document's fields, their types, which of them a reader may rely on, the encoding under which the document is stored, and the JSON Schema that a conforming document satisfies. The schema in Section 8 is checked against the packages in `tests/fixtures/format_compat/`, which are built by all three implementations.
 
 ## Table of Contents
 
 1. [Introduction](#1-introduction)
 2. [Conventions and Terminology](#2-conventions-and-terminology)
-3. [JSON Metadata Structure](#3-json-metadata-structure)
+3. [Document Structure](#3-document-structure)
 4. [Field Specifications](#4-field-specifications)
 5. [Validation Rules](#5-validation-rules)
-6. [Encoding and Serialization](#6-encoding-and-serialization)
-7. [ABNF Grammar](#7-abnf-grammar)
+6. [Encoding and Storage](#6-encoding-and-storage)
+7. [Identifier and Version Grammar](#7-identifier-and-version-grammar)
 8. [JSON Schema Definition](#8-json-schema-definition)
-9. [Processing Algorithms](#9-processing-algorithms)
-10. [Error Handling](#10-error-handling)
-11. [Security Considerations](#11-security-considerations)
-12. [Implementation Requirements](#12-implementation-requirements)
-13. [Test Vectors](#13-test-vectors)
-14. [References](#14-references)
+9. [Producer Variation](#9-producer-variation)
+10. [Processing Algorithms](#10-processing-algorithms)
+11. [Error Handling](#11-error-handling)
+12. [Security Considerations](#12-security-considerations)
+13. [Implementation Requirements](#13-implementation-requirements)
+14. [Test Vectors](#14-test-vectors)
+15. [References](#15-references)
 
 ## 1. Introduction
 
 ### 1.1 Motivation
 
-PSPF/2025 packages require structured metadata to describe their contents, execution requirements, and provenance. JSON provides an ideal balance between human readability, cross-language support, and parsing efficiency for v0 implementations. Future versions may introduce binary formats for performance-critical applications.
+A PSPF/2025 package is a launcher binary followed by data slots and an 8192-byte index (FEP-0001). The index carries offsets, sizes and checksums — the numbers needed to find and verify bytes. It carries no names, no descriptions and no instructions.
+
+The metadata document supplies those. It is what lets a reader report that a file is `myapp v2.1.0`, list its slots and their purposes, name the command it runs, and state whether it is signed — without extracting anything and without executing the launcher.
+
+JSON is used because three implementations in three languages must agree on it, and because the document is small enough that parsing cost does not matter next to the slot data it describes.
 
 ### 1.2 Scope
 
-This specification defines:
-- Complete JSON schema for PSPF/2025 package metadata
-- Validation rules and semantic constraints
-- Encoding and normalization requirements
-- Cross-language parsing algorithms
-- Extension mechanisms for vendor-specific fields
+This document specifies:
 
-This specification does NOT define:
-- Binary wire format (reserved for future versions)
-- Network transmission protocols
-- Metadata compression algorithms (handled at package level)
-- Runtime behavior of metadata fields
+- the fields of the metadata document, their types and their optionality
+- the validation a reader performs before trusting the document
+- the encoding and compression under which the document is stored
+- a JSON Schema that a conforming document satisfies
+- the points on which the three implementations differ
+
+This document does not specify:
+
+- the binary container, index layout or slot descriptors — FEP-0001
+- operation codes and their semantics — FEP-0003
+- the attestation slot, signing keys and policy evaluation — FEP-0004
 
 ### 1.3 Requirements Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119.html) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174.html) when, and only when, they appear in all capitals, as shown here.
+The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY and OPTIONAL are to be interpreted as described in [RFC2119].
+
+A field marked REQUIRED is one every conforming producer writes and every reader may rely on. A field marked OPTIONAL may be absent, and a reader MUST behave correctly when it is.
 
 ### 1.4 Related Documents
 
-- **FEP-0001**: Core binary format and operation chains
-- **FEP-0003**: Operation registry and allocation policy
-- **RFC 7159**: The JavaScript Object Notation (JSON) Data Interchange Format
-- **RFC 4627**: JSON Media Type
+| Document | Covers |
+|----------|--------|
+| FEP-0001 | Binary container, magic trailer, index block, slot descriptors |
+| FEP-0003 | Operation registry and operation codes |
+| FEP-0004 | Security attestation, signing keys, package policy |
 
 ## 2. Conventions and Terminology
 
 ### 2.1 Definitions
 
-**Metadata**: Structured information describing package contents and requirements
-**Slot Definition**: JSON object describing a single data slot in the package
-**Operation String**: Human-readable representation of an operation chain
-**Canonical Form**: Normalized JSON representation for signature verification
-**Extension Field**: Vendor-specific field prefixed with "x-"
+**Package**: A single file containing a launcher, slots, and a magic trailer.
+
+**Slot**: One addressable region of package data, described by both a binary descriptor in the index and an entry in the `slots` array of this document.
+
+**Metadata document**: The JSON object this specification defines.
+
+**Metadata archive**: The metadata document as stored in the package — UTF-8 JSON, gzip-compressed. The index's metadata checksum covers these bytes.
+
+**Workenv**: The directory a launcher extracts into at run time.
+
+**Producer**: An implementation that writes packages. Three exist: `flavor-python`, `flavor-go`, `flavor-rs`.
+
+**Reader**: An implementation that parses a metadata document.
 
 ### 2.2 Notation Conventions
 
-JSON examples use standard JSON notation with comments for clarity (comments are not valid in actual JSON):
+Field paths use dots: `package.name`, `slots[].checksum`.
 
-```json
-{
-  "field": "value",    // Comment for documentation
-  "number": 123,       // Integer value
-  "array": [1, 2, 3]   // Array of integers
-}
-```
-
-ABNF grammar follows [RFC5234] notation.
-
-Regular expressions use PCRE syntax.
+JSON examples are shown indented for readability. The stored form is not indented (Section 6).
 
 ### 2.3 Data Type Definitions
 
-| JSON Type | PSPF Type  | Range/Format                           |
-|-----------|------------|-----------------------------------------|
-| string    | identifier | `^[a-z0-9][a-z0-9_-]*$` max 255 chars |
-| string    | version    | Semantic versioning or custom format   |
-| string    | checksum   | Hex string, lowercase, no prefix       |
-| string    | operations | Operation chain string (see Section 7) |
-| number    | uint32     | 0 to 4,294,967,295                    |
-| number    | uint64     | 0 to 18,446,744,073,709,551,615      |
-| number    | timestamp  | Unix timestamp (seconds since epoch)   |
-| string    | path       | Forward slashes, no ".." traversal     |
+| Type | JSON representation | Notes |
+|------|---------------------|-------|
+| string | string | UTF-8 |
+| integer | number | No fractional part |
+| boolean | boolean | |
+| object | object | |
+| array | array | |
+| checksum | string | `"<algorithm>:<hex>"`, e.g. `"sha256:34c4e0…"` |
+| timestamp | string | RFC3339 |
+| mode | string | Octal, quoted: `"0755"` |
 
-## 3. JSON Metadata Structure
+## 3. Document Structure
 
 ### 3.1 Root Object
 
-The metadata MUST be a single JSON object with the following structure:
+A complete document, taken from a package built by `flavor-rs`:
 
 ```json
 {
-  "format_version": "2025.0.0",
+  "format": "PSPF/2025",
+  "format_version": "1.0.0",
   "package": {
-    "name": "package-name",
-    "version": "1.0.0",
-    "description": "Package description",
-    "author": "Author Name",
-    "license": "License-Identifier",
-    "homepage": "https://example.com"
-  },
-  "build": {
-    "timestamp": 1704067200,
-    "platform": "linux_x86_64",
-    "builder": "flavorpack-0.1.0",
-    "source_hash": "abc123...",
-    "reproducible": true
+    "name": "format-compat-fixture",
+    "version": "1.0.0"
   },
   "slots": [
     {
-      "id": 0,
-      "name": "slot-name",
-      "purpose": "code",
+      "slot": 0,
+      "id": "payload",
+      "source": "/build/inputs/payload.txt",
+      "target": "data/payload.txt",
+      "size": 125,
+      "checksum": "sha256:34c4e0f57a67a89825fd5e3c48e70c535ade2032de5ac3698fea31def5a13454",
+      "operations": "",
+      "purpose": "data",
       "lifecycle": "runtime",
-      "operations": "tar.gz",
-      "size": 1024,
-      "original_size": 2048,
-      "checksum": "deadbeef",
-      "permissions": "755"
+      "permissions": "0644",
+      "resolution": "build"
     }
   ],
   "execution": {
-    "entry_point": "./bin/app",
-    "args": ["--config", "app.conf"],
-    "env": {
-      "KEY": "value"
+    "primary_slot": 0,
+    "command": "true",
+    "env": {}
+  },
+  "verification": {
+    "integrity_seal": {
+      "required": true,
+      "algorithm": "ed25519"
     },
-    "working_directory": "."
+    "signed": true,
+    "require_verification": true
   },
-  "dependencies": {
-    "runtime": ["libc.so.6"],
-    "optional": ["libfoo.so.1"]
+  "build": {
+    "tool": "flavor-rs",
+    "tool_version": "0.4.6",
+    "timestamp": "2026-08-31T21:05:39.665548+00:00",
+    "deterministic": true,
+    "platform": {
+      "os": "macos",
+      "arch": "aarch64",
+      "host": "macos/aarch64 build-host.local"
+    }
   },
-  "extensions": {
-    "x-vendor-field": "vendor-specific-value"
-  }
+  "launcher": {
+    "tool": "launcher-stub.sh",
+    "tool_version": "0.4.6",
+    "size": 503,
+    "checksum": "sha256:02b29c4db29e4141af819c700414368a14d89ea6e9bddd66760a61b706643d21",
+    "capabilities": ["mmap", "signed"]
+  },
+  "compatibility": {
+    "min_format_version": "1.0.0",
+    "features": []
+  },
+  "setup_commands": []
 }
 ```
 
 ### 3.2 Object Hierarchy
 
 ```
-root
-├── format_version* (string)
-├── package* (object)
-│   ├── name* (string)
-│   ├── version* (string)
-│   ├── description (string)
-│   ├── author (string)
-│   ├── license (string)
-│   └── homepage (string)
-├── build (object)
-│   ├── timestamp (number)
-│   ├── platform (string)
-│   ├── builder (string)
-│   ├── source_hash (string)
-│   └── reproducible (boolean)
-├── slots* (array)
-│   └── [slot] (object)
-│       ├── id* (number)
-│       ├── name* (string)
-│       ├── purpose* (string)
-│       ├── lifecycle* (string)
-│       ├── operations* (string)
-│       ├── size* (number)
-│       ├── original_size (number)
-│       ├── checksum* (string)
-│       └── permissions (string)
-├── execution (object)
-│   ├── entry_point (string)
-│   ├── args (array of strings)
-│   ├── env (object)
-│   └── working_directory (string)
-├── dependencies (object)
-│   ├── runtime (array of strings)
-│   └── optional (array of strings)
-└── extensions (object)
-    └── x-* (any)
-
-* = required field
+metadata (object)
+├── format (string, REQUIRED)
+├── format_version (string, OPTIONAL)
+├── package (object, REQUIRED)
+│   ├── name (string, REQUIRED)
+│   ├── version (string, REQUIRED)
+│   └── description (string, OPTIONAL)
+├── slots (array, REQUIRED)
+│   └── [] (object)
+│       ├── slot (integer, REQUIRED)
+│       ├── id (string, REQUIRED)
+│       ├── source (string, REQUIRED)
+│       ├── target (string, REQUIRED)
+│       ├── size (integer, REQUIRED)
+│       ├── checksum (string, REQUIRED)
+│       ├── operations (string, REQUIRED)
+│       ├── purpose (string, REQUIRED)
+│       ├── lifecycle (string, REQUIRED)
+│       ├── permissions (string|null, OPTIONAL)
+│       ├── resolution (string, OPTIONAL)
+│       └── self_ref (boolean, OPTIONAL)
+├── execution (object, REQUIRED for interoperability — see §9.1)
+│   ├── primary_slot (integer, OPTIONAL, default 0)
+│   ├── command (string, REQUIRED)
+│   └── env (object, OPTIONAL, default {})
+├── verification (object, OPTIONAL)
+│   ├── integrity_seal (object, REQUIRED within)
+│   │   ├── required (boolean, REQUIRED)
+│   │   └── algorithm (string, REQUIRED)
+│   ├── signed (boolean, OPTIONAL, default false)
+│   ├── require_verification (boolean, OPTIONAL, default true)
+│   └── trust_signatures (object, OPTIONAL)
+├── build (object, OPTIONAL)
+├── launcher (object, OPTIONAL)
+├── compatibility (object, OPTIONAL)
+├── cache_validation (object, OPTIONAL)
+├── runtime (object, OPTIONAL)
+├── workenv (object, OPTIONAL)
+├── setup_commands (array, OPTIONAL, default [])
+└── policy (object, OPTIONAL — FEP-0004)
 ```
+
+Readers ignore members they do not recognise. A producer MAY add fields; a reader MUST NOT fail on them.
 
 ## 4. Field Specifications
 
 ### 4.1 Root Level Fields
 
-#### 4.1.1 format_version (REQUIRED)
+#### 4.1.1 format (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^\d{4}\.\d+\.\d+$`  
-**Example**: "2025.0.0"  
+**Value**: `"PSPF/2025"`
 
-Identifies the metadata format version. For v0, this MUST be "2025.0.0".
+Names the format. Every producer writes this exact string.
 
-#### 4.1.2 package (REQUIRED)
+#### 4.1.2 format_version (OPTIONAL)
 
-**Type**: object  
+**Type**: string  
+**Example**: `"1.0.0"`
 
-Contains basic package identification and information.
+Version of the metadata structure. Readers treat an absent or empty value as unversioned and fall back on `format`. See §9.2.
 
-#### 4.1.3 build (OPTIONAL)
+#### 4.1.3 package (REQUIRED)
 
-**Type**: object  
+**Type**: object
 
-Contains build-time information for reproducibility and provenance.
+Identity of the package. Section 4.2.
 
 #### 4.1.4 slots (REQUIRED)
 
 **Type**: array of objects  
-**Min Items**: 0  
-**Max Items**: 65535  
+**Min Items**: 0
 
-Array of slot definitions. MAY be empty for launcher-only packages.
+One entry per data slot, in index order. MAY be empty for a package that carries no slots. Section 4.3.
 
-#### 4.1.5 execution (OPTIONAL)
+#### 4.1.5 execution (REQUIRED for interoperability)
 
-**Type**: object  
+**Type**: object
 
-Runtime execution parameters and environment configuration.
+How the package runs. Section 4.4.
 
-#### 4.1.6 dependencies (OPTIONAL)
+Two of the three implementations treat this object as optional and refuse at the point of execution when it is absent; the Rust reader requires it to parse the document at all. A producer that intends its packages to be readable by every implementation MUST write it. See §9.1.
 
-**Type**: object  
+#### 4.1.6 verification (OPTIONAL)
 
-External dependencies required or recommended for package execution.
+**Type**: object
 
-#### 4.1.7 extensions (OPTIONAL)
+What verification the package declares for itself. Section 4.5.
 
-**Type**: object  
+#### 4.1.7 build (OPTIONAL)
 
-Vendor-specific extensions. All keys MUST begin with "x-".
+**Type**: object
+
+Provenance: which tool built the package, when, and on what platform. Section 4.6.
+
+#### 4.1.8 launcher (OPTIONAL)
+
+**Type**: object
+
+The launcher binary prefixed to the package. Section 4.7.
+
+#### 4.1.9 compatibility (OPTIONAL)
+
+**Type**: object
+
+The minimum format version and the feature names a reader needs. Section 4.8.
+
+#### 4.1.10 cache_validation (OPTIONAL)
+
+**Type**: object
+
+A file and expected content a launcher checks to decide whether an existing workenv is still good. Section 4.9.
+
+#### 4.1.11 runtime (OPTIONAL)
+
+**Type**: object
+
+Environment manipulation applied to the process the launcher starts. Section 4.10.
+
+#### 4.1.12 workenv (OPTIONAL)
+
+**Type**: object
+
+Directories to create in the workenv and environment variables scoped to it. Section 4.11.
+
+#### 4.1.13 setup_commands (OPTIONAL)
+
+**Type**: array  
+**Default**: `[]`
+
+Commands run after extraction and before the main command.
+
+#### 4.1.14 policy (OPTIONAL)
+
+**Type**: object
+
+Package-declared execution policy. Its contents are specified by FEP-0004 §8; this document treats the value as opaque and preserves it verbatim.
 
 ### 4.2 Package Object Fields
 
 #### 4.2.1 name (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^[a-z0-9][a-z0-9_-]*$`  
-**Min Length**: 1  
-**Max Length**: 255  
-**Example**: "my-application"  
+**Example**: `"myapp"`
 
-Package identifier. MUST be lowercase alphanumeric with hyphens and underscores.
+Package name. Section 7.1 gives the recommended grammar.
 
 #### 4.2.2 version (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^[0-9]+(\.[0-9]+)*([+-].+)?$`  
-**Max Length**: 255  
-**Example**: "1.2.3-beta+build.456"  
+**Example**: `"2.1.0"`
 
-Package version. SHOULD follow semantic versioning but MAY use custom schemes.
+Package version. Section 7.2 gives the recommended grammar.
 
 #### 4.2.3 description (OPTIONAL)
 
-**Type**: string  
-**Max Length**: 4096  
-**Example**: "A high-performance web server"  
+**Type**: string
 
-Human-readable package description.
-
-#### 4.2.4 author (OPTIONAL)
-
-**Type**: string  
-**Max Length**: 255  
-**Example**: "Jane Doe <jane@example.com>"  
-
-Package author or maintainer.
-
-#### 4.2.5 license (OPTIONAL)
-
-**Type**: string  
-**Max Length**: 255  
-**Example**: "MIT" or "Apache-2.0"  
-
-SPDX license identifier or custom license name.
-
-#### 4.2.6 homepage (OPTIONAL)
-
-**Type**: string  
-**Format**: URI  
-**Max Length**: 2048  
-**Example**: "https://example.com/project"  
-
-Project homepage or documentation URL.
+Human-readable summary.
 
 ### 4.3 Slot Object Fields
 
-#### 4.3.1 id (REQUIRED)
+Each entry describes one slot. The binary slot descriptor in the index (FEP-0001) is authoritative for offsets, sizes and the packed operation chain; this entry supplies the names and intent.
 
-**Type**: number  
-**Minimum**: 0  
-**Maximum**: 4294967295  
-**Example**: 0  
+#### 4.3.1 slot (REQUIRED)
 
-Unique slot identifier within the package. MUST be unique across all slots.
+**Type**: integer  
+**Minimum**: 0
 
-#### 4.3.2 name (REQUIRED)
+Index of the slot. Validates position: the entry at array position *n* has `slot` equal to *n*.
 
-**Type**: string  
-**Pattern**: `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`  
-**Max Length**: 255  
-**Example**: "python-runtime"  
-
-Human-readable slot name.
-
-#### 4.3.3 purpose (REQUIRED)
+#### 4.3.2 id (REQUIRED)
 
 **Type**: string  
-**Enum**: ["code", "data", "config", "media"]  
-**Example**: "code"  
+**Example**: `"payload"`
 
-Slot content classification:
-- `code`: Executable binaries or scripts
-- `data`: Application data files
-- `config`: Configuration files
-- `media`: Images, audio, video, or other media
+Identifier for the slot, unique within the package.
 
-#### 4.3.4 lifecycle (REQUIRED)
-
-**Type**: string  
-**Enum**: See table below  
-**Example**: "runtime"  
-
-| Value      | Description                              | Extraction Behavior           |
-|------------|------------------------------------------|-------------------------------|
-| init       | First run only, then removed            | Extract once, delete after    |
-| startup    | Extract at every startup                | Always extract fresh          |
-| runtime    | Extract on first use (default)          | Extract once, keep cached     |
-| shutdown   | Extract during cleanup                  | Extract at termination        |
-| cache      | Performance cache, can regenerate       | Extract if missing            |
-| temporary  | Remove after session ends               | Extract, delete at exit       |
-| lazy       | Load on-demand                          | Extract when accessed         |
-| eager      | Load immediately on startup             | Extract before execution      |
-| dev        | Development mode only                   | Extract if DEV flag set       |
-| config     | User-modifiable config files           | Extract if not present        |
-| platform   | Platform/OS specific content            | Extract if platform matches  |
-
-#### 4.3.5 operations (REQUIRED)
-
-**Type**: string  
-**Pattern**: See Section 7  
-**Example**: "tar.gz" or "tar|gzip"  
-
-Operation chain string describing transformations applied to slot data.
-
-#### 4.3.6 size (REQUIRED)
-
-**Type**: number  
-**Minimum**: 0  
-**Maximum**: 2^53-1 (JSON safe integer)  
-**Example**: 1048576  
-
-Size of slot data as stored in package (after operations applied).
-
-#### 4.3.7 original_size (OPTIONAL)
-
-**Type**: number  
-**Minimum**: 0  
-**Maximum**: 2^53-1  
-**Example**: 4194304  
-
-Original size before operations applied. If omitted, assumed equal to `size`.
-
-#### 4.3.8 checksum (REQUIRED)
+#### 4.3.3 source (REQUIRED)
 
 **Type**: string
-**Pattern**: `^[a-f0-9]{16}$`
-**Example**: "deadbeef01234567"
 
-SHA-256 hash of stored slot data (first 8 bytes) as 16-character hex string.
+Path the slot content was read from at build time. Provenance only; a reader MUST NOT resolve it. It records a path on the build machine and has no meaning on the machine running the package. MAY be empty for a slot the producer synthesised.
 
-#### 4.3.9 permissions (OPTIONAL)
+#### 4.3.4 target (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^[0-7]{3,4}$`  
-**Example**: "755" or "0644"  
+**Example**: `"data/payload.txt"`
 
-Unix-style permissions as octal string.
+Where the slot is written inside the workenv. Section 5.2.2 constrains the value.
 
-### 4.4 Build Object Fields
+#### 4.3.5 size (REQUIRED)
 
-#### 4.4.1 timestamp (OPTIONAL)
+**Type**: integer  
+**Minimum**: 0
 
-**Type**: number  
-**Example**: 1704067200  
+Size in bytes of the slot as stored — after any operations in the chain have been applied.
 
-Unix timestamp of package creation.
-
-#### 4.4.2 platform (OPTIONAL)
+#### 4.3.6 checksum (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^[a-z]+_[a-z0-9]+$`  
-**Example**: "linux_x86_64", "darwin_arm64", "windows_amd64"  
+**Example**: `"sha256:34c4e0f57a67a89825fd5e3c48e70c535ade2032de5ac3698fea31def5a13454"`
 
-Target platform identifier.
+Digest of the stored slot bytes, in `algorithm:hex` form.
 
-#### 4.4.3 builder (OPTIONAL)
-
-**Type**: string  
-**Max Length**: 255  
-**Example**: "flavorpack-0.1.0"  
-
-Tool and version used to create package.
-
-#### 4.4.4 source_hash (OPTIONAL)
+#### 4.3.7 operations (REQUIRED)
 
 **Type**: string  
-**Pattern**: `^[a-f0-9]{64}$`  
-**Example**: "abc123..."  
+**Examples**: `""`, `"gzip"`, `"tar|gzip"`, `"none"`
 
-SHA-256 hash of source code tree.
+The operation chain applied to the slot, as a descriptive label. The empty string and `"none"` both denote a slot stored verbatim.
 
-#### 4.4.5 reproducible (OPTIONAL)
+The authoritative chain is the packed operation codes in the binary slot descriptor (FEP-0001), registered in FEP-0003. A reader that extracts slots MUST use the packed codes. This field is for display.
+
+#### 4.3.8 purpose (REQUIRED)
+
+**Type**: string
+
+What the slot holds. Producers use `code`, `data`, `config` and `media`; readers accept any string.
+
+#### 4.3.9 lifecycle (REQUIRED)
+
+**Type**: string
+
+When the slot is extracted and how long it survives. Producers use the values below; readers accept any string.
+
+| Value | Meaning |
+|-------|---------|
+| `runtime` | Extract on first use, keep cached |
+| `startup` | Extract fresh at every start |
+| `init` | Extract once, remove after first run |
+| `eager` | Extract before execution begins |
+| `lazy` | Extract when first accessed |
+| `cache` | Regenerable; extract if missing |
+| `temporary` | Remove when the session ends |
+| `attestation` | Attestation payload (FEP-0004) |
+
+#### 4.3.10 permissions (OPTIONAL)
+
+**Type**: string or null  
+**Example**: `"0644"`
+
+Unix mode for the extracted file, as a quoted octal string. `null` and absence both mean the reader chooses. Ignored on platforms without Unix modes.
+
+#### 4.3.11 resolution (OPTIONAL)
+
+**Type**: string  
+**Values**: `"build"`, `"runtime"`, `"lazy"`
+
+When the slot content was or will be resolved.
+
+#### 4.3.12 self_ref (OPTIONAL)
+
+**Type**: boolean
+
+True when the slot refers to the launcher binary itself rather than to separate stored bytes.
+
+### 4.4 Execution Object Fields
+
+#### 4.4.1 command (REQUIRED)
+
+**Type**: string  
+**Example**: `"{workenv}/bin/app --config {workenv}/etc/app.conf"`
+
+The command line the launcher runs after extraction. Placeholders are substituted first:
+
+| Placeholder | Substitution |
+|-------------|--------------|
+| `{workenv}` | Absolute path of the workenv directory |
+| `{slot:N}` | Extracted path of slot *N* |
+
+#### 4.4.2 primary_slot (OPTIONAL)
+
+**Type**: integer  
+**Default**: `0`  
+**Minimum**: 0
+
+Index of the slot the package treats as its principal content. Absence is equivalent to `0`.
+
+#### 4.4.3 env (OPTIONAL)
+
+**Type**: object, string values  
+**Default**: `{}`  
+**Example**: `{"MODE": "prod"}`
+
+Environment variables set for the command. Values MAY contain the placeholders listed in §4.4.1.
+
+`env` is the key. A reader MUST read the environment from it.
+
+### 4.5 Verification Object Fields
+
+#### 4.5.1 integrity_seal (REQUIRED within `verification`)
+
+**Type**: object
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `required` | boolean | Yes | Whether the seal must be present and valid |
+| `algorithm` | string | Yes | Signature algorithm, e.g. `"ed25519"` |
+
+Declares the package's integrity seal. The seal itself lives in the index (FEP-0001); verifying it is specified by FEP-0004.
+
+This object states what the package asks of a reader. It is not evidence: a reader MUST NOT treat `required: true` or `signed: true` as showing that a valid signature exists. Only checking the seal in the index shows that.
+
+#### 4.5.2 signed (OPTIONAL)
 
 **Type**: boolean  
-**Example**: true  
+**Default**: `false`
 
-Whether package was built reproducibly.
+Whether the producer signed the package.
 
-### 4.5 Execution Object Fields
+#### 4.5.3 require_verification (OPTIONAL)
 
-#### 4.5.1 entry_point (OPTIONAL)
+**Type**: boolean  
+**Default**: `true`
 
-**Type**: string  
-**Max Length**: 4096  
-**Example**: "./bin/app"  
+Whether a launcher refuses to run the package when verification fails.
 
-Path to main executable within extracted package.
+#### 4.5.4 trust_signatures (OPTIONAL)
 
-#### 4.5.2 args (OPTIONAL)
+**Type**: object
 
-**Type**: array of strings  
-**Max Items**: 1024  
-**Example**: ["--config", "app.conf"]  
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `required` | boolean | Yes | Whether a trusted signature must be present |
+| `signers` | array | No | Accepted signers; defaults to `[]` |
 
-Default command-line arguments.
+Each entry of `signers`:
 
-#### 4.5.3 env (OPTIONAL)
+| Field | Type | Required |
+|-------|------|----------|
+| `name` | string | Yes |
+| `key_id` | string | Yes |
+| `algorithm` | string | Yes |
 
-**Type**: object  
-**Max Properties**: 1024  
-**Example**: {"PATH": "/app/bin:$PATH"}  
+### 4.6 Build Object Fields
 
-Environment variables to set. Values MAY contain variable references.
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `tool` | string | Yes | Producer name, e.g. `"flavor-rs"` |
+| `tool_version` | string | Yes | Producer version |
+| `timestamp` | string | Yes | RFC3339 build time |
+| `deterministic` | boolean | No | Defaults to `false` |
+| `platform` | object | Yes | Build platform |
 
-#### 4.5.4 working_directory (OPTIONAL)
+`platform`:
 
-**Type**: string  
-**Default**: "."  
-**Example**: "./data"  
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `os` | string | Yes | Build operating system |
+| `arch` | string | Yes | Build architecture |
+| `host` | string | No | Build host identity |
 
-Working directory for execution relative to extraction root.
+`host` names the machine that built the package. Producers write it only when `FLAVOR_INCLUDE_BUILD_HOST=1` is set, since it is an identifier a package need not carry. See §12.3.
+
+The values of `os` and `arch` are producer-defined strings and are not comparable between producers. See §9.3.
+
+### 4.7 Launcher Object Fields
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `tool` | string | Yes | Launcher implementation name |
+| `tool_version` | string | Yes | Launcher version |
+| `size` | integer | Yes | Launcher size in bytes |
+| `checksum` | string | Yes | Digest of the launcher bytes, `algorithm:hex` |
+| `capabilities` | array of strings | Yes | Capability names, e.g. `["mmap", "signed"]` |
+
+`size` MUST equal the launcher size recorded in the index (FEP-0001), which is the value verification uses.
+
+### 4.8 Compatibility Object Fields
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `min_format_version` | string | Yes | Lowest format version that can read the package |
+| `features` | array of strings | Yes | Feature names a reader needs; MAY be empty |
+
+### 4.9 Cache Validation Object Fields
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `check_file` | string | Yes | Path within the workenv to read |
+| `expected_content` | string | No | Content that marks the workenv current |
+
+A launcher reads `check_file` in an existing workenv and re-extracts when the content does not match.
+
+### 4.10 Runtime Object Fields
+
+**Type**: object with a single OPTIONAL member, `env`.
+
+`runtime.env` directs how the launcher builds the environment of the command, distinct from `execution.env`, which only adds variables:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `set` | object | Variables to set, overriding any inherited value |
+| `map` | object | Variables to rename, mapping source name to target name |
+| `unset` | array of strings | Variables to remove |
+| `pass` | array of strings | Variables to inherit; others are dropped |
+
+All four are OPTIONAL.
+
+### 4.11 Workenv Object Fields
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `directories` | array of objects | No | Directories to create before extraction |
+| `env` | object | No | Environment variables scoped to the workenv |
+
+Each entry of `directories`:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `path` | string | Yes | Directory path, MAY contain `{workenv}` |
+| `mode` | string | No | Octal mode, e.g. `"0700"` |
 
 ## 5. Validation Rules
 
 ### 5.1 Structural Validation
 
-The JSON document MUST:
-1. Be valid JSON according to [RFC7159]
-2. Have a single root object
-3. Include all required fields
-4. Not exceed 10MB when uncompressed
-5. Use UTF-8 encoding without BOM
+The stored document MUST:
+
+1. Be valid JSON per [RFC7159]
+2. Have a single object at its root
+3. Contain every REQUIRED field
+4. Be UTF-8 without a byte order mark
+5. Not exceed 10 MB when decompressed
 
 ### 5.2 Semantic Validation
 
 #### 5.2.1 Slot Validation
 
-- Slot IDs MUST be unique within the package
-- Slot names SHOULD be unique (warning if not)
-- Slot checksums MUST be exactly 8 hex characters
-- Operations strings MUST use only supported operations
+1. `slots[n].slot` MUST equal *n*
+2. `slots[].id` MUST be unique within the package
+3. The length of `slots` MUST equal the slot count in the index
+4. `slots[].size` MUST equal the size in the corresponding slot descriptor
+5. `slots[].checksum` MUST match the digest of the stored slot bytes
+
+Items 3 to 5 compare this document against the index. A mismatch means the two disagree about the same package and the reader MUST reject it.
 
 #### 5.2.2 Path Validation
 
-All path strings MUST:
-- Use forward slashes as separators
-- Not contain ".." components
-- Not begin with "/" (relative paths only)
-- Not contain null bytes
-- Be valid UTF-8
+`slots[].target` and `workenv.directories[].path` MUST NOT:
+
+1. Be absolute after placeholder substitution
+2. Contain a `..` component
+3. Resolve outside the workenv root
+4. Contain a NUL byte
+
+A reader MUST check these after substitution, not before: a placeholder can expand into a traversal.
 
 #### 5.2.3 Cross-Reference Validation
 
-- `slot.size` MUST match actual slot data size in package
-- `slot.checksum` MUST match computed Adler-32 of slot data
-- `execution.entry_point` SHOULD reference an extracted file
+1. `execution.primary_slot`, when it names a slot, MUST be a valid index into `slots`
+2. `{slot:N}` in `execution.command` MUST name a valid index
+3. `launcher.size` MUST equal the launcher size in the index
 
-### 5.3 Extension Field Validation
+### 5.3 Unknown Field Handling
 
-Extension fields in the `extensions` object:
-- MUST begin with "x-" prefix
-- MAY contain any valid JSON value
-- SHOULD use lowercase names with hyphens
-- MUST NOT conflict with standard fields
+A reader MUST ignore members it does not recognise, at every level. This is what lets a package written by a newer producer stay readable.
 
-## 6. Encoding and Serialization
+## 6. Encoding and Storage
 
-### 6.1 JSON Encoding Rules
+### 6.1 JSON Encoding
 
-Metadata MUST be encoded as:
-- UTF-8 without byte order mark (BOM)
-- No trailing whitespace
-- No comments (not valid JSON)
-- Unix line endings (LF, not CRLF)
+The document MUST be encoded as:
 
-### 6.2 Canonical Form
+- UTF-8, no byte order mark
+- No comments
+- LF line endings where any are present
 
-For signature verification, metadata MUST be normalized to canonical form:
+Producers write the document compactly, without indentation.
 
-1. **Object Key Ordering**: All object keys MUST be sorted lexicographically
-2. **Whitespace**: No unnecessary whitespace (compact form)
-3. **Number Format**: No leading zeros, no trailing decimal points
-4. **String Escaping**: Minimal escaping (only required characters)
-5. **Unicode Normalization**: NFC normalization for all strings
+### 6.2 Compression
 
-Canonical encoding:
-```
-jsonCanonical = json.dumps(
-    metadata,
-    separators=(',', ':'),
-    sort_keys=True,
-    ensure_ascii=False
-)
-```
+The document is gzip-compressed before storage. The compressed bytes are the metadata archive, and they begin with the gzip magic `1f 8b`. A reader detects that magic and decompresses; a document stored without compression is read as-is.
 
-### 6.3 Compression
+### 6.3 Integrity
 
-When stored in packages, metadata SHOULD be compressed using GZIP with:
-- Compression level: 9 (best compression)
-- No embedded filename or timestamp
-- CRC32 verification enabled
+The index records `metadata_checksum`, the SHA-256 of the **stored archive bytes** — the gzip-compressed form, exactly as it sits in the file.
 
-## 7. ABNF Grammar
+A reader verifying the metadata MUST hash the stored bytes. It MUST NOT re-serialise the document, re-order keys, or re-compress it before hashing: gzip output is not reproducible across compressors and JSON serialisation is not reproducible across languages, so any of those produces a digest that does not match.
 
-### 7.1 Operation String Grammar
+The Ed25519 integrity seal covers the index, which carries this checksum. The metadata is therefore sealed through the index rather than signed directly.
+
+## 7. Identifier and Version Grammar
+
+The grammars here describe what producers generate. Readers accept any string, so a document that departs from them is still readable; a producer SHOULD follow them.
+
+### 7.1 Package Name
 
 ```abnf
-operation-string = simple-op / compound-op / pipe-chain
+package-name = name-start *name-char
 
-simple-op = "raw" / "gzip" / "bzip2" / "xz" / "zstd" / "tar"
+name-start = LOWER / DIGIT
+name-char  = LOWER / DIGIT / "-" / "_"
 
-compound-op = "tar.gz" / "tar.bz2" / "tar.xz" / "tar.zst" /
-              "tgz" / "tbz2" / "txz"
-
-pipe-chain = operation 1*( "|" operation )
-
-operation = ALPHA 1*( ALPHA / DIGIT / "_" )
-
-ALPHA = %x41-5A / %x61-7A  ; A-Z / a-z
-DIGIT = %x30-39            ; 0-9
+LOWER = %x61-7A  ; a-z
+DIGIT = %x30-39  ; 0-9
 ```
 
-### 7.2 Version String Grammar
+### 7.2 Version String
 
 ```abnf
 version = major [ "." minor [ "." patch ] ] [ prerelease ] [ build ]
@@ -578,652 +688,376 @@ minor = 1*DIGIT
 patch = 1*DIGIT
 
 prerelease = "-" 1*prerelease-char
-build = "+" 1*build-char
+build      = "+" 1*build-char
 
 prerelease-char = ALPHA / DIGIT / "-" / "."
-build-char = ALPHA / DIGIT / "-" / "."
+build-char      = ALPHA / DIGIT / "-" / "."
 ```
 
-### 7.3 Identifier Grammar
+### 7.3 Slot Identifier
 
 ```abnf
-identifier = identifier-start *identifier-char
+slot-id = slot-id-start *slot-id-char
 
-identifier-start = LOWER / DIGIT
-identifier-char = LOWER / DIGIT / "-" / "_"
-
-LOWER = %x61-7A  ; a-z
+slot-id-start = LOWER / DIGIT / "_"
+slot-id-char  = LOWER / DIGIT / "-" / "_"
 ```
+
+A leading underscore marks a slot the producer synthesised rather than one the caller supplied. `_attestation` (FEP-0004) is the one in use.
+
+### 7.4 Checksum
+
+```abnf
+checksum  = algorithm ":" hex
+algorithm = 1*( LOWER / DIGIT )
+hex       = 1*HEXDIG
+```
+
+The prefix appears exactly once. `"sha256:sha256:…"` is malformed. See §9.4.
 
 ## 8. JSON Schema Definition
 
-### 8.1 Complete JSON Schema
+The schema below is satisfied by every package in `tests/fixtures/format_compat/`, which covers all three producers.
+
+`additionalProperties` is not constrained: §5.3 requires readers to tolerate unknown members, and a schema that forbade them would reject documents this specification requires readers to accept.
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pspf.io/schemas/2025.0.0/metadata.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provide.io/schemas/pspf-2025/metadata.json",
   "title": "PSPF/2025 Package Metadata",
   "type": "object",
-  "required": ["format_version", "package", "slots"],
-  "additionalProperties": false,
+  "required": ["format", "package", "slots"],
   "properties": {
-    "format_version": {
-      "type": "string",
-      "const": "2025.0.0"
-    },
+    "format": { "type": "string", "const": "PSPF/2025" },
+    "format_version": { "type": "string" },
     "package": {
       "type": "object",
       "required": ["name", "version"],
-      "additionalProperties": false,
       "properties": {
-        "name": {
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9_-]*$",
-          "minLength": 1,
-          "maxLength": 255
-        },
-        "version": {
-          "type": "string",
-          "pattern": "^[0-9]+(\\.[0-9]+)*([+-].+)?$",
-          "maxLength": 255
-        },
-        "description": {
-          "type": "string",
-          "maxLength": 4096
-        },
-        "author": {
-          "type": "string",
-          "maxLength": 255
-        },
-        "license": {
-          "type": "string",
-          "maxLength": 255
-        },
-        "homepage": {
-          "type": "string",
-          "format": "uri",
-          "maxLength": 2048
-        }
-      }
-    },
-    "build": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "timestamp": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "platform": {
-          "type": "string",
-          "pattern": "^[a-z]+_[a-z0-9]+$"
-        },
-        "builder": {
-          "type": "string",
-          "maxLength": 255
-        },
-        "source_hash": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$"
-        },
-        "reproducible": {
-          "type": "boolean"
-        }
+        "name": { "type": "string", "minLength": 1, "maxLength": 255 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 255 },
+        "description": { "type": "string" }
       }
     },
     "slots": {
       "type": "array",
-      "minItems": 0,
       "maxItems": 65535,
       "items": {
         "type": "object",
-        "required": ["id", "name", "purpose", "lifecycle", "operations", "size", "checksum"],
-        "additionalProperties": false,
+        "required": [
+          "slot", "id", "source", "target",
+          "size", "checksum", "operations", "purpose", "lifecycle"
+        ],
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 4294967295
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
-            "maxLength": 255
-          },
-          "purpose": {
-            "type": "string",
-            "enum": ["code", "data", "config", "media"]
-          },
-          "lifecycle": {
-            "type": "string",
-            "enum": ["init", "startup", "runtime", "shutdown", "cache", 
-                     "temporary", "lazy", "eager", "dev", "config", "platform"]
-          },
-          "operations": {
-            "type": "string",
-            "pattern": "^(raw|gzip|bzip2|xz|zstd|tar|tar\\.gz|tar\\.bz2|tar\\.xz|tar\\.zst|tgz|tbz2|txz|([a-z]+)(\\|[a-z]+)*)$"
-          },
-          "size": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
-          },
-          "original_size": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
-          },
-          "checksum": {
-            "type": "string",
-            "pattern": "^[a-f0-9]{16}$"
-          },
-          "permissions": {
-            "type": "string",
-            "pattern": "^[0-7]{3,4}$"
-          }
+          "slot": { "type": "integer", "minimum": 0 },
+          "id": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "source": { "type": "string", "maxLength": 4096 },
+          "target": { "type": "string", "maxLength": 4096 },
+          "size": { "type": "integer", "minimum": 0 },
+          "checksum": { "type": "string", "pattern": "^[a-z0-9]+:[0-9a-fA-F]+$|^[0-9a-fA-F]+$" },
+          "operations": { "type": "string" },
+          "purpose": { "type": "string" },
+          "lifecycle": { "type": "string" },
+          "permissions": { "type": ["string", "null"] },
+          "resolution": { "type": "string", "enum": ["build", "runtime", "lazy"] },
+          "self_ref": { "type": "boolean" }
         }
       }
     },
     "execution": {
       "type": "object",
-      "additionalProperties": false,
+      "required": ["command"],
       "properties": {
-        "entry_point": {
-          "type": "string",
-          "maxLength": 4096
-        },
-        "args": {
-          "type": "array",
-          "maxItems": 1024,
-          "items": {
-            "type": "string"
+        "primary_slot": { "type": "integer", "minimum": 0 },
+        "command": { "type": "string", "maxLength": 65535 },
+        "env": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "required": ["integrity_seal"],
+      "properties": {
+        "integrity_seal": {
+          "type": "object",
+          "required": ["required", "algorithm"],
+          "properties": {
+            "required": { "type": "boolean" },
+            "algorithm": { "type": "string" }
           }
         },
+        "signed": { "type": "boolean" },
+        "require_verification": { "type": "boolean" },
+        "trust_signatures": {
+          "type": "object",
+          "required": ["required"],
+          "properties": {
+            "required": { "type": "boolean" },
+            "signers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "key_id", "algorithm"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "key_id": { "type": "string" },
+                  "algorithm": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "build": {
+      "type": "object",
+      "required": ["tool", "tool_version", "timestamp", "platform"],
+      "properties": {
+        "tool": { "type": "string" },
+        "tool_version": { "type": "string" },
+        "timestamp": { "type": "string" },
+        "deterministic": { "type": "boolean" },
+        "platform": {
+          "type": "object",
+          "required": ["os", "arch"],
+          "properties": {
+            "os": { "type": "string" },
+            "arch": { "type": "string" },
+            "host": { "type": "string" }
+          }
+        }
+      }
+    },
+    "launcher": {
+      "type": "object",
+      "required": ["tool", "tool_version", "size", "checksum", "capabilities"],
+      "properties": {
+        "tool": { "type": "string" },
+        "tool_version": { "type": "string" },
+        "size": { "type": "integer", "minimum": 0 },
+        "checksum": { "type": "string" },
+        "capabilities": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "required": ["min_format_version", "features"],
+      "properties": {
+        "min_format_version": { "type": "string" },
+        "features": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "cache_validation": {
+      "type": "object",
+      "required": ["check_file"],
+      "properties": {
+        "check_file": { "type": "string" },
+        "expected_content": { "type": "string" }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "properties": {
         "env": {
           "type": "object",
-          "maxProperties": 1024,
-          "additionalProperties": {
-            "type": "string"
+          "properties": {
+            "set": { "type": "object", "additionalProperties": { "type": "string" } },
+            "map": { "type": "object", "additionalProperties": { "type": "string" } },
+            "unset": { "type": "array", "items": { "type": "string" } },
+            "pass": { "type": "array", "items": { "type": "string" } }
           }
-        },
-        "working_directory": {
-          "type": "string",
-          "maxLength": 4096
         }
       }
     },
-    "dependencies": {
+    "workenv": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
-        "runtime": {
+        "directories": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+              "path": { "type": "string" },
+              "mode": { "type": "string" }
+            }
           }
         },
-        "optional": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
+        "env": { "type": "object", "additionalProperties": { "type": "string" } }
       }
     },
-    "extensions": {
-      "type": "object",
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    }
+    "setup_commands": { "type": "array" },
+    "policy": { "type": "object" }
   }
 }
 ```
 
-## 9. Processing Algorithms
+## 9. Producer Variation
 
-### 9.1 Metadata Parsing Algorithm
+The three implementations do not agree on everything. Each item below is a difference a reader encounters in packages that exist, with the issue tracking it. A producer aiming for packages every implementation can read should follow the guidance in each.
 
-```
-function parseMetadata(jsonBytes):
-    // 1. Decode UTF-8
-    text = utf8Decode(jsonBytes)
-    if error:
-        return ERROR_INVALID_ENCODING
-    
-    // 2. Parse JSON
-    try:
-        metadata = jsonParse(text)
-    catch:
-        return ERROR_INVALID_JSON
-    
-    // 3. Validate against schema
-    if not validateSchema(metadata, PSPF_SCHEMA):
-        return ERROR_SCHEMA_VIOLATION
-    
-    // 4. Check format version
-    if metadata.format_version != "2025.0.0":
-        return ERROR_UNSUPPORTED_VERSION
-    
-    // 5. Validate semantic constraints
-    if not validateSemantics(metadata):
-        return ERROR_SEMANTIC_VIOLATION
-    
-    return metadata
-```
+### 9.1 The execution block
 
-### 9.2 Canonical Form Algorithm
+`flavor-go` declares `execution` optional and refuses at the point of execution when it is missing. `flavor-python` behaves the same way. `flavor-rs` requires the object to parse the document at all, so a package without one cannot be inspected or verified by it, only rejected.
 
-```
-function canonicalize(metadata):
-    // 1. Deep copy to avoid mutation
-    canonical = deepCopy(metadata)
-    
-    // 2. Sort all object keys recursively
-    canonical = sortKeysRecursive(canonical)
-    
-    // 3. Normalize numbers
-    canonical = normalizeNumbers(canonical)
-    
-    // 4. Normalize Unicode strings to NFC
-    canonical = normalizeUnicode(canonical)
-    
-    // 5. Serialize with minimal whitespace
-    json = JSON.stringify(canonical, null, 0)
-    
-    // 6. Ensure consistent separators
-    json = json.replace(/: /g, ':')
-    json = json.replace(/, /g, ',')
-    
-    return json
-```
+Tracked in provide-io/flavorpack#48. Until it closes, write `execution`.
 
-### 9.3 Checksum Verification Algorithm
+### 9.2 format_version
+
+`flavor-rs` and `flavor-python` write `"1.0.0"`. `flavor-go` writes the empty string.
+
+A reader MUST NOT depend on this field to decide how to parse. `format` identifies the format; `compatibility.min_format_version` states the requirement.
+
+### 9.3 Platform naming
+
+`build.platform` records the build machine in each producer's own vocabulary. On the same Apple Silicon host:
+
+| Producer | `os` | `arch` |
+|----------|------|--------|
+| `flavor-rs` | `macos` | `aarch64` |
+| `flavor-go` | `darwin` | `arm64` |
+| `flavor-python` | `darwin` | `arm64` |
+
+The pairs name the same platform. A reader MUST NOT compare these values across producers or use them to decide whether a package will run.
+
+### 9.4 Checksum prefixes
+
+`launcher.checksum` written by `flavor-python` carries the algorithm prefix twice — `"sha256:sha256:02b2…"`. The digest after the second prefix is correct.
+
+A reader parsing a checksum should strip the algorithm prefix repeatedly rather than once. Tracked in provide-io/flavorpack#49.
+
+### 9.5 Target paths
+
+`flavor-python` writes `slots[].target` with an explicit `{workenv}/` prefix; `flavor-rs` and `flavor-go` write a path relative to the workenv with no prefix. Both denote the same location. A reader MUST accept either, and MUST apply §5.2.2 after substitution.
+
+## 10. Processing Algorithms
+
+### 10.1 Reading
 
 ```
-function verifyMetadataChecksum(metadata, expectedHash):
-    // 1. Canonicalize metadata
-    canonical = canonicalize(metadata)
-    
-    // 2. Encode to UTF-8
-    bytes = utf8Encode(canonical)
-    
-    // 3. Compute SHA-256
-    computedHash = sha256(bytes)
-    
-    // 4. Compare hashes
-    return constantTimeEqual(computedHash, expectedHash)
+1. Read the index from the magic trailer                    (FEP-0001)
+2. Read metadata_offset and metadata_size from the index
+3. Read that many bytes at that offset                       -> archive
+4. If archive begins with 1f 8b, gunzip it                   -> document
+5. Parse the document as UTF-8 JSON
+6. Apply the structural validation of §5.1
+7. Apply the semantic validation of §5.2
 ```
 
-## 10. Error Handling
+Step 6 precedes step 7 because the cross-checks in §5.2 read fields that §5.1 has not yet shown to exist.
 
-### 10.1 Error Codes
+### 10.2 Verifying
 
-```c
-// JSON Errors (1000-1099)
-#define ERROR_INVALID_ENCODING      1000
-#define ERROR_INVALID_JSON          1001
-#define ERROR_SCHEMA_VIOLATION      1002
-#define ERROR_UNSUPPORTED_VERSION   1003
-#define ERROR_SEMANTIC_VIOLATION    1004
-
-// Field Errors (1100-1199)
-#define ERROR_MISSING_REQUIRED      1100
-#define ERROR_INVALID_TYPE          1101
-#define ERROR_INVALID_PATTERN       1102
-#define ERROR_INVALID_ENUM          1103
-#define ERROR_OUT_OF_RANGE          1104
-
-// Slot Errors (1200-1299)
-#define ERROR_DUPLICATE_SLOT_ID     1200
-#define ERROR_INVALID_OPERATIONS    1201
-#define ERROR_CHECKSUM_MISMATCH     1202
-#define ERROR_SIZE_MISMATCH         1203
-
-// Path Errors (1300-1399)
-#define ERROR_PATH_TRAVERSAL        1300
-#define ERROR_INVALID_PATH          1301
-#define ERROR_ABSOLUTE_PATH         1302
+```
+1. archive <- the stored metadata bytes, before decompression
+2. digest  <- SHA-256(archive)
+3. Compare against index.metadata_checksum
 ```
 
-### 10.2 Error Recovery
+The comparison is over the stored bytes. See §6.3.
 
-Implementations SHOULD attempt graceful degradation:
+### 10.3 Extracting
 
-1. **Missing Optional Fields**: Use defaults where sensible
-2. **Unknown Extension Fields**: Ignore "x-" prefixed fields
-3. **Version Mismatch**: Attempt compatibility if minor version
-4. **Encoding Issues**: Try alternative encodings (UTF-16, Latin-1)
+```
+For each entry of slots, in order:
+  1. Find the matching slot descriptor in the index
+  2. Read the stored bytes for that descriptor
+  3. Verify them against slots[].checksum
+  4. Apply the inverse of the packed operation chain    (FEP-0003)
+  5. Substitute placeholders in slots[].target
+  6. Validate the result per §5.2.2
+  7. Write the file and apply slots[].permissions
+```
 
-### 10.3 Diagnostic Output
+Step 4 uses the packed codes in the descriptor, not the `operations` string (§4.3.7). Step 6 follows step 5, never precedes it.
 
-Error messages MUST include:
-- Error code
-- Field path (e.g., "slots[2].checksum")
-- Expected vs actual values
-- Line/column number if available
+## 11. Error Handling
 
-Example:
+| Condition | Reader behaviour |
+|-----------|------------------|
+| Archive will not decompress | Reject the package |
+| Document is not valid JSON | Reject the package |
+| A REQUIRED field is absent | Reject the package |
+| Slot count disagrees with the index | Reject the package |
+| A slot checksum does not match | Reject the package |
+| A target path fails §5.2.2 | Reject the package |
+| `execution` absent | Read and report normally; refuse to run |
+| `command` absent or empty | Read and report normally; refuse to run |
+| An unrecognised member is present | Ignore it and continue |
+
+Rejecting means refusing every operation on the package. Refusing to run means inspection and verification still work, and only execution fails. The distinction matters: a package that cannot run is exactly one an operator wants to be able to inspect.
+
+## 12. Security Considerations
+
+### 12.1 The metadata is not evidence
+
+Every field in `verification` is a claim the package makes about itself, written by whoever built it. A reader MUST establish that a package is signed by checking the seal in the index, never by reading `verification.signed`.
+
+### 12.2 Path traversal
+
+`slots[].target` and `workenv.directories[].path` become filesystem paths. They arrive from the package, so an attacker who can write a package controls them. §5.2.2 applies to every one, after substitution.
+
+### 12.3 What the document discloses
+
+The document travels with the package and is readable by anyone holding it, without verification and without extraction.
+
+`slots[].source` records build-machine paths, which can carry usernames and directory layout. `build.platform.host` names the build machine; producers write it only under `FLAVOR_INCLUDE_BUILD_HOST=1` for that reason. `execution.env` and `workenv.env` are stored in the clear and MUST NOT carry secrets.
+
+### 12.4 Size limits
+
+A reader MUST bound the decompressed document (§5.1) before parsing it. The archive is compressed, so a small package can carry a document that expands without limit.
+
+## 13. Implementation Requirements
+
+A conforming reader MUST:
+
+1. Parse a document containing only the REQUIRED fields
+2. Ignore members it does not recognise (§5.3)
+3. Apply the defaults in Section 4 for absent OPTIONAL fields
+4. Verify the metadata against the stored bytes (§6.3)
+5. Validate every path after substitution (§5.2.2)
+6. Bound the decompressed size before parsing (§12.4)
+7. Read the package environment from `execution.env`
+8. Take the operation chain from the slot descriptor, not `operations`
+
+A conforming producer MUST:
+
+1. Write every REQUIRED field
+2. Write `format` as `"PSPF/2025"`
+3. Write `slots` in index order with `slot` matching position
+4. Write checksums as `algorithm:hex`, the prefix appearing once
+5. Write `execution`, until #48 closes (§9.1)
+6. Write the package environment under `env`
+
+## 14. Test Vectors
+
+The packages in `tests/fixtures/format_compat/v1/` are built once by each producer and committed. `rust.psp`, `go.psp` and `python.psp` carry the same payload and are signed with the same derived key, so a change that alters what a producer writes shows up as a difference between them.
+
+`tests/fixtures/format_compat/execution/omits-primary-slot.json` is a document that omits `primary_slot` and carries a non-empty `env`. Every implementation reads it, resolves `primary_slot` to `0`, and sees `MODE=prod`.
+
+The harnesses:
+
+- `tests/format_2025/test_format_compat.py`
+- `src/flavor-go/pkg/psp/format_2025/format_compat_test.go`
+- `src/flavor-rs/tests/format_compat.rs`
+
+A minimal conforming document:
+
 ```json
 {
-  "error": 1102,
-  "field": "slots[2].checksum",
-  "message": "Invalid pattern",
-  "expected": "^[a-f0-9]{8}$",
-  "actual": "DEADBEEF",
-  "line": 45,
-  "column": 23
+  "format": "PSPF/2025",
+  "package": {"name": "minimal", "version": "1.0.0"},
+  "slots": [],
+  "execution": {"command": "true"}
 }
 ```
 
-## 11. Security Considerations
+## 15. References
 
-### 11.1 Input Validation
-
-Implementations MUST protect against:
-
-**JSON Bombs**: Deeply nested structures or large expansions
-- Maximum nesting depth: 100 levels
-- Maximum string length: 10MB
-- Maximum array size: 65535 items
-- Maximum object properties: 10000
-
-**Resource Exhaustion**: 
-- Limit total metadata size to 10MB uncompressed
-- Timeout parsing after 5 seconds
-- Limit memory usage during parsing
-
-**Injection Attacks**:
-- Sanitize all strings before use in commands
-- Validate paths to prevent directory traversal
-- Escape special characters in environment variables
-
-### 11.2 Trust Boundaries
-
-Metadata is untrusted input until verified:
-
-1. Parse and validate structure
-2. Verify metadata checksum from index block
-3. Verify package signature
-4. Only then trust content
-
-### 11.3 Information Disclosure
-
-Sensitive information in metadata:
-- Build paths may reveal system layout
-- Environment variables may contain secrets
-- Source hashes may reveal proprietary code structure
-
-Implementations SHOULD:
-- Redact sensitive paths in logs
-- Not expose full metadata to untrusted code
-- Sanitize error messages
-
-## 12. Implementation Requirements
-
-### 12.1 Parser Requirements
-
-All implementations MUST:
-1. Accept any valid JSON according to schema
-2. Reject invalid JSON with appropriate errors
-3. Handle UTF-8, UTF-16, and UTF-32 encodings
-4. Support full Unicode range including emoji
-5. Parse numbers up to 2^53-1 accurately
-
-### 12.2 Cross-Language Compatibility
-
-#### Python Implementation
-```python
-import json
-import jsonschema
-from typing import Dict, Any
-
-def parse_metadata(data: bytes) -> Dict[str, Any]:
-    """Parse and validate PSPF metadata."""
-    text = data.decode('utf-8')
-    metadata = json.loads(text)
-    jsonschema.validate(metadata, PSPF_SCHEMA)
-    return metadata
-
-def canonicalize(metadata: Dict[str, Any]) -> bytes:
-    """Convert to canonical form."""
-    return json.dumps(
-        metadata,
-        separators=(',', ':'),
-        sort_keys=True,
-        ensure_ascii=False
-    ).encode('utf-8')
-```
-
-#### Go Implementation
-```go
-package pspf
-
-import (
-    "encoding/json"
-    "github.com/xeipuuv/gojsonschema"
-)
-
-type Metadata struct {
-    FormatVersion string   `json:"format_version"`
-    Package      Package  `json:"package"`
-    Slots        []Slot   `json:"slots"`
-    // ... other fields
-}
-
-func ParseMetadata(data []byte) (*Metadata, error) {
-    var meta Metadata
-    if err := json.Unmarshal(data, &meta); err != nil {
-        return nil, err
-    }
-    
-    // Validate against schema
-    result, err := ValidateSchema(meta)
-    if err != nil || !result.Valid() {
-        return nil, ErrSchemaViolation
-    }
-    
-    return &meta, nil
-}
-```
-
-#### Rust Implementation
-```rust
-use serde::{Deserialize, Serialize};
-use serde_json;
-use jsonschema;
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Metadata {
-    format_version: String,
-    package: Package,
-    slots: Vec<Slot>,
-    // ... other fields
-}
-
-fn parse_metadata(data: &[u8]) -> Result<Metadata, Error> {
-    let text = std::str::from_utf8(data)?;
-    let metadata: Metadata = serde_json::from_str(text)?;
-    
-    // Validate against schema
-    let schema = json!(PSPF_SCHEMA);
-    let compiled = jsonschema::JSONSchema::compile(&schema)?;
-    compiled.validate(&json!(metadata))?;
-    
-    Ok(metadata)
-}
-```
-
-### 12.3 Performance Requirements
-
-Implementations SHOULD meet these targets:
-
-- **Parsing**: < 10ms for 100KB metadata
-- **Validation**: < 5ms for schema validation
-- **Canonicalization**: < 2ms for typical metadata
-- **Memory Usage**: < 10x metadata size
-
-## 13. Test Vectors
-
-### 13.1 Minimal Valid Metadata
-
-**Input**:
-```json
-{
-  "format_version": "2025.0.0",
-  "package": {
-    "name": "test",
-    "version": "1.0.0"
-  },
-  "slots": []
-}
-```
-
-**Canonical Form** (hex):
-```
-7b22666f726d61745f76657273696f6e223a22323032352e302e30222c227061636b616765223a7b226e616d65223a2274657374222c2276657273696f6e223a22312e302e30227d2c22736c6f7473223a5b5d7d
-```
-
-**SHA-256**: `5f95b7cf2f47fc5b7866ea021fe51cea6bc3bbceb9d3eb87a1244bd8db576eb0`
-
-### 13.2 Complete Metadata Example
-
-**Input**:
-```json
-{
-  "format_version": "2025.0.0",
-  "package": {
-    "name": "example-app",
-    "version": "2.1.0-beta+build.123",
-    "description": "Example application",
-    "author": "PSPF Team",
-    "license": "MIT",
-    "homepage": "https://pspf.io"
-  },
-  "build": {
-    "timestamp": 1704067200,
-    "platform": "linux_x86_64",
-    "builder": "flavorpack-0.1.0",
-    "source_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-    "reproducible": true
-  },
-  "slots": [
-    {
-      "id": 0,
-      "name": "runtime",
-      "purpose": "code",
-      "lifecycle": "startup",
-      "operations": "tar.gz",
-      "size": 1048576,
-      "original_size": 4194304,
-      "checksum": "deadbeef",
-      "permissions": "755"
-    },
-    {
-      "id": 1,
-      "name": "config",
-      "purpose": "config",
-      "lifecycle": "config",
-      "operations": "gzip",
-      "size": 1024,
-      "checksum": "cafebabe"
-    }
-  ],
-  "execution": {
-    "entry_point": "./bin/app",
-    "args": ["--config", "/etc/app.conf"],
-    "env": {
-      "APP_HOME": "/opt/app",
-      "LOG_LEVEL": "info"
-    },
-    "working_directory": "."
-  },
-  "dependencies": {
-    "runtime": ["libc.so.6", "libssl.so.3"],
-    "optional": ["libcuda.so.12"]
-  },
-  "extensions": {
-    "x-vendor-signature": "xyz789",
-    "x-custom-field": {
-      "nested": "value"
-    }
-  }
-}
-```
-
-### 13.3 Invalid Examples
-
-**Duplicate Slot ID**:
-```json
-{
-  "format_version": "2025.0.0",
-  "package": {"name": "test", "version": "1.0.0"},
-  "slots": [
-    {"id": 0, "name": "slot1", ...},
-    {"id": 0, "name": "slot2", ...}  // ERROR: Duplicate ID
-  ]
-}
-```
-Expected Error: `ERROR_DUPLICATE_SLOT_ID (1200)`
-
-**Invalid Operation String**:
-```json
-{
-  "format_version": "2025.0.0",
-  "package": {"name": "test", "version": "1.0.0"},
-  "slots": [{
-    "id": 0,
-    "operations": "invalid|operation",  // ERROR: Unknown operation
-    ...
-  }]
-}
-```
-Expected Error: `ERROR_INVALID_OPERATIONS (1201)`
-
-**Path Traversal Attempt**:
-```json
-{
-  "execution": {
-    "entry_point": "../../etc/passwd"  // ERROR: Path traversal
-  }
-}
-```
-Expected Error: `ERROR_PATH_TRAVERSAL (1300)`
-
-## 14. References
-
-### 14.1 Normative References
-
-[RFC2119](https://www.rfc-editor.org/rfc/rfc2119.html) Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
-
-[RFC8174](https://www.rfc-editor.org/rfc/rfc8174.html) Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017.
-
-[RFC7159] Bray, T., Ed., "The JavaScript Object Notation (JSON) Data Interchange Format", RFC 7159, March 2014.
-
-[RFC5234] Crocker, D., Ed., and P. Overell, "Augmented BNF for Syntax Specifications: ABNF", STD 68, RFC 5234, January 2008.
-
-[RFC4627] Crockford, D., "The application/json Media Type for JavaScript Object Notation (JSON)", RFC 4627, July 2006.
-
-### 14.2 Informative References
-
-[FEP-0001] "PSPF/2025 Core Format & Operation Chains Specification", FEP-0001, January 2025.
-
-[FEP-0003] "PSPF/2025 Operation Registry and Allocation Policy", FEP-0003, January 2025.
-
-[JSON-SCHEMA] "JSON Schema: A Media Type for Describing JSON Documents", draft-handrews-json-schema-02, September 2019.
-
-[SEMVER] Preston-Werner, T., "Semantic Versioning 2.0.0", https://semver.org/spec/v2.0.0.html
-
-[SPDX] "Software Package Data Exchange (SPDX) Specification", https://spdx.org/specifications
-
----
-
-**Authors' Addresses**
-
-[Author contact information]
-
-**Copyright Notice**
-
-Copyright (c) 2025 IETF Trust and the persons identified as the document authors. All rights reserved.
+- [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
+- [RFC7159] Bray, T., "The JavaScript Object Notation (JSON) Data Interchange Format", RFC 7159, March 2014.
+- [RFC3339] Klyne, G. and C. Newman, "Date and Time on the Internet: Timestamps", RFC 3339, July 2002.
+- [RFC1952] Deutsch, P., "GZIP file format specification version 4.3", RFC 1952, May 1996.
+- [FEP-0001] PSPF/2025 Core Format and Operation Chains
+- [FEP-0003] PSPF/2025 Operation Registry
+- [FEP-0004] PSPF/2025 Security Attestation Extension

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dev = [
     # protobuf is included via provide-testkit[all]>=0.4.0 on non-Windows; add explicitly for Windows
     "protobuf>=4.0; sys_platform == 'win32'",
     "hypothesis>=6.0",
+    # Validates the JSON Schema in FEP-0002 against the committed fixtures
+    "jsonschema>=4.0",
+    "types-jsonschema>=4.0",
 ]
 docs = [
     "provide-testkit[docs]>=0.4.0",

--- a/tests/format_2025/test_fep0002_schema.py
+++ b/tests/format_2025/test_fep0002_schema.py
@@ -1,0 +1,157 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Check FEP-0002's JSON Schema against the packages the builders produce.
+
+FEP-0002 §8 publishes a schema and claims every package in
+tests/fixtures/format_compat/ satisfies it. A specification whose schema nobody
+runs describes whatever it described on the day it was written, so this runs it:
+the schema is read out of the document itself, and the fixtures are read out of
+the packages, and the two have to agree.
+
+The fixtures are built once by each of the three implementations and committed,
+so a producer that starts writing something else fails here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from flavor.psp.format_2025 import PSPFReader
+
+pytestmark = [
+    pytest.mark.cross_language,
+    pytest.mark.packaging,
+    pytest.mark.ci,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = REPO_ROOT / "docs" / "reference" / "spec" / "fep-0002-json-metadata-format.md"
+FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "format_compat"
+FIXTURE_NAMES = ("rust.psp", "go.psp", "python.psp")
+
+
+def _schema() -> dict[str, Any]:
+    """Extract the published schema from FEP-0002 §8."""
+    blocks = re.findall(r"```json\n(\{.*?\n\})\n```", SPEC.read_text(encoding="utf-8"), re.S)
+    for block in blocks:
+        candidate: dict[str, Any] = json.loads(block)
+        if "$schema" in candidate:
+            return candidate
+    pytest.fail("FEP-0002 §8 has no JSON Schema block")
+
+
+SCHEMA = _schema()
+
+
+def test_published_schema_is_well_formed() -> None:
+    """The schema in the specification is a valid Draft 2020-12 schema."""
+    Draft202012Validator.check_schema(SCHEMA)
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_committed_packages_satisfy_the_published_schema(name: str) -> None:
+    """Each producer's package validates against FEP-0002 §8."""
+    with PSPFReader(FIXTURE_ROOT / "v1" / name) as reader:
+        document = reader.read_metadata()
+
+    errors = sorted(Draft202012Validator(SCHEMA).iter_errors(document), key=lambda e: list(e.path))
+    assert not errors, "\n".join(f"{list(e.path)}: {e.message}" for e in errors)
+
+
+def test_execution_contract_fixture_satisfies_the_published_schema() -> None:
+    """The execution-block fixture is a conforming document, not just a readable one."""
+    document = json.loads((FIXTURE_ROOT / "execution" / "omits-primary-slot.json").read_text(encoding="utf-8"))
+    errors = list(Draft202012Validator(SCHEMA).iter_errors(document))
+    assert not errors, "\n".join(f"{list(e.path)}: {e.message}" for e in errors)
+
+
+def test_minimal_document_from_section_14_is_conforming() -> None:
+    """The minimal example FEP-0002 §14 offers has to actually validate."""
+    minimal = {
+        "format": "PSPF/2025",
+        "package": {"name": "minimal", "version": "1.0.0"},
+        "slots": [],
+        "execution": {"command": "true"},
+    }
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(minimal))
+
+
+def test_unknown_members_are_accepted() -> None:
+    """§5.3 requires readers to tolerate unknown members, so the schema must too.
+
+    A schema with additionalProperties false would reject documents the
+    specification requires readers to accept, which is the one way this file
+    could pass while describing the wrong format.
+    """
+    document = {
+        "format": "PSPF/2025",
+        "package": {"name": "minimal", "version": "1.0.0"},
+        "slots": [],
+        "execution": {"command": "true"},
+        "a_field_from_a_later_producer": {"anything": 1},
+    }
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(document))
+
+
+@pytest.mark.parametrize(
+    ("label", "document"),
+    [
+        ("missing format", {"package": {"name": "m", "version": "1"}, "slots": []}),
+        ("wrong format", {"format": "PSPF/2024", "package": {"name": "m", "version": "1"}, "slots": []}),
+        ("missing version", {"format": "PSPF/2025", "package": {"name": "m"}, "slots": []}),
+        ("empty name", {"format": "PSPF/2025", "package": {"name": "", "version": "1"}, "slots": []}),
+        ("slots not an array", {"format": "PSPF/2025", "package": {"name": "m", "version": "1"}, "slots": {}}),
+        (
+            "slot without a checksum",
+            {
+                "format": "PSPF/2025",
+                "package": {"name": "m", "version": "1"},
+                "slots": [
+                    {
+                        "slot": 0,
+                        "id": "a",
+                        "source": "",
+                        "target": "t",
+                        "size": 1,
+                        "operations": "",
+                        "purpose": "data",
+                        "lifecycle": "runtime",
+                    }
+                ],
+            },
+        ),
+        (
+            "execution without a command",
+            {
+                "format": "PSPF/2025",
+                "package": {"name": "m", "version": "1"},
+                "slots": [],
+                "execution": {},
+            },
+        ),
+        (
+            "verification without a seal",
+            {
+                "format": "PSPF/2025",
+                "package": {"name": "m", "version": "1"},
+                "slots": [],
+                "verification": {"signed": True},
+            },
+        ),
+    ],
+)
+def test_malformed_documents_are_rejected(label: str, document: dict[str, Any]) -> None:
+    """The schema has to bite. One that accepts anything would pass every test above."""
+    assert list(Draft202012Validator(SCHEMA).iter_errors(document)), f"{label} was accepted"
+
+
+# 🌶️📦🔚

--- a/uv.lock
+++ b/uv.lock
@@ -3,16 +3,16 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform != 'freebsd' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'freebsd'",
     "python_full_version == '3.14.*' and sys_platform != 'freebsd' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'freebsd'",
+    "python_full_version >= '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'freebsd' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'freebsd'",
+    "python_full_version == '3.13.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'freebsd' and sys_platform != 'win32')",
-    "python_full_version >= '3.15' and sys_platform == 'freebsd'",
-    "python_full_version == '3.14.*' and sys_platform == 'freebsd'",
-    "python_full_version == '3.13.*' and sys_platform == 'freebsd'",
     "python_full_version < '3.13' and sys_platform == 'freebsd'",
-    "python_full_version >= '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version < '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "platform_machine == 'ARM64' and sys_platform == 'win32'",
 ]
@@ -744,11 +744,11 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform != 'freebsd' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'freebsd' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'freebsd' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'freebsd' and sys_platform != 'win32')",
-    "python_full_version >= '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version < '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "platform_machine == 'ARM64' and sys_platform == 'win32'",
 ]
@@ -968,10 +968,12 @@ build-backends = [
 ]
 dev = [
     { name = "hypothesis" },
+    { name = "jsonschema" },
     { name = "memray", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "protobuf", marker = "sys_platform == 'win32'" },
     { name = "provide-testkit" },
     { name = "provide-testkit", extra = ["all"], marker = "sys_platform != 'win32'" },
+    { name = "types-jsonschema" },
 ]
 docs = [
     { name = "mkdocs-mermaid2-plugin" },
@@ -995,10 +997,12 @@ build-backends = [
 ]
 dev = [
     { name = "hypothesis", specifier = ">=6.0" },
+    { name = "jsonschema", specifier = ">=4.0" },
     { name = "memray", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'", specifier = ">=1.0" },
     { name = "protobuf", marker = "sys_platform == 'win32'", specifier = ">=4.0" },
     { name = "provide-testkit", marker = "sys_platform == 'win32'", specifier = ">=0.4.0" },
     { name = "provide-testkit", extras = ["all"], marker = "sys_platform != 'win32'", specifier = ">=0.4.0" },
+    { name = "types-jsonschema", specifier = ">=4.0" },
 ]
 docs = [
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.0" },
@@ -1666,6 +1670,33 @@ name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
 
 [[package]]
 name = "keyring"
@@ -3767,6 +3798,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.8.31"
 source = { registry = "https://pypi.org/simple" }
@@ -3914,6 +3959,129 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
@@ -4426,6 +4594,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/b7/65a3ebc728ddcdfa3ac6b8872956c14193e5b95e9b43ae5d988d29f41202/types_grpcio-1.83.0.20260730.tar.gz", hash = "sha256:e2b0532526a563dbb39aa6ee39fe0961488116ac1afec3065607532c93299b64", size = 15455, upload-time = "2026-07-30T04:44:31.863Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/1f/6bd33dd7cfb782669c25e669abe0058d9dc4e1c25f34b8e6b97845c531ca/types_grpcio-1.83.0.20260730-py3-none-any.whl", hash = "sha256:400e0517d088e90ecfe302a96f09728cb9c72508d835fa0793fce552cd4e1477", size = 15917, upload-time = "2026-07-30T04:44:31.027Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
FEP-0002 §8 published a JSON Schema with `additionalProperties: false` describing an execution object of `entry_point`, `args`, `env`, `working_directory`, and a root permitting `format_version`, `package`, `slots`, `build`, `execution`, `dependencies`, `extensions`.

Every package the three builders produce carries five root members that schema rejects:

| | |
|---|---|
| in every package, rejected by the schema | `format`, `verification`, `launcher`, `compatibility`, `setup_commands` |
| in the schema, in no package | `dependencies`, `extensions` |
| execution keys in use | `primary_slot`, `command`, `env` |
| execution keys in the schema | `entry_point`, `args`, `env`, `working_directory` |

`env` is the sole overlap. `verification` — the member holding the integrity seal — is among the rejected.

FEP-0001 is accurate (8192-byte index, 8200-byte trailer, `📦 0xF09F93A6` / `🪄 0xF09FAA84`), so this is one document out of step, not a spec suite to discard.

## What the document now says

Taken from the Rust and Go structures and checked against the committed fixtures. Corrections worth naming:

**§6.3 — the metadata checksum.** SHA-256 over the *stored gzip bytes*, which is what `VerifyMetadataChecksum` and its Rust counterpart compute. The replaced text prescribed canonical JSON — sorted keys, compact separators, NFC — before signing. An implementer following it produces a digest matching nothing: gzip output isn't reproducible across compressors, and JSON serialisation isn't reproducible across languages. This is the correction I'd most want reviewed.

**§4.5.1 — verification is a claim, not evidence.** A reader establishes signing by checking the seal in the index, never by reading `verification.signed`. #35 was a `verify` command reporting checks it never made; the same mistake is available to anyone reading this metadata.

**§4.3.7 — `operations` is descriptive.** Extraction uses the packed codes in the slot descriptor, which is what both launchers do.

**§5.2.2 — validate paths after substitution.** A placeholder can expand into a traversal.

**§7 — grammars are producer guidance.** Readers accept any string. The replaced grammar admitted neither `""` nor `"none"` for operations — both in the fixtures — and excluded the leading underscore of `_attestation`.

## §9 Producer Variation

Where the three differ, in the spec rather than only in a tracker, since a reader meeting packages from all three meets all five: the execution block (#48), `format_version`, platform naming (`macos`/`aarch64` vs `darwin`/`arm64`), the doubled checksum prefix (#49), and the `{workenv}/` target prefix.

## The schema is no longer a claim

`tests/format_2025/test_fep0002_schema.py` reads the schema out of the document and:

- validates all three fixture packages, the execution fixture, and §14's minimal example
- asserts it **rejects** 14 malformed documents — a schema accepting everything would otherwise pass every test above it
- asserts it accepts unknown members, since §5.3 requires readers to tolerate them

Verified to bite: naming a field required that producers omit fails 6 of its 15 tests.

That test is the point. A specification whose schema nobody runs describes whatever it described the day it was written.

## Verification

`ci/pr-tests.sh` green (Rust, Go, Python). `ci/quality-checks.sh` green for all three. TOC anchors and every `§` cross-reference resolve.

mypy strict caught two errors in the new test on push that `quality-checks.sh` did not — a missing stub package and an `Any` return. Both fixed; `types-jsonschema` is in the dev group alongside `jsonschema`.

## Notes

`jsonschema` joins the dev dependency group for that test — not needed at run time. Say the word if you'd rather not take the dependency and I'll hand-roll the structural check instead.

`scripts/check_doc_links.py`, which CLAUDE.md tells you to run for docs, is not in the tree. I checked this file's anchors by hand. Worth a separate issue if you want it back.