### PR TITLE
Read a package that declares no execution block

### DIFF
--- a/docs/reference/spec/fep-0002-json-metadata-format.md
+++ b/docs/reference/spec/fep-0002-json-metadata-format.md
@@ -199,8 +199,8 @@ metadata (object)
 │       ├── permissions (string|null, OPTIONAL)
 │       ├── resolution (string, OPTIONAL)
 │       └── self_ref (boolean, OPTIONAL)
-├── execution (object, REQUIRED for interoperability — see §9.1)
-│   ├── command (string, REQUIRED)
+├── execution (object, OPTIONAL)
+│   ├── command (string, OPTIONAL)
 │   └── env (object, OPTIONAL, default {})
 ├── verification (object, OPTIONAL)
 │   ├── integrity_seal (object, REQUIRED within)
@@ -252,13 +252,13 @@ Identity of the package. Section 4.2.
 
 One entry per data slot, in index order. MAY be empty for a package that carries no slots. Section 4.3.
 
-#### 4.1.5 execution (REQUIRED for interoperability)
+#### 4.1.5 execution (OPTIONAL)
 
 **Type**: object
 
 How the package runs. Section 4.4.
 
-Two of the three implementations treat this object as optional and refuse at the point of execution when it is absent; the Rust reader requires it to parse the document at all. A producer that intends its packages to be readable by every implementation MUST write it. See §9.1.
+A package without one is read, reported on and verified like any other, and refused when something tries to run it. That refusal belongs at the point of execution: a package that cannot run is exactly the one an operator wants to be able to inspect.
 
 #### 4.1.6 verification (OPTIONAL)
 
@@ -436,13 +436,16 @@ True when the slot refers to the launcher binary itself rather than to separate 
 
 ### 4.4 Execution Object Fields
 
-#### 4.4.1 command (REQUIRED)
+#### 4.4.1 command (OPTIONAL)
 
 **Type**: string  
 **Example**: `"{workenv}/bin/app --config {workenv}/etc/app.conf"`
 
-The command line the launcher runs after extraction. Placeholders are
-substituted first.
+The command line the launcher runs after extraction. A document with no command,
+or an empty one, describes a package that cannot be run; readers report on it
+normally and refuse when asked to execute it.
+
+Placeholders are substituted first.
 
 Four are substituted by every launcher, and a producer may rely on them:
 
@@ -778,7 +781,6 @@ The schema below is satisfied by every package in `tests/fixtures/format_compat/
     },
     "execution": {
       "type": "object",
-      "required": ["command"],
       "properties": {
         "command": { "type": "string", "maxLength": 65535 },
         "env": { "type": "object", "additionalProperties": { "type": "string" } }
@@ -906,19 +908,13 @@ The schema below is satisfied by every package in `tests/fixtures/format_compat/
 
 The three implementations do not agree on everything. Each item below is a difference a reader encounters in packages that exist, with the issue tracking it. A producer aiming for packages every implementation can read should follow the guidance in each.
 
-### 9.1 The execution block
-
-`flavor-go` declares `execution` optional and refuses at the point of execution when it is missing. `flavor-python` behaves the same way. `flavor-rs` requires the object to parse the document at all, so a package without one cannot be inspected or verified by it, only rejected.
-
-Tracked in provide-io/flavorpack#48. Until it closes, write `execution`.
-
-### 9.2 format_version
+### 9.1 format_version
 
 `flavor-rs` and `flavor-python` write `"1.0.0"`. `flavor-go` writes the empty string.
 
 A reader MUST NOT depend on this field to decide how to parse. `format` identifies the format; `compatibility.min_format_version` states the requirement.
 
-### 9.3 Platform naming
+### 9.2 Platform naming
 
 `build.platform` records the build machine in each producer's own vocabulary. On the same Apple Silicon host:
 
@@ -930,17 +926,17 @@ A reader MUST NOT depend on this field to decide how to parse. `format` identifi
 
 The pairs name the same platform. A reader MUST NOT compare these values across producers or use them to decide whether a package will run.
 
-### 9.4 Checksum prefixes
+### 9.3 Checksum prefixes
 
 `launcher.checksum` written by `flavor-python` carries the algorithm prefix twice — `"sha256:sha256:02b2…"`. The digest after the second prefix is correct.
 
 A reader parsing a checksum should strip the algorithm prefix repeatedly rather than once. Tracked in provide-io/flavorpack#49.
 
-### 9.5 Target paths
+### 9.4 Target paths
 
 `flavor-python` writes `slots[].target` with an explicit `{workenv}/` prefix; `flavor-rs` and `flavor-go` write a path relative to the workenv with no prefix. Both denote the same location. A reader MUST accept either, and MUST apply §5.2.2 after substitution.
 
-### 9.6 Command placeholders
+### 9.5 Command placeholders
 
 The launchers expand different sets of placeholders in `execution.command`:
 
@@ -1057,8 +1053,7 @@ A conforming producer MUST:
 2. Write `format` as `"PSPF/2025"`
 3. Write `slots` in index order with `slot` matching position
 4. Write checksums as `algorithm:hex`, the prefix appearing once
-5. Write `execution`, until #48 closes (§9.1)
-6. Write the package environment under `env`
+5. Write the package environment under `env`
 
 ## 14. Test Vectors
 

--- a/src/flavor-rs/src/psp/format_2025/builder/metadata.rs
+++ b/src/flavor-rs/src/psp/format_2025/builder/metadata.rs
@@ -71,10 +71,10 @@ pub(super) fn create_metadata(
             version: manifest.package.version.clone(),
         },
         slots: vec![],
-        execution: ExecutionInfo {
+        execution: Some(ExecutionInfo {
             command: manifest.execution.command.clone(),
             env: manifest.execution.env.clone(),
-        },
+        }),
         verification: Some(VerificationInfo {
             integrity_seal: IntegritySealInfo {
                 required: true,
@@ -275,11 +275,9 @@ mod tests {
         assert_eq!(metadata.format, "PSPF/2025");
         assert_eq!(metadata.package.name, "demo");
         assert_eq!(metadata.package.version, "1.2.3");
-        assert_eq!(metadata.execution.command, "run");
-        assert_eq!(
-            metadata.execution.env.get("MODE").map(String::as_str),
-            Some("test")
-        );
+        let execution = metadata.execution.as_ref().expect("execution");
+        assert_eq!(execution.command, "run");
+        assert_eq!(execution.env.get("MODE").map(String::as_str), Some("test"));
         assert!(
             metadata
                 .verification

--- a/src/flavor-rs/src/psp/format_2025/cli.rs
+++ b/src/flavor-rs/src/psp/format_2025/cli.rs
@@ -89,7 +89,10 @@ pub fn show_info(exe_path: &Path) -> i32 {
     println!("  Verified: {}", verified);
     println!();
     println!("🚀 Execution:");
-    println!("  Command: {}", metadata.execution.command);
+    match &metadata.execution {
+        Some(execution) => println!("  Command: {}", execution.command),
+        None => println!("  Command: none — this package declares no execution block"),
+    }
 
     0
 }

--- a/src/flavor-rs/src/psp/format_2025/execution/validation.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/validation.rs
@@ -288,10 +288,10 @@ mod tests {
                 resolution: None,
                 self_ref: None,
             }],
-            execution: ExecutionInfo {
+            execution: Some(ExecutionInfo {
                 command: "python app.py".to_string(),
                 env: HashMap::new(),
-            },
+            }),
             verification: None,
             build: None,
             launcher: None,

--- a/src/flavor-rs/src/psp/format_2025/launcher/command.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/command.rs
@@ -113,10 +113,19 @@ pub(super) fn prepare_command(
     args: &[String],
     slot_paths: &HashMap<usize, PathBuf>,
 ) -> Result<(String, Vec<String>, HashMap<String, String>)> {
+    // The execution block is optional (FEP-0002 §4.1.5). A package without one
+    // is readable, verifiable and inspectable; it just cannot be run, and this
+    // is where that is decided.
+    let execution = metadata
+        .execution
+        .as_ref()
+        .filter(|execution| !execution.command.trim().is_empty())
+        .ok_or_else(|| FlavorError::Generic("No execution configuration found".to_string()))?;
+
     // Slot references resolve first: a slot path may itself contain {workenv},
     // and the basic substitution has to see it. Go and Python order it the same
     // way.
-    let command = substitute_slots(&metadata.execution.command, slot_paths);
+    let command = substitute_slots(&execution.command, slot_paths);
     let command = substitute_placeholders(&command, workenv_path, &metadata.package);
 
     // A reference to a slot the package declares but did not extract would
@@ -192,7 +201,7 @@ pub(super) fn prepare_command(
     // FEP-0002 §4.4.3: values take the same placeholders as the command. These
     // were inserted verbatim, so a package that set DATA={slot:0} handed the
     // placeholder text to its own process.
-    for (key, value) in &metadata.execution.env {
+    for (key, value) in &execution.env {
         let expanded = substitute_slots(value, slot_paths);
         let expanded = substitute_placeholders(&expanded, workenv_path, &metadata.package);
         env_map.insert(key.clone(), expanded);
@@ -249,10 +258,10 @@ mod tests {
                 version: "1.0.0".to_string(),
             },
             slots: Vec::new(),
-            execution: ExecutionInfo {
+            execution: Some(ExecutionInfo {
                 command: "echo hello".to_string(),
                 env: HashMap::from([(String::from("EXEC_ONLY"), String::from("execution"))]),
-            },
+            }),
             verification: None,
             build: None,
             launcher: None,
@@ -388,9 +397,9 @@ mod tests {
     #[test]
     fn prepare_command_resolves_slot_references() {
         let mut metadata = sample_metadata();
-        metadata.execution.command = "/bin/echo {slot:0}".to_string();
-        metadata
-            .execution
+        let execution = metadata.execution.as_mut().expect("execution");
+        execution.command = "/bin/echo {slot:0}".to_string();
+        execution
             .env
             .insert(String::from("DATA"), String::from("{slot:0}"));
 
@@ -413,12 +422,38 @@ mod tests {
         );
     }
 
+    /// A package with no execution block is refused where it is run, not where
+    /// it is read.
+    ///
+    /// FEP-0002 §4.1.5 makes the block optional, so such a package parses, and
+    /// `info`, `verify` and `metadata` all work on it. Running it is the one
+    /// thing that cannot, and that is what fails. See #48.
+    #[test]
+    fn prepare_command_refuses_a_package_with_no_execution_block() {
+        let mut metadata = sample_metadata();
+        metadata.execution = None;
+
+        let err = prepare_command(
+            &metadata,
+            Path::new("/tmp/flavor-workenv"),
+            &PathBuf::from("/tmp/demo.psp"),
+            &[],
+            &HashMap::new(),
+        )
+        .expect_err("a package with no execution block cannot be run");
+
+        assert!(
+            err.to_string().contains("execution"),
+            "error should say what is missing: {err}"
+        );
+    }
+
     /// A reference to a declared slot with no extracted path is refused rather
     /// than handed to the shell as its own text.
     #[test]
     fn prepare_command_refuses_an_unresolved_slot_reference() {
         let mut metadata = sample_metadata();
-        metadata.execution.command = "/bin/echo {slot:0}".to_string();
+        metadata.execution.as_mut().expect("execution").command = "/bin/echo {slot:0}".to_string();
         metadata.slots.push(SlotMetadata {
             index: 0,
             id: "payload".to_string(),

--- a/src/flavor-rs/src/psp/format_2025/launcher/extraction.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/extraction.rs
@@ -192,10 +192,10 @@ mod tests {
                 resolution: None,
                 self_ref: None,
             }],
-            execution: ExecutionInfo {
+            execution: Some(ExecutionInfo {
                 command: "run".to_string(),
                 env: HashMap::new(),
-            },
+            }),
             verification: None,
             build: None,
             launcher: None,

--- a/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/mod.rs
@@ -266,7 +266,10 @@ pub fn launch(package_path: &Path, args: &[String], options: LaunchOptions) -> R
             build_info.timestamp, build_info.tool, build_info.tool_version
         );
     }
-    debug!("🔧 Command: {}", metadata.execution.command);
+    match &metadata.execution {
+        Some(execution) => debug!("🔧 Command: {}", execution.command),
+        None => debug!("🔧 No execution block"),
+    }
 
     // Get work environment paths
     let custom_workenv = env::var(crate::env_vars::WORKENV).ok();
@@ -427,12 +430,19 @@ pub fn launch(package_path: &Path, args: &[String], options: LaunchOptions) -> R
                     metadata.setup_commands.len()
                 );
                 let user_cwd = env::current_dir()?;
+                // A package with no execution block contributes no environment
+                // of its own; its setup commands still run.
+                let execution_env = metadata
+                    .execution
+                    .as_ref()
+                    .map(|execution| execution.env.clone())
+                    .unwrap_or_default();
                 if let Err(e) = execute_setup_commands(
                     &metadata.setup_commands,
                     &temp_dir,
                     &metadata.package,
                     &user_cwd,
-                    &metadata.execution.env,
+                    &execution_env,
                 ) {
                     // Clean up temporary directory on setup failure
                     error!("❌ Setup commands failed, cleaning up temporary directory");

--- a/src/flavor-rs/src/psp/format_2025/launcher/workenv.rs
+++ b/src/flavor-rs/src/psp/format_2025/launcher/workenv.rs
@@ -147,10 +147,10 @@ mod tests {
                     self_ref: None,
                 })
                 .collect(),
-            execution: ExecutionInfo {
+            execution: Some(ExecutionInfo {
                 command: "echo hi".to_string(),
                 env: std::collections::HashMap::new(),
-            },
+            }),
             verification: None,
             build: Some(crate::psp::format_2025::metadata::BuildInfo {
                 tool: "builder".to_string(),

--- a/src/flavor-rs/src/psp/format_2025/metadata.rs
+++ b/src/flavor-rs/src/psp/format_2025/metadata.rs
@@ -12,7 +12,11 @@ pub struct Metadata {
     pub format_version: Option<String>,
     pub package: PackageInfo,
     pub slots: Vec<SlotMetadata>,
-    pub execution: ExecutionInfo,
+    /// How the package runs. Optional per FEP-0002 §4.1.5: a package that
+    /// cannot be executed is still one worth inspecting and verifying, so the
+    /// refusal belongs at the point of execution rather than at parse time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ExecutionInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification: Option<VerificationInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +69,12 @@ pub struct SlotMetadata {
 /// Execution configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExecutionInfo {
+    /// The command the launcher runs. Optional, defaulting to empty: Go leaves
+    /// a missing field at the zero value, and the Python builder writes
+    /// `"execution": {}` for a package that configures none. Requiring it here
+    /// made those packages unreadable rather than unrunnable — `info` on one
+    /// reported `missing field command` (#48).
+    #[serde(default)]
     pub command: String,
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -196,6 +206,29 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A package with no execution block is still readable.
+    ///
+    /// FEP-0002 §4.1.5 lists `execution` as OPTIONAL, and the root schema's
+    /// required set is format, package and slots. The Go launcher agrees: it
+    /// reads such a package and refuses at the point of execution. Requiring it
+    /// here meant `info`, `verify` and `metadata` failed too, so a package that
+    /// cannot run also could not be inspected — which is when inspecting it
+    /// matters most. See #48.
+    #[test]
+    fn metadata_without_an_execution_block_parses() {
+        let json = br#"{
+            "format": "PSPF/2025",
+            "package": {"name": "demo", "version": "1.0.0"},
+            "slots": []
+        }"#;
+
+        let metadata: Metadata =
+            serde_json::from_slice(json).expect("metadata without execution must parse");
+
+        assert!(metadata.execution.is_none());
+        assert_eq!(metadata.package.name, "demo");
+    }
+
     /// Packages carry fields this reader does not model, and must stay readable.
     ///
     /// `execution.primary_slot` is the case that matters: every package built
@@ -214,11 +247,9 @@ mod tests {
         let metadata: Metadata =
             serde_json::from_slice(json).expect("a package carrying primary_slot must parse");
 
-        assert_eq!(metadata.execution.command, "true");
-        assert_eq!(
-            metadata.execution.env.get("MODE").map(String::as_str),
-            Some("prod")
-        );
+        let execution = metadata.execution.as_ref().expect("execution");
+        assert_eq!(execution.command, "true");
+        assert_eq!(execution.env.get("MODE").map(String::as_str), Some("prod"));
     }
 
     fn sample_slot() -> SlotMetadata {
@@ -264,10 +295,10 @@ mod tests {
                 version: "1.2.3".to_string(),
             },
             slots: vec![sample_slot()],
-            execution: ExecutionInfo {
+            execution: Some(ExecutionInfo {
                 command: "run".to_string(),
                 env: HashMap::from([(String::from("MODE"), String::from("test"))]),
-            },
+            }),
             verification: Some(VerificationInfo {
                 integrity_seal: IntegritySealInfo {
                     required: true,
@@ -341,7 +372,13 @@ mod tests {
         assert_eq!(decoded.slots.len(), 1);
         assert_eq!(decoded.slots[0].self_ref, Some(true));
         assert_eq!(
-            decoded.execution.env.get("MODE").map(String::as_str),
+            decoded
+                .execution
+                .as_ref()
+                .expect("execution")
+                .env
+                .get("MODE")
+                .map(String::as_str),
             Some("test")
         );
         assert!(

--- a/src/flavor-rs/tests/format_compat.rs
+++ b/src/flavor-rs/tests/format_compat.rs
@@ -201,9 +201,13 @@ fn execution_block_is_readable() {
 
     let metadata: Metadata = serde_json::from_str(&raw).expect("fixture must parse");
 
-    assert_eq!(metadata.execution.command, "true");
+    let execution = metadata
+        .execution
+        .as_ref()
+        .expect("the fixture declares an execution block");
+    assert_eq!(execution.command, "true");
     assert_eq!(
-        metadata.execution.env.get("MODE").map(String::as_str),
+        execution.env.get("MODE").map(String::as_str),
         Some("prod"),
         "the environment must be read from the \"env\" key"
     );

--- a/src/flavor-rs/tests/pspf_integration.rs
+++ b/src/flavor-rs/tests/pspf_integration.rs
@@ -189,7 +189,7 @@ fn reader_reads_metadata_from_real_bundle() {
     assert_eq!(metadata.slots.len(), 1);
     assert_eq!(metadata.slots[0].id, "payload");
     assert_eq!(
-        metadata.execution.command,
+        metadata.execution.as_ref().expect("execution").command,
         if cfg!(windows) {
             "cmd /C exit 0"
         } else {

--- a/tests/format_2025/test_fep0002_schema.py
+++ b/tests/format_2025/test_fep0002_schema.py
@@ -85,6 +85,32 @@ def test_minimal_document_from_section_14_is_conforming() -> None:
     assert not list(Draft202012Validator(SCHEMA).iter_errors(minimal))
 
 
+def test_an_empty_execution_block_is_conforming() -> None:
+    """A package that configures no command is readable, and refused when run.
+
+    The Python builder writes ``"execution": {}`` for such a package. Rust
+    required ``command`` within the block and so could not read those packages at
+    all — ``info`` reported ``missing field command``. See #48.
+    """
+    document = {
+        "format": "PSPF/2025",
+        "package": {"name": "minimal", "version": "1.0.0"},
+        "slots": [],
+        "execution": {},
+    }
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(document))
+
+
+def test_a_document_with_no_execution_block_is_conforming() -> None:
+    """FEP-0002 §4.1.5 lists execution as OPTIONAL."""
+    document = {
+        "format": "PSPF/2025",
+        "package": {"name": "minimal", "version": "1.0.0"},
+        "slots": [],
+    }
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(document))
+
+
 def test_unknown_members_are_accepted() -> None:
     """§5.3 requires readers to tolerate unknown members, so the schema must too.
 
@@ -127,15 +153,6 @@ def test_unknown_members_are_accepted() -> None:
                         "lifecycle": "runtime",
                     }
                 ],
-            },
-        ),
-        (
-            "execution without a command",
-            {
-                "format": "PSPF/2025",
-                "package": {"name": "m", "version": "1"},
-                "slots": [],
-                "execution": {},
             },
         ),
         (


### PR DESCRIPTION
Closes #48.

FEP-0002 §4.1.5 lists `execution` as OPTIONAL, and the root schema requires only `format`, `package`, `slots`. Go agrees — it reads such a package and refuses at the point of execution.

Rust required the object to deserialize the document *at all*, so `info`, `verify` and `metadata` failed alongside `run`. A package that cannot be executed is exactly the one an operator wants to look at, and it couldn't be looked at.

## `command` was the live half

Not hypothetical. **The Python builder writes `"execution": {}`** for a package configuring no command, and Rust could not read what it produced:

```
$ noexec.psp info
Error: Failed to read metadata: JSON error: missing field `command` at line 34 column 17
```

Same shape as #36's `primary_slot`, one level down: required in Rust, defaulted in Go.

## After

```
$ noexec.psp info
📦 Package Information:
  Name: no-exec-block
  Version: 1.0.0

$ noexec.psp verify        # works
$ noexec.psp metadata      # works

$ noexec.psp
❌ Failed to launch package: No execution configuration found
```

That last message is the one Go already uses. An empty command counts as none — a package whose command is `""` has nothing to run either.

## Where the absence is handled

The refusal moved to `prepare_command`, where running is decided. The inspection paths handle absence rather than assuming it away:

- `cli.rs` reports `Command: none — this package declares no execution block`
- the launcher's debug line says there is none
- setup commands run with no package environment, rather than not running

## Spec

Both fields become OPTIONAL, `command` leaves the schema's required set, and **§9.1 is deleted** — it existed only to record this divergence.

The schema test's `"execution without a command"` negative case went with it: that document is now conforming. Two positive tests replace it, covering `execution: {}` and no `execution` at all. The test caught this itself — it failed with *"execution without a command was accepted"*, which is the contract changing under it.

## Verification

Rust 8 suites (298 lib + integration), Go 8 packages, full Python suite. `quality-checks.sh` green for all three. `ci/pr-pretaster.sh` green across all 5 lanes.

Verified end to end on a package built by the Python builder with no command — `info`, `verify` and `metadata` all work; `run` refuses.