### PR TITLE
Stop tests printing the whole environment on failure

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/env_assert_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/env_assert_test.go
@@ -1,0 +1,94 @@
+package format_2025
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// envEntry returns the `KEY=value` entry for key, and fails the test naming only
+// the key when there is none.
+//
+// The environment a launcher hands a package inherits the one the tests run in,
+// so it holds whatever the developer or the CI runner has set. Reporting a
+// missing variable by printing all of them puts every one of those values into
+// the failure output, which on CI is a build log. Report the entry under test
+// and the number of entries; that is what the assertion is about.
+func envEntry(t *testing.T, env []string, key string) string {
+	t.Helper()
+
+	prefix := key + "="
+	var found []string
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			found = append(found, entry)
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatalf("no %s entry among the %d environment entries", key, len(env))
+		return ""
+	}
+
+	// exec.Cmd deduplicates before starting the process and keeps the last
+	// occurrence, so that is the value the package receives.
+	return found[len(found)-1]
+}
+
+// envValue returns the value of key, failing the test if it is absent.
+func envValue(t *testing.T, env []string, key string) string {
+	t.Helper()
+	return strings.TrimPrefix(envEntry(t, env, key), key+"=")
+}
+
+// TestNoTestFormatsTheWholeEnvironment refuses the pattern envEntry exists to
+// replace.
+//
+// A failure message built from the whole of cmd.Env or os.Environ() prints
+// every variable the test process holds. That reads as harmless until the test
+// fails on a machine with credentials in the environment, or on CI, where the
+// output is a build log. It is the failing case that leaks, which is the case
+// nobody rehearses.
+func TestNoTestFormatsTheWholeEnvironment(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+
+	// Joining the environment into one string is the shape that reaches a
+	// format verb; anything narrower names a single variable.
+	banned := []string{
+		"strings.Join(cmd.Env",
+		"strings.Join(os.Environ()",
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, "_test.go") || name == "env_assert_test.go" {
+			continue
+		}
+
+		src, err := os.ReadFile(name) //nolint:gosec // fixture path is a directory entry
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		checked++
+
+		for lineNo, line := range strings.Split(string(src), "\n") {
+			code, _, _ := strings.Cut(line, "//")
+			for _, pattern := range banned {
+				if strings.Contains(code, pattern) {
+					t.Errorf("%s:%d builds a failure message from the whole environment via %s -- use envValue(t, cmd.Env, key) instead:\n\t%s",
+						name, lineNo+1, pattern, strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no test files scanned; this guard is checking nothing")
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
@@ -469,15 +469,14 @@ func TestRunBundleWithCwdPreparesWorkenvAndCommands(t *testing.T) {
 		t.Fatalf("expected setup command output to exist: %v", err)
 	}
 
-	env := strings.Join(cmd.Env, "\n")
-	if !strings.Contains(env, EnvWorkenv+"="+workenvDir) {
-		t.Fatalf("expected FLAVOR_WORKENV to point at workenv, env=%q", env)
+	if got := envValue(t, cmd.Env, EnvWorkenv); got != workenvDir {
+		t.Errorf("%s = %q, want %q", EnvWorkenv, got, workenvDir)
 	}
-	if !strings.Contains(env, "RUNTIME_FLAG=on") {
-		t.Fatalf("expected runtime env entry in cmd.Env, env=%q", env)
+	if got := envValue(t, cmd.Env, "RUNTIME_FLAG"); got != "on" {
+		t.Errorf("RUNTIME_FLAG = %q, want %q", got, "on")
 	}
-	if !strings.Contains(env, "CUSTOM_SLOT=") || !strings.Contains(env, "slot_0_slot-alpha") {
-		t.Fatalf("expected slot placeholder expansion in cmd.Env, env=%q", env)
+	if got := envValue(t, cmd.Env, "CUSTOM_SLOT"); !strings.Contains(got, "slot_0_slot-alpha") {
+		t.Errorf("CUSTOM_SLOT = %q, want the slot placeholder expanded", got)
 	}
 }
 
@@ -1137,8 +1136,8 @@ func TestRunBundleWithCwdUsesCustomWorkenvPath(t *testing.T) {
 	if _, err := os.Stat(expectedWorkenv); err != nil {
 		t.Fatalf("expected derived workenv to exist: %v", err)
 	}
-	if env := strings.Join(cmd.Env, "\n"); !strings.Contains(env, EnvWorkenv+"="+expectedWorkenv) {
-		t.Fatalf("expected FLAVOR_WORKENV=%s in env, got env=%q", expectedWorkenv, env)
+	if got := envValue(t, cmd.Env, EnvWorkenv); got != expectedWorkenv {
+		t.Errorf("%s = %q, want %q", EnvWorkenv, got, expectedWorkenv)
 	}
 }
 

--- a/tests/pretaster/scripts/combo_test.py
+++ b/tests/pretaster/scripts/combo_test.py
@@ -29,9 +29,13 @@ def handle_command(cmd: str, *args: str) -> int:  # noqa: C901 - command dispatc
         print(f"  Workenv: {os.getenv('FLAVOR_WORKENV', 'Not set')}")
         return 0
     elif cmd == "env":
-        for key in sorted(os.environ.keys())[:10]:
-            print(f"  {key}={os.environ[key][:50]}")
-        print(f"  ... ({len(os.environ)} total)")
+        # Only the launcher's own variables. This runs inside a package under
+        # test, so the environment is whatever the developer or the CI runner
+        # had set, and its output goes to a build log.
+        flavor_keys = sorted(k for k in os.environ if k.startswith("FLAVOR_"))
+        for key in flavor_keys:
+            print(f"  {key}={os.environ[key]}")
+        print(f"  ... ({len(os.environ)} variables in total, {len(flavor_keys)} of them FLAVOR_*)")
         return 0
     elif cmd == "argv":
         print("📝 Arguments received:")

--- a/tests/pretaster/scripts/combo_test.sh
+++ b/tests/pretaster/scripts/combo_test.sh
@@ -16,8 +16,11 @@ case "$CMD" in
         exit 0
         ;;
     env)
-        env | sort | head -10
-        echo "  ... ($(env | wc -l) total)"
+        # Only the launcher's own variables. This runs inside a package under
+        # test, so the environment is whatever the developer or the CI runner
+        # had set, and its output goes to a build log.
+        env | grep '^FLAVOR_' | sort
+        echo "  ... ($(env | wc -l) variables in total, $(env | grep -c '^FLAVOR_') of them FLAVOR_*)"
         exit 0
         ;;
     argv)


### PR DESCRIPTION
Closes #55.

`TestRunBundleWithCwdPreparesWorkenvAndCommands` reported a missing variable by formatting all of them:

```go
env := strings.Join(cmd.Env, "\n")
if !strings.Contains(env, "RUNTIME_FLAG=on") {
    t.Fatalf("expected runtime env entry in cmd.Env, env=%q", env)
}
```

`cmd.Env` is what the launcher hands the package, and it inherits the environment the tests run in. When this failed during #52 it printed every variable the machine had set, **including live credentials for several third-party services**. On CI that output is a build log.

It's the failing path that prints — so the leak arrives exactly when someone is about to copy the output somewhere.

## The fix

Four assertions across two tests now name the variable they're about:

```go
if got := envValue(t, cmd.Env, "RUNTIME_FLAG"); got != "on" {
    t.Errorf("RUNTIME_FLAG = %q, want %q", got, "on")
}
```

`envValue` returns one entry; with none, it reports the key and how many entries there were — never their contents.

`TestNoTestFormatsTheWholeEnvironment` refuses `strings.Join(cmd.Env` and `strings.Join(os.Environ()` anywhere in the package's tests. Verified against a file carrying the pattern:

```
--- FAIL: TestNoTestFormatsTheWholeEnvironment
    zz_guardprobe_test.go:11 builds a failure message from the whole environment
    via strings.Join(cmd.Env -- use envValue(t, cmd.Env, key) instead
```

## The pretaster helpers had it too

Latently — no config invokes those subcommands today, but they exist to be run:

| | before | after |
|---|---|---|
| `combo_test.sh` | `env \| sort \| head -10` — full values | FLAVOR_* only, plus a count |
| `combo_test.py` | first 10 keys, 50 chars of each value | FLAVOR_* only, plus a count |

50 characters is most of a token, and alphabetical order puts several real ones in the first ten.

## Found while fixing it

The launcher sets **`FLAVOR_WORKENV` twice**, with different values. The old assertion passed because a substring match found the second one; exact equality surfaced it.

`exec.Cmd` deduplicates keeping the last entry — verified — so the package receives the correct value and nothing is broken today. `envValue` returns the last entry for the same reason. Filing separately as tidiness rather than a defect.

## Verification

Go all 8 packages, `make check`, `quality-checks.sh` for Go and Python. `ci/pr-pretaster.sh` green across all lanes (6, 8, 4 checks, 0 skipped).