### PR TITLE
Set each environment variable once

### DIFF
--- a/src/flavor-go/pkg/psp/format_2025/env_assert_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/env_assert_test.go
@@ -92,3 +92,31 @@ func TestNoTestFormatsTheWholeEnvironment(t *testing.T) {
 		t.Fatal("no test files scanned; this guard is checking nothing")
 	}
 }
+
+// assertNoDuplicateEnvKeys fails when a key appears more than once in the
+// environment handed to a package.
+//
+// exec.Cmd deduplicates before starting the process and keeps the last
+// occurrence, so a duplicate is survivable — but only because of that rule.
+// Anything reading the slice directly sees the first entry, and a launcher that
+// grew a direct execve path would inherit neither the rule nor the intent.
+func assertNoDuplicateEnvKeys(t *testing.T, env []string) {
+	t.Helper()
+
+	seen := make(map[string]int, len(env))
+	for _, entry := range env {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		seen[key]++
+	}
+
+	for key, count := range seen {
+		if count > 1 {
+			// The key is named; the values are not, since they are whatever the
+			// environment held.
+			t.Errorf("%s appears %d times in the environment handed to the package", key, count)
+		}
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution.go
@@ -575,7 +575,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 				setupExec.Dir = userCwd
 
 				setupExec.Env = os.Environ()
-				setupExec.Env = append(setupExec.Env, fmt.Sprintf("%s=%s", EnvWorkenv, workenvDir))
+				setupExec.Env = setEnv(setupExec.Env, EnvWorkenv, workenvDir)
 
 				for i, env := range setupExec.Env {
 					if strings.HasPrefix(env, "PATH=") {
@@ -667,12 +667,11 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 	cmd.Env = setFlavorCacheBeforeWorkenv(cmd.Env, logger)
 
 	// Add FLAVOR_* variables
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", EnvWorkenv, workenvDir))
+	cmd.Env = setEnv(cmd.Env, EnvWorkenv, workenvDir)
 	logger.Debug("➕ Added FLAVOR_WORKENV", "path", workenvDir)
 
-	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("%s=%s", EnvOriginalCommand, originalCmd),
-		fmt.Sprintf("%s=%s", EnvCommandName, binaryName))
+	cmd.Env = setEnv(cmd.Env, EnvOriginalCommand, originalCmd)
+	cmd.Env = setEnv(cmd.Env, EnvCommandName, binaryName)
 	logger.Debug("🏷️ Added command name environment variables",
 		EnvOriginalCommand, originalCmd,
 		EnvCommandName, binaryName)
@@ -695,7 +694,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 		if runtime.GOOS == "windows" {
 			binDir = "Scripts"
 		}
-		cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", filepath.Join(workenvDir, binDir)))
+		cmd.Env = setEnv(cmd.Env, "PATH", filepath.Join(workenvDir, binDir))
 	}
 
 	// Process runtime.env configuration
@@ -712,7 +711,7 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 				placeholder := fmt.Sprintf("{slot:%d}", idx)
 				v = strings.ReplaceAll(v, placeholder, filepath.ToSlash(path))
 			}
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+			cmd.Env = setEnv(cmd.Env, k, v)
 			logging.Trace(logger, "➕ Added package env var", "key", k, "value", v)
 		}
 	}

--- a/src/flavor-go/pkg/psp/format_2025/execution_env.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_env.go
@@ -25,9 +25,31 @@ func setFlavorCacheBeforeWorkenv(env []string, logger *slog.Logger) []string {
 
 	// Use workenv.GetCacheRoot() for cross-platform cache directory consistency
 	flavorCache := filepath.Join(workenv.GetCacheRoot(), "workenv")
-	env = append(env, fmt.Sprintf("%s=%s", EnvCache, flavorCache))
+	env = setEnv(env, EnvCache, flavorCache)
 	logger.Debug("🗂️ Setting FLAVOR_CACHE to HOST cache", "path", flavorCache)
 	return env
+}
+
+// setEnv sets key to value, replacing an existing entry rather than adding a
+// second one.
+//
+// The environment handed to a package starts as os.Environ(), so appending a
+// FLAVOR_* variable that the caller already had set produces two entries for
+// it. exec.Cmd deduplicates keeping the last, so the intended value does reach
+// the process — but anything reading the slice directly sees the first, and the
+// rule is Go's rather than the platform's.
+func setEnv(env []string, key, value string) []string {
+	entry := fmt.Sprintf("%s=%s", key, value)
+	prefix := key + "="
+
+	for i, existing := range env {
+		if strings.HasPrefix(existing, prefix) {
+			env[i] = entry
+			return env
+		}
+	}
+
+	return append(env, entry)
 }
 
 // getenv retrieves an environment variable value from the environment list.

--- a/src/flavor-go/pkg/psp/format_2025/execution_env_set_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_env_set_test.go
@@ -1,0 +1,67 @@
+package format_2025
+
+import (
+	"testing"
+)
+
+func TestSetEnvReplacesRatherThanDuplicating(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"HOME=/home/tim", "FLAVOR_WORKENV=/old", "PATH=/usr/bin"}
+	got := setEnv(env, "FLAVOR_WORKENV", "/new")
+
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 — the entry should be replaced, not added: %v", len(got), got)
+	}
+	if value := envValue(t, got, "FLAVOR_WORKENV"); value != "/new" {
+		t.Errorf("FLAVOR_WORKENV = %q, want %q", value, "/new")
+	}
+	assertNoDuplicateEnvKeys(t, got)
+}
+
+func TestSetEnvAppendsWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"HOME=/home/tim"}
+	got := setEnv(env, "FLAVOR_WORKENV", "/new")
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %v", len(got), got)
+	}
+	if value := envValue(t, got, "FLAVOR_WORKENV"); value != "/new" {
+		t.Errorf("FLAVOR_WORKENV = %q, want %q", value, "/new")
+	}
+}
+
+// A key is matched whole. FLAVOR_WORKENV_CACHE must not be mistaken for
+// FLAVOR_WORKENV, which a prefix test without the "=" would do.
+func TestSetEnvMatchesTheWholeKey(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FLAVOR_WORKENV_CACHE=false"}
+	got := setEnv(env, "FLAVOR_WORKENV", "/new")
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 — FLAVOR_WORKENV_CACHE is a different key: %v", len(got), got)
+	}
+	if value := envValue(t, got, "FLAVOR_WORKENV_CACHE"); value != "false" {
+		t.Errorf("FLAVOR_WORKENV_CACHE = %q, want %q", value, "false")
+	}
+	if value := envValue(t, got, "FLAVOR_WORKENV"); value != "/new" {
+		t.Errorf("FLAVOR_WORKENV = %q, want %q", value, "/new")
+	}
+}
+
+func TestSetEnvKeepsOtherEntriesInOrder(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"A=1", "B=2", "C=3"}
+	got := setEnv(env, "B", "changed")
+
+	want := []string{"A=1", "B=changed", "C=3"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_execution_test.go
@@ -1139,6 +1139,7 @@ func TestRunBundleWithCwdUsesCustomWorkenvPath(t *testing.T) {
 	if got := envValue(t, cmd.Env, EnvWorkenv); got != expectedWorkenv {
 		t.Errorf("%s = %q, want %q", EnvWorkenv, got, expectedWorkenv)
 	}
+	assertNoDuplicateEnvKeys(t, cmd.Env)
 }
 
 func TestRunBundleWithCwdRejectsInvalidSetupCommand(t *testing.T) {


### PR DESCRIPTION
Closes #57.

The environment handed to a package starts as `os.Environ()` and then had variables appended:

```go
cmd.Env = os.Environ()
cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", EnvWorkenv, workenvDir))
```

So any variable the caller already had set arrived **twice**, with different values. `FLAVOR_WORKENV` is the one that shows, because setting it is how a caller asks for a custom workenv — the feature and the duplicate arrive together.

## Nothing was broken

`exec.Cmd` deduplicates before starting the process and keeps the last occurrence, verified rather than assumed:

```go
cmd.Env = []string{"DUP=first", "DUP=second"}   // process sees "second"
```

So the intended value reaches the package. It's survivable because of that rule, not because the environment is right — code reading the slice sees the *first* entry, and the rule is Go's rather than the platform's.

## The fix

`setEnv` replaces an existing entry or appends when there is none. Six sites now use it:

| site | |
|---|---|
| `FLAVOR_WORKENV` (command) | was appending |
| `FLAVOR_WORKENV` (setup commands) | was appending |
| `FLAVOR_ORIGINAL_COMMAND`, `FLAVOR_COMMAND_NAME` | were appending |
| `execution.env` entries | were appending |
| `FLAVOR_CACHE`, `PATH` fallback | already guarded by `hasEnv` / `pathFound`; converted so the guard lives in one place |

It matches the whole key — `FLAVOR_WORKENV_CACHE` is not `FLAVOR_WORKENV`, which a prefix test without the `=` would confuse. That's one of the four unit tests.

## The assertion

`assertNoDuplicateEnvKeys` names any key appearing twice, reporting the **key and count only** — the values are whatever the environment held, which is what #55 was about. It runs against the environment the custom-workenv path produces, which is where the duplicate appeared.

Against the previous code:

```
FLAVOR_WORKENV appears 2 times in the environment handed to the package
```

## Rust

The Rust launcher collects its environment into a `HashMap<String, String>`, so it cannot produce a duplicate. The suspicion I recorded in the issue doesn't hold there — noting it so nobody re-checks.

## Verification

Go all 8 packages, `make check`, `quality-checks.sh`. `ci/pr-pretaster.sh` green across all 5 lanes.