### PR TITLE
Resolve {slot:N} to where the slot actually is

### DIFF
--- a/docs/guide/packaging/configuration.md
+++ b/docs/guide/packaging/configuration.md
@@ -358,8 +358,9 @@ shell = false  # Direct execution (faster)
 | Placeholder | Expands To | Example |
 |-------------|------------|---------|
 | `{workenv}` | Cache directory | `/home/user/.cache/flavor/workenv/pspf-abc123` |
-| `{slot:N}` | Slot N path | `/home/user/.cache/flavor/workenv/pspf-abc123/slots/0` |
-| `{package}` | Package file path | `/path/to/myapp.psp` |
+| `{slot:N}` | Slot N path | `/home/user/.cache/flavor/workenv/pspf-abc123/data/payload.txt` |
+| `{package_name}` | Package name | `myapp` |
+| `{version}` | Package version | `2.1.0` |
 
 ### Signal Handling
 

--- a/docs/reference/spec/fep-0002-json-metadata-format.md
+++ b/docs/reference/spec/fep-0002-json-metadata-format.md
@@ -444,15 +444,21 @@ True when the slot refers to the launcher binary itself rather than to separate 
 The command line the launcher runs after extraction. Placeholders are
 substituted first.
 
-Three are substituted by every launcher, and a producer may rely on them:
+Four are substituted by every launcher, and a producer may rely on them:
 
 | Placeholder | Substitution |
 |-------------|--------------|
 | `{workenv}` | Absolute path of the workenv directory |
 | `{package_name}` | `package.name` |
 | `{version}` | `package.version` |
+| `{slot:N}` | Path of slot *N* in the workenv |
 
-Five more are substituted by some launchers and passed through literally by the
+A slot resolves to where its content sits once extracted: `workenv/<target>` for
+a slot with a target, `workenv/slot_<N>_<id>` for one without, and the workenv
+itself for a slot whose operations include `tar`, whose entries are spread
+across it rather than gathered at one path.
+
+Three more are substituted by some launchers and passed through literally by the
 rest. A command using one runs correctly under the launchers that expand it and
 receives the placeholder text verbatim under the others, which fails at the
 point the command runs and nowhere earlier. §9.6 gives the support matrix, and
@@ -460,7 +466,6 @@ the divergence is tracked in provide-io/flavorpack#52.
 
 | Placeholder | Substitution |
 |-------------|--------------|
-| `{slot:N}` | Extracted path of slot *N* |
 | `{bin}` | The workenv's binary directory |
 | `{python}` | Interpreter path |
 | `{python_bin}` | Interpreter's binary directory |
@@ -944,17 +949,15 @@ The launchers expand different sets of placeholders in `execution.command`:
 | `{workenv}` | yes | yes | yes |
 | `{package_name}` | yes | yes | yes |
 | `{version}` | yes | yes | yes |
-| `{slot:N}` | no | yes | yes |
+| `{slot:N}` | yes | yes | yes |
 | `{bin}` | no | no | yes |
 | `{python}` | no | no | yes |
 | `{python_bin}` | no | no | yes |
 
-A command that depends on any of the last five runs under some launchers and
-passes the placeholder text to the shell under the others. `{slot:N}` is the one
-to watch: two launchers implement it, and the third is the default launcher for
-packages the Python builder produces.
+A command that depends on any of the last three runs under Python and passes the
+placeholder text to the shell under the others.
 
-A producer targeting every launcher should confine itself to the first three.
+A producer targeting every launcher should confine itself to the first four.
 
 Tracked in provide-io/flavorpack#52.
 

--- a/src/flavor-go/pkg/psp/format_2025/execution.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution.go
@@ -606,8 +606,14 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 		return nil, errors.New("no execution configuration found")
 	}
 
+	// {slot:N} resolves to where a slot sits in the finished workenv. slotPaths
+	// reports neither: after extraction it names a temporary directory that is
+	// removed before this runs, and on the cached path every entry is the
+	// workenv root. Derive them from the targets instead.
+	commandSlotPaths := buildSlotPaths(metadata, workenvDirForCmd, logger)
+
 	command := metadata.Execution.Command
-	for idx, path := range slotPaths {
+	for idx, path := range commandSlotPaths {
 		placeholder := fmt.Sprintf("{slot:%d}", idx)
 		// Convert slot paths to forward slashes for command string on Windows
 		command = strings.ReplaceAll(command, placeholder, filepath.ToSlash(path))
@@ -702,9 +708,9 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 	if metadata.Execution.Environment != nil {
 		logger.Debug("➕ Adding package-defined environment variables", "count", len(metadata.Execution.Environment))
 		for k, v := range metadata.Execution.Environment {
-			for idx, path := range slotPaths {
+			for idx, path := range commandSlotPaths {
 				placeholder := fmt.Sprintf("{slot:%d}", idx)
-				v = strings.ReplaceAll(v, placeholder, path)
+				v = strings.ReplaceAll(v, placeholder, filepath.ToSlash(path))
 			}
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 			logging.Trace(logger, "➕ Added package env var", "key", k, "value", v)

--- a/src/flavor-go/pkg/psp/format_2025/execution_slotpaths.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slotpaths.go
@@ -1,0 +1,54 @@
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+)
+
+// buildSlotPaths maps each slot index to the path its content occupies in the
+// finished workenv.
+//
+// The command needs where a slot ends up, which is not what extraction reports.
+// Extraction unpacks into a temporary directory and moves the result into
+// place, so its paths name a directory that is gone by the time the command
+// runs; and the cached path assigned every slot the workenv root, which is a
+// directory rather than a file. Neither resolves {slot:N} to anything usable,
+// so it is derived from the target instead, the way the Rust launcher and the
+// Python executor both derive it.
+//
+// A slot whose target escapes the workenv is left out. The reference then stays
+// unresolved and the caller refuses the command, which is the safe direction.
+func buildSlotPaths(metadata *Metadata, workenvDir string, logger *slog.Logger) map[int]string {
+	slotPaths := make(map[int]string, len(metadata.Slots))
+
+	for _, slot := range metadata.Slots {
+		target := strings.TrimSpace(slot.Target)
+		target = strings.TrimPrefix(target, "{workenv}/")
+		target = strings.TrimPrefix(target, "{workenv}")
+
+		switch {
+		case strings.Contains(slot.Operations, "tar"):
+			// A tar slot spreads its entries across the workenv and has no single
+			// path of its own, so it resolves to the workenv. Python's executor
+			// settled on the same answer.
+			slotPaths[slot.Slot] = filepath.Clean(workenvDir)
+
+		case target == "" || target == ".":
+			// Extraction gives a slot with no target a directory of its own.
+			slotPaths[slot.Slot] = filepath.Join(workenvDir, fmt.Sprintf("slot_%d_%s", slot.Slot, slot.ID))
+
+		default:
+			resolved, err := resolveWorkenvTarget(workenvDir, target)
+			if err != nil {
+				logger.Warn("⚠️ Slot target does not resolve inside the workenv",
+					"slot", slot.Slot, "id", slot.ID, "target", slot.Target, "error", err)
+				continue
+			}
+			slotPaths[slot.Slot] = filepath.Clean(resolved)
+		}
+	}
+
+	return slotPaths
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_slotpaths_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slotpaths_test.go
@@ -1,0 +1,70 @@
+package format_2025
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+func TestBuildSlotPathsResolvesTargetsUnderTheWorkenv(t *testing.T) {
+	t.Parallel()
+
+	workenv := filepath.Join(string(filepath.Separator), "cache", "workenv", "demo")
+	metadata := &Metadata{Slots: []SlotMetadata{
+		{Slot: 0, ID: "script", Target: "bin/show.sh"},
+		{Slot: 1, ID: "payload", Target: "{workenv}/data/payload.txt"},
+	}}
+
+	got := buildSlotPaths(metadata, workenv, logging.NewNullLogger())
+
+	want := map[int]string{
+		0: filepath.Join(workenv, "bin", "show.sh"),
+		1: filepath.Join(workenv, "data", "payload.txt"),
+	}
+	for idx, path := range want {
+		if got[idx] != path {
+			t.Errorf("slot %d = %q, want %q", idx, got[idx], path)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d paths, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// A path is only usable if it names the slot's file. Neither of the values the
+// command previously received did: extraction reports a temporary directory
+// that is removed before the command runs, and the cached branch assigned every
+// slot the workenv root.
+func TestBuildSlotPathsNamesFilesNotTheWorkenvRoot(t *testing.T) {
+	t.Parallel()
+
+	workenv := filepath.Join(string(filepath.Separator), "cache", "workenv", "demo")
+	metadata := &Metadata{Slots: []SlotMetadata{{Slot: 0, ID: "script", Target: "bin/show.sh"}}}
+
+	got := buildSlotPaths(metadata, workenv, logging.NewNullLogger())
+
+	if got[0] == workenv {
+		t.Fatalf("slot 0 resolved to the workenv root %q", got[0])
+	}
+	if strings.Contains(got[0], string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
+		t.Errorf("slot 0 resolved into a temporary directory: %q", got[0])
+	}
+	if !strings.HasSuffix(got[0], filepath.Join("bin", "show.sh")) {
+		t.Errorf("slot 0 = %q, want it to end at the slot's target", got[0])
+	}
+}
+
+func TestBuildSlotPathsDropsATargetThatEscapes(t *testing.T) {
+	t.Parallel()
+
+	workenv := filepath.Join(string(filepath.Separator), "cache", "workenv", "demo")
+	metadata := &Metadata{Slots: []SlotMetadata{{Slot: 0, ID: "escape", Target: "../../etc/passwd"}}}
+
+	got := buildSlotPaths(metadata, workenv, logging.NewNullLogger())
+
+	if _, present := got[0]; present {
+		t.Errorf("a target escaping the workenv must not resolve, got %q", got[0])
+	}
+}

--- a/src/flavor-rs/src/psp/format_2025/execution/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/mod.rs
@@ -8,7 +8,7 @@ mod validation;
 pub use commands::{
     execute_command, execute_main_command, execute_setup_commands, run_command, shell_split,
 };
-pub use placeholders::substitute_placeholders;
+pub use placeholders::{substitute_placeholders, substitute_slots};
 pub use validation::{
     IndexMetadata, check_workenv_validity_full, save_index_metadata, save_package_checksum,
 };

--- a/src/flavor-rs/src/psp/format_2025/execution/placeholders.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/placeholders.rs
@@ -2,7 +2,8 @@
 
 use super::super::metadata::PackageInfo;
 use log::warn;
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 /// Substitute placeholders in text
 pub fn substitute_placeholders(text: &str, workenv_dir: &Path, package: &PackageInfo) -> String {
@@ -17,4 +18,70 @@ pub fn substitute_placeholders(text: &str, workenv_dir: &Path, package: &Package
     text.replace("{workenv}", workenv_str)
         .replace("{package_name}", &package.name)
         .replace("{version}", &package.version)
+}
+
+/// Substitute `{slot:N}` with the extracted path of slot *N*.
+///
+/// Applied before [`substitute_placeholders`], matching the order the Go and
+/// Python launchers use: a slot path may itself contain `{workenv}`, and the
+/// basic substitution has to see it.
+///
+/// Paths are written with forward slashes. On Windows a backslash in a command
+/// string is an escape to the shell that runs it, and the other two launchers
+/// convert for the same reason.
+///
+/// An index with no extracted path is left as it stands, so an out-of-range
+/// reference reaches the caller rather than being silently blanked.
+pub fn substitute_slots(text: &str, slot_paths: &HashMap<usize, PathBuf>) -> String {
+    if !text.contains("{slot:") {
+        return text.to_string();
+    }
+
+    let mut out = text.to_string();
+    for (index, path) in slot_paths {
+        let replacement = path.to_string_lossy().replace('\\', "/");
+        out = out.replace(&format!("{{slot:{index}}}"), &replacement);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths() -> HashMap<usize, PathBuf> {
+        HashMap::from([
+            (0, PathBuf::from("/workenv/data/payload.txt")),
+            (1, PathBuf::from("/workenv/bin/tool")),
+        ])
+    }
+
+    #[test]
+    fn substitutes_each_slot_reference() {
+        assert_eq!(
+            substitute_slots("{slot:1} --input {slot:0}", &paths()),
+            "/workenv/bin/tool --input /workenv/data/payload.txt"
+        );
+    }
+
+    #[test]
+    fn leaves_text_without_a_reference_alone() {
+        assert_eq!(substitute_slots("/bin/true", &paths()), "/bin/true");
+    }
+
+    #[test]
+    fn leaves_an_index_with_no_path_as_it_stands() {
+        // The caller decides what an out-of-range reference means; blanking it
+        // here would turn a broken command into a differently broken one.
+        assert_eq!(substitute_slots("{slot:9}", &paths()), "{slot:9}");
+    }
+
+    #[test]
+    fn writes_paths_with_forward_slashes() {
+        let windows = HashMap::from([(0, PathBuf::from(r"C:\workenv\bin\tool"))]);
+        assert_eq!(
+            substitute_slots("{slot:0}", &windows),
+            "C:/workenv/bin/tool"
+        );
+    }
 }

--- a/src/flavor-rs/src/psp/format_2025/launcher/command.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/command.rs
@@ -1,13 +1,13 @@
 //! Command preparation and environment setup
 
-use super::super::execution::{shell_split, substitute_placeholders};
+use super::super::execution::{shell_split, substitute_placeholders, substitute_slots};
 use super::super::metadata::Metadata;
 use super::super::runtime::process_runtime_env;
 use crate::exceptions::{FlavorError, Result};
 use log::{debug, warn};
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Resolve executable path using PATH environment variable
 ///
@@ -99,16 +99,33 @@ pub fn resolve_executable(executable: &str) -> String {
     }
 }
 
+/// Report the first `{slot:N}` left in `text` that names a slot the package
+/// declares, or `None` when every reference resolved.
+fn unresolved_slot_reference(text: &str, slot_count: usize) -> Option<usize> {
+    (0..slot_count).find(|index| text.contains(&format!("{{slot:{index}}}")))
+}
+
 /// Prepare the command to execute
 pub(super) fn prepare_command(
     metadata: &Metadata,
     workenv_path: &Path,
     package_path: &Path,
     args: &[String],
+    slot_paths: &HashMap<usize, PathBuf>,
 ) -> Result<(String, Vec<String>, HashMap<String, String>)> {
-    // Substitute placeholders in command
-    let command =
-        substitute_placeholders(&metadata.execution.command, workenv_path, &metadata.package);
+    // Slot references resolve first: a slot path may itself contain {workenv},
+    // and the basic substitution has to see it. Go and Python order it the same
+    // way.
+    let command = substitute_slots(&metadata.execution.command, slot_paths);
+    let command = substitute_placeholders(&command, workenv_path, &metadata.package);
+
+    // A reference to a slot the package declares but did not extract would
+    // reach the shell as its own text. Refuse instead.
+    if let Some(index) = unresolved_slot_reference(&command, metadata.slots.len()) {
+        return Err(FlavorError::Generic(format!(
+            "Command references slot {index}, which has no extracted path"
+        )));
+    }
 
     debug!("🎯 Final command: {command}");
 
@@ -157,8 +174,9 @@ pub(super) fn prepare_command(
     if let Some(ref workenv_info) = metadata.workenv {
         if let Some(ref workenv_env) = workenv_info.env {
             for (key, value) in workenv_env {
+                let expanded_value = substitute_slots(value, slot_paths);
                 let expanded_value =
-                    substitute_placeholders(value, workenv_path, &metadata.package);
+                    substitute_placeholders(&expanded_value, workenv_path, &metadata.package);
                 // Don't override FLAVOR_CACHE_DIR if it's already set
                 if key != crate::env_vars::CACHE_DIR
                     || !env_map.contains_key(crate::env_vars::CACHE_DIR)
@@ -170,8 +188,14 @@ pub(super) fn prepare_command(
     }
 
     // Add execution environment variables (layer 3)
+    //
+    // FEP-0002 §4.4.3: values take the same placeholders as the command. These
+    // were inserted verbatim, so a package that set DATA={slot:0} handed the
+    // placeholder text to its own process.
     for (key, value) in &metadata.execution.env {
-        env_map.insert(key.clone(), value.clone());
+        let expanded = substitute_slots(value, slot_paths);
+        let expanded = substitute_placeholders(&expanded, workenv_path, &metadata.package);
+        env_map.insert(key.clone(), expanded);
     }
 
     // Add FLAVOR_WORKENV
@@ -209,6 +233,7 @@ pub(super) fn prepare_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::psp::format_2025::metadata::SlotMetadata;
     use crate::psp::format_2025::metadata::{
         ExecutionInfo, Metadata, PackageInfo, RuntimeEnv, RuntimeInfo, WorkenvInfo,
     };
@@ -355,6 +380,75 @@ mod tests {
         assert_eq!(resolved, "flavor-tool");
     }
 
+    /// `{slot:N}` in the command resolves to that slot's extracted path.
+    ///
+    /// Go and Python both substitute it, and this implementation is the default
+    /// launcher for packages the Python builder produces, so a command using it
+    /// reached the shell here as the literal text `{slot:0}`. See #52.
+    #[test]
+    fn prepare_command_resolves_slot_references() {
+        let mut metadata = sample_metadata();
+        metadata.execution.command = "/bin/echo {slot:0}".to_string();
+        metadata
+            .execution
+            .env
+            .insert(String::from("DATA"), String::from("{slot:0}"));
+
+        let slot_paths = HashMap::from([(0usize, PathBuf::from("/tmp/flavor-workenv/data.txt"))]);
+
+        let (_executable, args, env_map) = prepare_command(
+            &metadata,
+            Path::new("/tmp/flavor-workenv"),
+            &PathBuf::from("/tmp/demo.psp"),
+            &[],
+            &slot_paths,
+        )
+        .expect("prepare command");
+
+        assert_eq!(args, vec!["/tmp/flavor-workenv/data.txt".to_string()]);
+        assert_eq!(
+            env_map.get("DATA").map(String::as_str),
+            Some("/tmp/flavor-workenv/data.txt"),
+            "slot references in environment values resolve too"
+        );
+    }
+
+    /// A reference to a declared slot with no extracted path is refused rather
+    /// than handed to the shell as its own text.
+    #[test]
+    fn prepare_command_refuses_an_unresolved_slot_reference() {
+        let mut metadata = sample_metadata();
+        metadata.execution.command = "/bin/echo {slot:0}".to_string();
+        metadata.slots.push(SlotMetadata {
+            index: 0,
+            id: "payload".to_string(),
+            source: String::new(),
+            target: "data.txt".to_string(),
+            size: 1,
+            checksum: "sha256:ab".to_string(),
+            operations: String::new(),
+            purpose: "data".to_string(),
+            lifecycle: "runtime".to_string(),
+            permissions: None,
+            resolution: None,
+            self_ref: None,
+        });
+
+        let err = prepare_command(
+            &metadata,
+            Path::new("/tmp/flavor-workenv"),
+            &PathBuf::from("/tmp/demo.psp"),
+            &[],
+            &HashMap::new(),
+        )
+        .expect_err("a slot with no extracted path must not reach the shell");
+
+        assert!(
+            err.to_string().contains("slot 0"),
+            "error should name the slot: {err}"
+        );
+    }
+
     #[test]
     fn test_prepare_command_applies_env_layers_and_path_prepend() {
         let metadata = sample_metadata();
@@ -368,6 +462,7 @@ mod tests {
             workenv_path,
             &package_path,
             &[String::from("--flag")],
+            &HashMap::new(),
         )
         .expect("prepare command");
 

--- a/src/flavor-rs/src/psp/format_2025/launcher/extraction.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/extraction.rs
@@ -87,8 +87,14 @@ pub(super) fn build_slot_paths(
     let mut slot_paths = HashMap::new();
 
     for slot in &metadata.slots {
-        // Target field specifies where to extract (relative to workenv)
-        let slot_path = workenv_path.join(normalize_slot_target(&slot.target));
+        // A tar slot spreads its entries across the workenv and has no single
+        // path of its own, so it resolves to the workenv. The Go launcher and
+        // Python's executor settle on the same answer.
+        let slot_path = if slot.operations.contains("tar") {
+            workenv_path.to_path_buf()
+        } else {
+            workenv_path.join(normalize_slot_target(&slot.target))
+        };
         slot_paths.insert(slot.index, slot_path);
     }
 

--- a/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
@@ -556,8 +556,13 @@ pub fn launch(package_path: &Path, args: &[String], options: LaunchOptions) -> R
     };
 
     // Prepare command
+    //
+    // Slot paths are rebuilt against the final workenv rather than taken from
+    // extraction, which reports the temporary directory it unpacked into. That
+    // directory is gone by the time the command runs.
+    let slot_paths = build_slot_paths(&metadata, &workenv_path);
     let (executable, cmd_args, env_map) =
-        prepare_command(&metadata, &workenv_path, package_path, args)?;
+        prepare_command(&metadata, &workenv_path, package_path, args, &slot_paths)?;
 
     // Get execution mode
     let exec_mode = env::var(crate::env_vars::EXEC_MODE).unwrap_or_else(|_| "exec".to_string());


### PR DESCRIPTION
Closes #52.

`{slot:N}` is documented for package authors in `docs/guide/packaging/configuration.md` and covered by taster's slot suite. **It worked in neither launcher.**

I filed #52 as "missing in Rust". Building the end-to-end test found Go broken too, in two different ways.

## Rust never substituted it

`substitute_placeholders` handled `{workenv}`, `{package_name}`, `{version}` and nothing else, so a command reached the shell carrying the literal text `{slot:0}`.

The slot paths were computed and thrown away — the binding read `let (_slot_paths, _init_paths)`.

## Go substituted the wrong paths

**After extraction** it used the temporary directory slots were unpacked into, which is removed once they're moved into place:

```
No such file or directory: .../.app-go.pspf/tmp/26410/bin/show.sh
```

**On the cached path** every slot was assigned the workenv root, so the command tried to execute a directory:

```
/Users/.../workenv/app-go: is a directory
```

## The fix

Both now derive the path from what the package declares, and agree on the three cases extraction produces:

| slot | resolves to |
|---|---|
| has a target | `workenv/<target>` |
| no target | `workenv/slot_<N>_<id>` |
| operations include `tar` | the workenv — entries are spread across it, so there is no single path |

The tar case matches what Python's executor settled on.

Rust also now expands placeholders in `execution.env` values, which it inserted verbatim — a package setting `DATA={slot:0}` handed the placeholder text to its own process. FEP-0002 §4.4.3 has always said those values take the same placeholders as the command.

A reference to a slot the package declares but did not extract is now refused rather than passed on, so it fails where it can be understood.

## Verified end to end

One package, built once, run under both launchers, fresh and cached:

```
rs  fresh : ARG: /Users/.../workenv/app-rs/data/payload.txt
rs  cached: ARG: /Users/.../workenv/app-rs/data/payload.txt
go  fresh : ARG: /Users/.../workenv/app-go/data/payload.txt
go  cached: ARG: /Users/.../workenv/app-go/data/payload.txt
```

with the same resolution reaching `execution.env`. Before this, the Rust rows were the literal `{slot:1}` and the Go rows were the two failures above.

## Docs

FEP-0002 §4.4.1 and §9.6 move `{slot:N}` into the set every launcher expands, and §4.4.1 now states where a slot resolves to.

The packaging guide promised `{package}` — implemented in none of the three. Replaced there with `{package_name}` and `{version}`, which all three do.

## Verification

Rust 296 lib tests + integration, Go all 8 packages, `make check`, `quality-checks.sh` for both. `ci/pr-pretaster.sh` green across all lanes (6, 8 and 4 checks, 0 skipped).

## Separate finding, filing shortly

`TestRunBundleWithCwdPreparesWorkenvAndCommands` prints the entire process environment in its failure message. When it failed during this work it emitted a screenful of live API tokens. In CI that output goes into a build log — worth fixing independently of this change.