### PR TITLE
Write the launcher hash with one algorithm prefix

### DIFF
--- a/src/flavor/psp/format_2025/builder.py
+++ b/src/flavor/psp/format_2025/builder.py
@@ -19,7 +19,7 @@ import time
 from typing import Any
 
 from provide.foundation import logger
-from provide.foundation.crypto import format_checksum as calculate_checksum
+from provide.foundation.crypto import format_checksum
 from provide.foundation.platform import get_arch_name, get_os_name
 
 from flavor.config.defaults import (
@@ -212,7 +212,7 @@ def prepare_slots(slots: list[SlotMetadata], options: BuildOptions) -> list[Prep
             checksum_data_size=len(data_to_checksum),
             checksum_type="sha256",
         )
-        checksum_str = calculate_checksum(data_to_checksum, "sha256")
+        checksum_str = format_checksum(data_to_checksum, "sha256")
         # Compute SHA-256 truncated to 8 bytes for binary descriptor
         hash_bytes = hashlib.sha256(data_to_checksum).digest()[:8]
         checksum_uint64 = int.from_bytes(hash_bytes, byteorder="little")
@@ -354,7 +354,8 @@ def _prepare_attestation_slot(
     launcher_type = "rust"
     launcher_data = load_launcher_binary(launcher_type, explicit_path=spec.options.launcher_bin)
     launcher_version = extract_launcher_version(launcher_data)
-    launcher_hash = f"sha256:{calculate_checksum(launcher_data, 'sha256')}"
+    # format_checksum returns "sha256:<hex>"; the prefix belongs to it, not here.
+    launcher_hash = format_checksum(launcher_data, "sha256")
 
     # ---- python version ------------------------------------------------------
     py_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"

--- a/src/flavor/psp/format_2025/metadata/assembly.py
+++ b/src/flavor/psp/format_2025/metadata/assembly.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import socket
 from typing import Any
 
-from provide.foundation.crypto import format_checksum as calculate_checksum
+from provide.foundation.crypto import format_checksum
 from provide.foundation.platform import get_arch_name, get_os_name, get_platform_string
 from provide.foundation.utils import get_version
 
@@ -195,7 +195,7 @@ def get_launcher_info(launcher_type: str) -> dict[str, Any]:
     }
 
     tool_name = launcher_map.get(launcher_type, "flavor-rs-launcher")
-    checksum = calculate_checksum(launcher_data, "sha256")
+    checksum = format_checksum(launcher_data, "sha256")
 
     return {
         "data": launcher_data,

--- a/src/flavor/psp/format_2025/slots.py
+++ b/src/flavor/psp/format_2025/slots.py
@@ -283,12 +283,12 @@ class SlotMetadata:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        from provide.foundation.crypto import format_checksum as calculate_checksum
+        from provide.foundation.crypto import format_checksum
 
         # Ensure checksum has prefix
         if not self.checksum:
             # Create a placeholder checksum from the id
-            self.checksum = calculate_checksum(self.id.encode(), "sha256")
+            self.checksum = format_checksum(self.id.encode(), "sha256")
 
         return {
             "slot": self.index,  # Position validator

--- a/src/flavor/psp/format_2025/writer.py
+++ b/src/flavor/psp/format_2025/writer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, BinaryIO
 
 from provide.foundation import logger
-from provide.foundation.crypto import Ed25519Signer, format_checksum as calculate_checksum
+from provide.foundation.crypto import Ed25519Signer, format_checksum
 from provide.foundation.file import (
     align_offset,
     align_to_page,
@@ -146,7 +146,7 @@ def _create_launcher_info(launcher_data: bytes) -> dict[str, Any]:
         "data": launcher_data,
         "tool": "launcher",
         "tool_version": extract_launcher_version(launcher_data),
-        "checksum": calculate_checksum(launcher_data, "sha256"),
+        "checksum": format_checksum(launcher_data, "sha256"),
         "capabilities": ["mmap", "async", "sandbox"],
     }
 

--- a/tests/format_2025/test_launcher_hash_prefix.py
+++ b/tests/format_2025/test_launcher_hash_prefix.py
@@ -1,0 +1,118 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""The launcher hash carries its algorithm prefix exactly once.
+
+``format_checksum`` returns a value that already reads ``sha256:<hex>``. It is
+imported into the builder under the name ``calculate_checksum``, which reads
+like it returns a bare digest, and one of the three call sites adds a prefix of
+its own. The result reaches metadata, the SBOM and the attestation.
+
+FEP-0002 §7.4 gives the grammar: the prefix appears once.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+from provide.foundation.crypto import format_checksum
+import pytest
+
+from flavor.psp.format_2025.pspf_builder import PSPFBuilder
+from flavor.psp.format_2025.reader import PSPFReader
+from flavor.psp.format_2025.sbom import build_sbom
+
+CHECKSUM = re.compile(r"^[a-z0-9]+:[0-9a-fA-F]+$")
+SHA256_HEX = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def test_format_checksum_already_carries_the_prefix() -> None:
+    """The premise: a caller that adds ``sha256:`` is adding a second one."""
+    assert format_checksum(b"x", "sha256").startswith("sha256:")
+    assert CHECKSUM.match(format_checksum(b"x", "sha256"))
+
+
+def test_builder_launcher_hash_has_one_prefix() -> None:
+    """The value the builder stores matches the FEP-0002 §7.4 grammar."""
+    launcher_hash = format_checksum(b"launcher bytes", "sha256")
+
+    assert CHECKSUM.match(launcher_hash), launcher_hash
+    assert launcher_hash.count(":") == 1, launcher_hash
+    algorithm, digest = launcher_hash.split(":", 1)
+    assert algorithm == "sha256"
+    assert SHA256_HEX.match(digest), digest
+
+
+def test_sbom_records_a_hash_a_consumer_can_use() -> None:
+    """A doubled prefix survives into the SBOM as a hash that is not a digest.
+
+    ``_parse_hash`` splits on the first colon, so ``sha256:sha256:<hex>`` yields
+    a content field of ``sha256:<hex>`` under an algorithm of ``SHA-256``. That
+    is a CycloneDX hash entry whose content is not hexadecimal.
+    """
+    launcher_hash = format_checksum(b"launcher bytes", "sha256")
+    sbom = build_sbom(
+        {
+            "launcher_hash": launcher_hash,
+            "launcher_language": "rust",
+            "launcher_version": "1.0.0",
+            "packages": [],
+            "python_version": "3.11.0",
+            "python_hash": "",
+        }
+    )
+
+    assert sbom is not None, "build_sbom returned nothing for an enabled build"
+
+    launcher = [c for c in sbom["components"] if "launcher" in c.get("name", "")]
+    assert launcher, f"no launcher component in {[c.get('name') for c in sbom['components']]}"
+
+    for entry in launcher[0]["hashes"]:
+        assert SHA256_HEX.match(entry["content"]), (
+            f"{entry['alg']} content {entry['content']!r} is not a hex digest"
+        )
+
+
+def test_a_built_package_carries_usable_hashes_in_its_attestation(tmp_path: Path) -> None:
+    """End to end, through the builder, on a package it actually produced.
+
+    The two tests above check the pieces. This one runs the builder and reads
+    what it wrote, so it covers the call site rather than a reconstruction of it.
+    """
+    output = tmp_path / "hashed.psp"
+    result = (
+        PSPFBuilder.create()
+        .metadata(name="hash-prefix-test", version="1.0.0")
+        .add_slot(id="data", data=b"payload")
+        .with_keys(seed="test-hash-prefix")
+        .build(output)
+    )
+    assert result.success, result.errors
+
+    with PSPFReader(output) as reader:
+        descriptors = reader.read_slot_descriptors()
+        attestation = json.loads(reader.read_slot(len(descriptors) - 1))
+
+    hashes = [
+        (component.get("name"), entry)
+        for component in attestation.get("sbom", {}).get("components", [])
+        for entry in (component.get("hashes") or [])
+    ]
+    assert hashes, "the attestation SBOM records no hashes at all"
+
+    for name, entry in hashes:
+        assert SHA256_HEX.match(entry["content"]), (
+            f"{name}: {entry['alg']} content {entry['content']!r} is not a hex digest"
+        )
+
+    provenance = attestation.get("provenance", {})
+    for key, value in provenance.items():
+        if isinstance(value, str) and value.count(":") > 1 and value.startswith("sha256:"):
+            pytest.fail(f"provenance.{key} carries a doubled algorithm prefix: {value!r}")
+
+
+# 🌶️📦🔚


### PR DESCRIPTION
Closes #49.

`format_checksum` returns `sha256:<hex>`. It is imported into four modules as `calculate_checksum`, which reads like it returns a bare digest, and one of five call sites adds a prefix of its own:

```python
launcher_hash = f"sha256:{calculate_checksum(launcher_data, 'sha256')}"
```

Go and Rust write one prefix.

## It doesn't stop at the metadata

The value flows into the SBOM, where `_parse_hash` splits on the first colon:

```
_parse_hash("sha256:sha256:02b2…")  ->  ("SHA-256", "sha256:02b2…")
```

So **every SBOM the Python builder produces records a CycloneDX hash whose content is not hexadecimal**, under `alg: SHA-256`. A consumer validating against the CycloneDX schema rejects it; one comparing the hash to a digest it computed finds no match, while the same launcher in a Go- or Rust-built package matches. It also reaches the attestation slot.

That is wider than the issue described — I filed #49 against the metadata field before tracing where the value went.

## The fix

The prefix is removed from the call site, and the alias with it. The alias is why the mistake is easy to make and hard to see, and the name is taken elsewhere: `HelperManager.calculate_checksum` is an unrelated method over a path and a size. All five sites now read `format_checksum(...)`; none adds a prefix.

| site | before | after |
|---|---|---|
| `builder.py:357` | wrapped in an f-string | bare |
| `builder.py:215`, `slots.py:291`, `writer.py:149`, `metadata/assembly.py:198` | already bare | unchanged, renamed |

## Test

`tests/format_2025/test_launcher_hash_prefix.py` builds a package through `PSPFBuilder`, reads its attestation slot, and requires every hash in the embedded SBOM to be a hex digest — so it covers the call site rather than a reconstruction of it.

Against the previous code it fails with:

```
flavor-rust-launcher: SHA-256 content
'sha256:94f91724ca91f45c7da6adfc9072814ff21e7f53f9337396e0bf8186f81ce68c'
is not a hex digest
```

FEP-0002 §7.4 gives the grammar the value now satisfies; §9.4 records the difference this removes, and can come out of the spec once this lands.

## Verification

`ci/pr-tests.sh` green — Rust, Go, and Python (2779 passed). `ruff` clean; mypy strict clean on push, after it caught an unguarded `dict | None` in the new test.