### PR TITLE
Lint the Rust tests, and fix what that finds

### DIFF
--- a/ci/quality-checks.sh
+++ b/ci/quality-checks.sh
@@ -85,7 +85,7 @@ case "$LANGUAGE" in
     cd src/flavor-rs || exit 1
     say "## 🦀 Rust Code Quality"
     say ""
-    check blocking "Clippy"       cargo clippy --all-features -- -D warnings
+    check blocking "Clippy"       cargo clippy --all-features --all-targets -- -D warnings
     check blocking "Rustfmt"      cargo fmt -- --check
     check advisory "Cargo machete" cargo machete
     ;;

--- a/src/flavor-rs/Makefile
+++ b/src/flavor-rs/Makefile
@@ -58,7 +58,7 @@ fmt:
 
 lint:
 	@echo "🔍 Linting Rust code..."
-	@cargo clippy -- -D warnings
+	@cargo clippy --all-targets -- -D warnings
 	@echo "✅ Clippy linting passed"
 
 security:

--- a/src/flavor-rs/src/api.rs
+++ b/src/flavor-rs/src/api.rs
@@ -130,7 +130,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn write_synthetic_pspf_package(path: &Path) {
-        let mut bytes = vec![0u8; MAGIC_TRAILER_SIZE as usize];
+        let mut bytes = vec![0u8; MAGIC_TRAILER_SIZE];
         bytes[..PACKAGE_EMOJI_BYTES.len()].copy_from_slice(PACKAGE_EMOJI_BYTES);
         let trailer_start = bytes.len() - MAGIC_WAND_EMOJI_BYTES.len();
         bytes[trailer_start..].copy_from_slice(MAGIC_WAND_EMOJI_BYTES);

--- a/src/flavor-rs/src/lib.rs
+++ b/src/flavor-rs/src/lib.rs
@@ -55,6 +55,12 @@
     clippy::too_many_arguments, // Some functions need refactoring
     missing_docs,               // Documentation is in progress
 )]
+// A test says what it expects and stops when that is not what it got, so the
+// error-handling lints above are noise there -- 437 of the 478 they reported
+// were unwrap/expect in tests. Allowing that family under cfg(test) leaves the
+// rest of the lints watching test code, which is what nothing was doing before:
+// they were switched off wholesale by CI running clippy without --all-targets.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic,))]
 
 pub mod api;
 pub mod env_vars;

--- a/src/flavor-rs/src/psp/format_2025/builder/finalization.rs
+++ b/src/flavor-rs/src/psp/format_2025/builder/finalization.rs
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(slot_table_size, SLOT_DESCRIPTOR_SIZE as u64);
         assert_eq!(descriptor_table_offset % SLOT_ALIGNMENT, 0);
 
-        stream_slot_data(&mut out, &mut descriptors, &[slot_path.clone()])
+        stream_slot_data(&mut out, &mut descriptors, std::slice::from_ref(&slot_path))
             .expect("stream slot data");
         let streamed_offset = descriptors[0].offset;
         assert!(streamed_offset >= descriptor_table_offset + SLOT_DESCRIPTOR_SIZE as u64);

--- a/src/flavor-rs/src/psp/format_2025/builder/mod.rs
+++ b/src/flavor-rs/src/psp/format_2025/builder/mod.rs
@@ -399,8 +399,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result
-                .err()
-                .expect("error")
+                .expect_err("error")
                 .to_string()
                 .contains("only supported on Windows")
         );

--- a/src/flavor-rs/src/psp/format_2025/execution/commands.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/commands.rs
@@ -356,6 +356,41 @@ fn build_workenv_path(workenv_dir: &Path, existing_path: Option<&str>) -> String
     }
 }
 
+/// Execute main command with environment
+pub fn execute_main_command(
+    command: &str,
+    args: &[String],
+    env: HashMap<String, String>,
+    workdir: &Path,
+) -> Result<i32> {
+    let parts = shell_split(command);
+    if parts.is_empty() {
+        return Ok(0);
+    }
+
+    let resolved_cmd = resolve_executable(&parts[0]);
+    let mut cmd = Command::new(&resolved_cmd);
+
+    // Add command arguments
+    if parts.len() > 1 {
+        cmd.args(&parts[1..]);
+    }
+
+    // Add user arguments
+    cmd.args(args);
+
+    // Set working directory
+    cmd.current_dir(workdir);
+
+    // Set environment
+    cmd.envs(env);
+
+    // Execute and get status
+    let status = cmd.status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,39 +676,4 @@ mod tests {
             .expect("command should execute");
         assert_eq!(result, 7);
     }
-}
-
-/// Execute main command with environment
-pub fn execute_main_command(
-    command: &str,
-    args: &[String],
-    env: HashMap<String, String>,
-    workdir: &Path,
-) -> Result<i32> {
-    let parts = shell_split(command);
-    if parts.is_empty() {
-        return Ok(0);
-    }
-
-    let resolved_cmd = resolve_executable(&parts[0]);
-    let mut cmd = Command::new(&resolved_cmd);
-
-    // Add command arguments
-    if parts.len() > 1 {
-        cmd.args(&parts[1..]);
-    }
-
-    // Add user arguments
-    cmd.args(args);
-
-    // Set working directory
-    cmd.current_dir(workdir);
-
-    // Set environment
-    cmd.envs(env);
-
-    // Execute and get status
-    let status = cmd.status()?;
-
-    Ok(status.code().unwrap_or(1))
 }

--- a/src/flavor-rs/src/psp/format_2025/extraction.rs
+++ b/src/flavor-rs/src/psp/format_2025/extraction.rs
@@ -443,7 +443,7 @@ mod tests {
     }
 
     fn write_octal(field: &mut [u8], value: u64, width: usize) {
-        let mut encoded = format!("{value:0width$o}", width = width).into_bytes();
+        let mut encoded = format!("{value:0width$o}").into_bytes();
         encoded.push(0);
         if field.len() > encoded.len() {
             encoded.push(b' ');
@@ -598,8 +598,9 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let target = temp_dir.path().join("nested/tool");
         let mut descriptor = SlotDescriptor::new(0);
-        descriptor.permissions = 0o755u16 as u8;
-        descriptor.permissions_high = (0o755u16 >> 8) as u8;
+        let [low, high] = 0o755u16.to_le_bytes();
+        descriptor.permissions = low;
+        descriptor.permissions_high = high;
 
         extract_single_file(b"hello, world", &target, &[descriptor], 0)
             .expect("extract single file");
@@ -650,13 +651,13 @@ mod tests {
         #[test]
         fn prop_resolve_always_under_dest(target in "([a-z0-9_./]{0,50})") {
             let dest = Path::new("/tmp/workenv");
-            match resolve_in_workenv(dest, Path::new(&target)) {
-                Ok(resolved) => prop_assert!(
+            // Rejection is always safe; only an accepted path has to be checked.
+            if let Ok(resolved) = resolve_in_workenv(dest, Path::new(&target)) {
+                prop_assert!(
                     resolved.starts_with(dest),
                     "Resolved path {:?} escapes {:?}",
                     resolved, dest
-                ),
-                Err(_) => {} // Rejection is always safe
+                );
             }
         }
 

--- a/src/flavor-rs/src/utils/mod.rs
+++ b/src/flavor-rs/src/utils/mod.rs
@@ -71,10 +71,10 @@ mod tests {
 
     #[test]
     fn is_env_true_handles_truthy_and_falsey_values() {
-        assert!(matches!(is_env_true_from_value(Some("true")), true));
-        assert!(matches!(is_env_true_from_value(Some("YES")), true));
-        assert!(matches!(is_env_true_from_value(Some("0")), false));
-        assert!(matches!(is_env_true_from_value(None), false));
+        assert!(is_env_true_from_value(Some("true")));
+        assert!(is_env_true_from_value(Some("YES")));
+        assert!(!is_env_true_from_value(Some("0")));
+        assert!(!is_env_true_from_value(None));
     }
 
     #[test]


### PR DESCRIPTION
Closes #28.

CI ran `cargo clippy --all-features -- -D warnings` — library and binaries, and nothing else. **Test code had no lint floor at all**, so a genuine problem in a fixture builder had nowhere to surface.

## 478 → 11 → 0

Adding `--all-targets` reported 478 errors. 437 were `unwrap`/`expect` in tests — which is what the crate's error-handling lints exist for, and not what tests should be judged by: a test says what it expects and stops when that isn't what it got.

Those three lints are allowed under `cfg(test)`. That leaves **every other lint watching test code**, including the ones that were the reason to look.

The issue proposed exactly this (option 2) and predicted roughly this outcome.

## The eleven, all real

| finding | |
|---|---|
| **`u16` cast to `u8` that truncates** | `0o755` doesn't fit a byte. Splitting it across `permissions`/`permissions_high` is the intent, so it now says so with `to_le_bytes` instead of relying on the cast to drop the high bits |
| `MAGIC_TRAILER_SIZE as usize` | already a `usize` |
| a `clone` to build a one-element slice | `from_ref` doesn't allocate |
| `.err().expect(...)` | `expect_err` |
| 4× `matches!(expr, true)` | the expression *is* the assertion |
| a `match` with an empty second arm | that's an `if let` |
| a `format!` naming a variable | it could interpolate |
| a function defined after the test module | at the end of the file |

The truncating cast is the one the issue hoped this would catch.

## Proving the gate actually reaches test code

Not assumed — a `len_zero` violation placed in a test module:

```
src/zz_probe.rs:10:12: error: length comparison to zero: help: using `is_empty` is clearer
```

Before this change, that file would have been invisible to the gate.

`ci/quality-checks.sh` and the flavor-rs `Makefile` both pass `--all-targets`, so `make lint` and CI now agree about what is linted — they didn't before.

## Verification

`cargo clippy --all-features --all-targets -- -D warnings` clean. All 8 Rust test suites pass. `ci/quality-checks.sh rust` green. `cargo fmt --check` clean.