### PR TITLE
Make the builder prove the launcher it ships can read the package

### DIFF
--- a/docs/reference/spec/fep-0002-json-metadata-format.md
+++ b/docs/reference/spec/fep-0002-json-metadata-format.md
@@ -652,6 +652,18 @@ A reader MUST check these after substitution, not before: a placeholder can expa
 
 A reader MUST ignore members it does not recognise, at every level. This is what lets a package written by a newer producer stay readable.
 
+### 5.4 Compatibility Directions
+
+Two directions are possible between a package and the code reading it. This specification promises one.
+
+**A newer reader accepts an older package.** Every implementation is checked against packages committed before it (§14), so a change that breaks this direction fails its own suite rather than someone's install.
+
+**An older reader is not promised a newer package.** A producer that begins writing a member, or stops writing an OPTIONAL one, remains conforming. A reader built before that change may reject the result, and nothing in this specification prevents it.
+
+That asymmetry places one obligation on readers. A reader MUST NOT mark a member OPTIONAL in this specification as required in its own parser — an absent OPTIONAL member takes the default in Section 4 (§13). Requiredness is expressed differently by each implementation: a struct field that is not `Option` in Rust, a schema entry listed under `required`, a constructor argument without a default. Any of them rejects every conforming package that omits the member.
+
+The cost of getting this wrong is paid late. A package carries the launcher that runs it, so the producer writing the metadata and the launcher reading it are versioned separately and only their combination ships. A producer that stops writing an OPTIONAL member the embedded launcher requires produces a package that builds clean and fails when someone runs it. §13 requires the producer to close that gap before reporting success.
+
 ## 6. Encoding and Storage
 
 ### 6.1 JSON Encoding
@@ -1054,6 +1066,9 @@ A conforming producer MUST:
 3. Write `slots` in index order with `slot` matching position
 4. Write checksums as `algorithm:hex`, the prefix appearing once
 5. Write the package environment under `env`
+6. Confirm the launcher it embeds reads the package it just wrote, before reporting success (§5.4)
+
+Requirement 6 is a check the producer makes against its own output, not a compatibility matrix: the launcher under test is the one being shipped. It holds for members no one has defined yet, and it turns a failure that would surface in whoever runs the package into a failure of the build that made it.
 
 ## 14. Test Vectors
 

--- a/src/flavor/config/defaults.py
+++ b/src/flavor/config/defaults.py
@@ -173,6 +173,11 @@ ENV_TRUSTED_KEYS_DIR = "FLAVOR_TRUSTED_KEYS_DIR"
 ENV_LOG_LEVEL = "FLAVOR_LOG_LEVEL"
 ENV_VALIDATION = "FLAVOR_VALIDATION"
 ENV_LAUNCHER_BIN = "FLAVOR_LAUNCHER_BIN"
+# Set to "1" to make a package's embedded launcher take a subcommand (info,
+# verify, extract) instead of running the payload. Read by both the Go and Rust
+# launchers; see src/flavor-rs/src/env_vars.rs and
+# src/flavor-go/pkg/psp/format_2025/envvars.go.
+ENV_LAUNCHER_CLI = "FLAVOR_LAUNCHER_CLI"
 ENV_WORKENV_BASE = "FLAVOR_WORKENV_BASE"
 ENV_WORKENV = "FLAVOR_WORKENV"
 

--- a/src/flavor/packaging/orchestrator.py
+++ b/src/flavor/packaging/orchestrator.py
@@ -24,6 +24,7 @@ from flavor.packaging.orchestrator_helpers import (
     create_python_slot_tarballs,
     find_builder_executable,
     find_launcher_executable,
+    verify_built_package,
     write_manifest_file,
 )
 from flavor.packaging.python.packager import PythonPackager
@@ -176,6 +177,15 @@ class PackagingOrchestrator:
             self._build_with_external_builder()
         else:
             self._build_with_python_builder()
+
+        # The builder and the launcher prepended to its output are versioned
+        # separately, so a package can build clean and be unreadable by the very
+        # launcher it ships. Catch that here rather than in a user's hands.
+        verify_built_package(
+            Path(self.output_flavor_path),
+            launcher_name=self._launcher_path.name,
+            host_platform=self.platform,
+        )
 
     @log_only_error_context(
         context_provider=lambda: {"operation": "build_with_python_builder"},

--- a/src/flavor/packaging/orchestrator_helpers.py
+++ b/src/flavor/packaging/orchestrator_helpers.py
@@ -12,11 +12,18 @@ import tarfile
 from typing import Any
 
 from provide.foundation import logger
+from provide.foundation.errors import ProcessError
 from provide.foundation.file.formats import write_json
 from provide.foundation.platform import is_windows
+from provide.foundation.process import run
 from provide.foundation.serialization import json_dumps
 
-from flavor.config.defaults import ENV_BUILDER_BIN, ENV_LAUNCHER_BIN
+from flavor.config.defaults import (
+    ENV_BUILDER_BIN,
+    ENV_LAUNCHER_BIN,
+    ENV_LAUNCHER_CLI,
+    ENV_LAUNCHER_LOG_LEVEL,
+)
 from flavor.exceptions import BuildError
 from flavor.packaging.defaults import DEFAULT_ENV_ISOLATION_UNSET, WINDOWS_SYSTEM_PASS
 
@@ -372,6 +379,110 @@ def find_launcher_executable(launcher_bin: str | None) -> Path:
                 "\n"
                 f"🔍 Searched locations: {manager.helpers_bin.as_posix()}, {manager.installed_helpers_bin.as_posix()}"
             ) from e
+
+
+def _run_launcher_verify(package_path: Path) -> Any:
+    """Run a package's own launcher against it in CLI mode."""
+    return run(
+        [package_path.as_posix(), "verify"],
+        env={
+            **os.environ,
+            ENV_LAUNCHER_CLI: "1",
+            # Launchers log at debug by default, which buries the one line that
+            # says why the package was rejected under startup trace.
+            ENV_LAUNCHER_LOG_LEVEL: "error",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _last_lines(output: str | None, count: int = 3) -> str:
+    """Return the final non-empty lines of launcher output.
+
+    The diagnosis is the last thing a launcher prints, and anything a stray
+    logger emits first would otherwise be reported as the reason.
+    """
+    lines = [line.strip() for line in (output or "").splitlines() if line.strip()]
+    return "\n   ".join(lines[-count:])
+
+
+def verify_built_package(package_path: Path, *, launcher_name: str, host_platform: str) -> None:
+    """Ask a freshly built package's own launcher to read it back.
+
+    A PSPF package is a launcher with slots appended, so every build joins two
+    independently versioned halves: the builder that writes the metadata and the
+    launcher binary prepended to it. Nothing else makes them agree. When the
+    builder stops writing a field the embedded launcher requires, the build still
+    succeeds and the package fails at run time, wherever it has reached by then.
+
+    Running the package's own launcher against it turns that into a build
+    failure. It needs no compatibility matrix, because the launcher under test is
+    the one being shipped, and it holds for fields nobody has thought of yet.
+
+    Args:
+        package_path: The package the builder just wrote.
+        launcher_name: File name of the launcher embedded in it, which carries
+            the platform it was built for.
+        host_platform: Platform this build is running on.
+
+    Raises:
+        BuildError: The package is missing, or its launcher will not read it.
+    """
+    if not package_path.exists():
+        raise BuildError(f"Build reported success but produced no file: {package_path}")
+
+    # Running the package means running the launcher inside it, which only works
+    # when that launcher is native. A foreign one is a deliberate --launcher-bin
+    # choice, already warned about when the launcher is resolved.
+    if host_platform not in launcher_name and "any" not in launcher_name:
+        logger.warning(
+            "⚠️🚀 Skipping launcher read-back: embedded launcher is not native",
+            launcher=launcher_name,
+            host=host_platform,
+            package=package_path.name,
+            consequence="a launcher that cannot read this package would not be caught here",
+        )
+        return
+
+    logger.info("🔍🚀 Asking the embedded launcher to read the package back...")
+    try:
+        result = _run_launcher_verify(package_path)
+    except ProcessError as exc:
+        # The package could not be started at all -- a noexec mount, a lost exec
+        # bit. That says nothing about the package, but it does mean this build
+        # never confirmed the one thing it was supposed to, so it does not pass.
+        raise BuildError(
+            f"❌ Could not run {package_path.name} to check it.\n"
+            "\n"
+            "   The build cannot confirm the embedded launcher reads the package, "
+            "so it stops rather than report a check it never made.\n"
+            "\n"
+            f"   {exc}\n"
+            "\n"
+            "💡 Usually the output directory is mounted noexec, or the package lost "
+            "its execute bit."
+        ) from exc
+
+    if result.returncode == 0:
+        logger.info("✅🚀 Embedded launcher reads the package it ships in")
+        return
+
+    said = _last_lines(result.stderr) or _last_lines(result.stdout)
+    raise BuildError(
+        f"❌ The launcher embedded in {package_path.name} cannot read the package it ships in.\n"
+        "\n"
+        "   Anyone running this package would get the same failure, so the build "
+        "stops here instead.\n"
+        "\n"
+        f"   Launcher said: {said or f'exit status {result.returncode}, no output'}\n"
+        "\n"
+        "💡 This usually means the builder and the launcher are different versions:\n"
+        f"   • rebuild the helpers so both halves match ({ENV_LAUNCHER_BIN} overrides which "
+        "launcher is used)\n"
+        "   • or the metadata changed in a way the launcher cannot parse"
+    )
 
 
 def create_python_builder_metadata(

--- a/tests/packaging/test_orchestrator_self_check.py
+++ b/tests/packaging/test_orchestrator_self_check.py
@@ -1,0 +1,245 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for the post-build check that a package is readable by its own launcher.
+
+A PSPF package carries the launcher that runs it, so a build mixes two versions:
+the builder writing the metadata and the launcher binary prepended to it. Nothing
+made them agree. A builder that drops a field the embedded launcher requires
+produces a package that builds clean and fails at run time, in whoever's hands it
+reached — which is the expensive shape for a defect to have.
+
+``verify_built_package`` closes that by asking the embedded launcher to read the
+package back before the build is allowed to succeed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from flavor.exceptions import BuildError
+from flavor.packaging.orchestrator_helpers import verify_built_package
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the stub launchers are shell scripts",
+)
+
+
+def _stub_package(path: Path, body: str) -> Path:
+    """Write an executable stub standing in for a built package."""
+    path.write_text(f"#!/bin/sh\n{body}\n")
+    path.chmod(0o755)
+    return path
+
+
+class TestVerifyBuiltPackage:
+    """The embedded launcher has to accept the package before the build passes."""
+
+    def test_package_its_launcher_reads_is_accepted(self, tmp_path: Path) -> None:
+        """A launcher that verifies its package lets the build finish."""
+        package = _stub_package(tmp_path / "good.psp", "exit 0")
+
+        verify_built_package(
+            package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+        )
+
+    def test_package_its_launcher_cannot_read_fails_the_build(self, tmp_path: Path) -> None:
+        """A launcher that rejects its own package fails the build, not the user."""
+        package = _stub_package(tmp_path / "bad.psp", "exit 1")
+
+        with pytest.raises(BuildError, match=r"cannot read the package"):
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+            )
+
+    def test_failure_carries_what_the_launcher_said(self, tmp_path: Path) -> None:
+        """The launcher's own diagnosis reaches the developer.
+
+        Without it the error says a package is unreadable and not why, which
+        leaves the actual missing field to be rediscovered by hand.
+        """
+        package = _stub_package(
+            tmp_path / "bad.psp",
+            'echo "missing field \\`primary_slot\\`" >&2\nexit 1',
+        )
+
+        with pytest.raises(BuildError, match=r"primary_slot"):
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+            )
+
+    def test_diagnosis_survives_leading_log_noise(self, tmp_path: Path) -> None:
+        """The reason is the last thing printed, not the first.
+
+        Launchers emit startup logging before they get as far as rejecting a
+        package, so reporting the head of the output names a log line as the
+        cause and buries the real one.
+        """
+        package = _stub_package(
+            tmp_path / "noisy.psp",
+            'echo "DEBUG launcher process started" >&2\n'
+            'echo "DEBUG reading trailer" >&2\n'
+            'echo "Error: missing field \\`primary_slot\\`" >&2\n'
+            "exit 1",
+        )
+
+        with pytest.raises(BuildError) as caught:
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+            )
+
+        reported = [line for line in str(caught.value).splitlines() if "Launcher said" in line]
+        assert reported, "the failure did not quote the launcher at all"
+        assert "primary_slot" in str(caught.value)
+
+    def test_check_runs_the_launcher_in_cli_mode(self, tmp_path: Path) -> None:
+        """Without FLAVOR_LAUNCHER_CLI the launcher runs the payload instead of verifying.
+
+        A check that silently executed the package would be worse than no check.
+        """
+        package = _stub_package(
+            tmp_path / "probe.psp",
+            '[ "$FLAVOR_LAUNCHER_CLI" = "1" ] || exit 1\n[ "$1" = "verify" ] || exit 1\nexit 0',
+        )
+
+        verify_built_package(
+            package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+        )
+
+    def test_foreign_launcher_skips_the_check(self, tmp_path: Path) -> None:
+        """A launcher built for another platform cannot run here, so the check stands down.
+
+        The stub fails if executed, so reaching the end proves it was not run.
+        """
+        package = _stub_package(tmp_path / "foreign.psp", "exit 1")
+
+        verify_built_package(
+            package, launcher_name="flavor-rs-launcher-linux_arm64", host_platform="darwin_arm64"
+        )
+
+    def test_platform_agnostic_launcher_is_still_checked(self, tmp_path: Path) -> None:
+        """An "any" launcher runs anywhere, so it gets checked anywhere.
+
+        Skipping it would silently drop the check for every package built with one.
+        """
+        package = _stub_package(tmp_path / "any.psp", "exit 1")
+
+        with pytest.raises(BuildError, match=r"cannot read the package"):
+            verify_built_package(package, launcher_name="flavor-rs-launcher-any", host_platform="darwin_arm64")
+
+    def test_skip_is_reported(self, tmp_path: Path) -> None:
+        """A skipped check says so, naming both platforms.
+
+        A check that quietly does nothing reads as a check that passed, which is
+        the failure this whole function exists to remove.
+        """
+        package = _stub_package(tmp_path / "foreign.psp", "exit 1")
+
+        with patch("flavor.packaging.orchestrator_helpers.logger") as log:
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_arm64", host_platform="darwin_arm64"
+            )
+
+        said = " ".join(str(call) for call in log.warning.call_args_list)
+        assert "linux_arm64" in said, f"skip did not name the launcher: {said}"
+        assert "darwin_arm64" in said, f"skip did not name the host platform: {said}"
+
+    def test_unrunnable_environment_is_reported_as_itself(self, tmp_path: Path) -> None:
+        """A package that will not start is a different failure from one that is rejected.
+
+        A noexec mount or a lost execute bit stops the check from running at all.
+        Reporting that as "the launcher cannot read the package" sends the
+        developer after a format bug that is not there.
+        """
+        package = tmp_path / "noexec.psp"
+        package.write_text("#!/bin/sh\nexit 0\n")
+        package.chmod(0o644)
+
+        with pytest.raises(BuildError, match=r"Could not run"):
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+            )
+
+    def test_unrunnable_environment_does_not_pass_silently(self, tmp_path: Path) -> None:
+        """Not being able to check is not the same as checking and passing."""
+        package = tmp_path / "noexec.psp"
+        package.write_text("#!/bin/sh\nexit 0\n")
+        package.chmod(0o644)
+
+        with pytest.raises(BuildError) as caught:
+            verify_built_package(
+                package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+            )
+
+        assert "never made" in str(caught.value)
+
+    def test_missing_package_is_an_error(self, tmp_path: Path) -> None:
+        """A build that produced no file at all fails here rather than later."""
+        with pytest.raises(BuildError, match=r"produced no file"):
+            verify_built_package(
+                tmp_path / "absent.psp",
+                launcher_name="flavor-rs-launcher-linux_amd64",
+                host_platform="linux_amd64",
+            )
+
+
+class TestIntegrityIsNotRunnability:
+    """A package can pass every integrity check and still not run."""
+
+    def test_python_verifier_accepts_what_the_launcher_rejects(self, tmp_path: Path) -> None:
+        """``flavor pack --verify`` proves Python can read a package, not that it runs.
+
+        The existing post-build check calls FlavorVerifier: checksums, signature,
+        magic. All of those hold for a package whose embedded launcher refuses to
+        parse the metadata, so the build reports "Package integrity verified" for
+        something nobody can execute. The two checks answer different questions
+        and neither substitutes for the other.
+        """
+        from flavor.psp.format_2025.pspf_builder import PSPFBuilder
+        from flavor.verification import FlavorVerifier
+
+        payload = tmp_path / "payload.txt"
+        payload.write_text("payload\n")
+
+        # Stands in for a launcher that cannot read what this builder wrote.
+        launcher = tmp_path / "launcher-stub.sh"
+        launcher.write_text("#!/bin/sh\necho 'Error: missing field' >&2\nexit 1\n")
+        launcher.chmod(0o755)
+
+        package = tmp_path / "unrunnable.psp"
+        result = (
+            PSPFBuilder.create()
+            .metadata(name="probe", version="1.0.0", execution={"command": "true", "env": {}})
+            .add_slot(
+                id="payload",
+                data=payload,
+                target="data/payload.txt",
+                operations="",
+                purpose="data",
+                lifecycle="runtime",
+                permissions="0644",
+            )
+            .with_keys(seed="integrity-is-not-runnability")
+            .with_options(launcher_bin=launcher)
+            .build(package)
+        )
+        assert result.success, result.errors
+        package.chmod(0o755)
+
+        integrity = FlavorVerifier.verify_package(package)
+        assert integrity["valid"], "fixture is wrong: the package should be internally sound"
+        assert integrity["checksums_valid"]
+        assert integrity["signature_valid"]
+
+        with pytest.raises(BuildError, match=r"cannot read the package"):
+            verify_built_package(package, launcher_name="flavor-rs-launcher-any", host_platform="linux_amd64")
+
+
+# 🌶️📦🔚

--- a/tests/resilience/test_launcher_availability.py
+++ b/tests/resilience/test_launcher_availability.py
@@ -148,8 +148,11 @@ class TestLauncherAvailability:
         mock_find.return_value = Path("launcher-windows-amd64")
         orchestrator = orchestrator_factory()
         orchestrator.build_package()
-        mock_logger.assert_called_once()
-        assert "mismatch" in mock_logger.call_args[0][0].lower()
+        # logger is a shared singleton, so this mock also catches the launcher
+        # read-back skip that a foreign launcher triggers. Assert the mismatch
+        # warning is among the calls rather than that it is the only one.
+        warnings = [str(call).lower() for call in mock_logger.call_args_list]
+        assert any("mismatch" in warning for warning in warnings), warnings
 
 
 class TestLauncherReproducibility:

--- a/tests/test_coverage_final3.py
+++ b/tests/test_coverage_final3.py
@@ -468,6 +468,7 @@ class TestOrchestratorBranches:
             patch("flavor.packaging.orchestrator.os.access", return_value=True),
             patch("flavor.packaging.orchestrator.logger") as mock_logger,
             patch.object(orch, "_build_with_python_builder"),
+            patch("flavor.packaging.orchestrator.verify_built_package"),
             patch(
                 "flavor.packaging.orchestrator.get_platform_string",
                 return_value="darwin_arm64",
@@ -515,6 +516,7 @@ class TestOrchestratorBranches:
             patch("flavor.packaging.orchestrator.os.access", return_value=True),
             patch("flavor.packaging.orchestrator.run") as mock_run,
             patch.object(orch, "_detect_launcher_type", return_value="rust"),
+            patch("flavor.packaging.orchestrator.verify_built_package"),
         ):
             orch.platform = "darwin_arm64"
             orch.build_package()

--- a/tests/test_coverage_gaps_batch2.py
+++ b/tests/test_coverage_gaps_batch2.py
@@ -1575,6 +1575,9 @@ class TestPackagingOrchestrator:
             patch("flavor.packaging.orchestrator.find_launcher_executable", return_value=launcher),
             patch("flavor.packaging.orchestrator.os.access", return_value=True),
             patch.object(orch, "_build_with_python_builder") as mock_build,
+            # The mocked builder writes no package, so the post-build read-back
+            # has nothing to run. It has its own tests.
+            patch("flavor.packaging.orchestrator.verify_built_package"),
         ):
             orch.build_package()
         mock_build.assert_called_once()


### PR DESCRIPTION
## The gap

A PSPF package is a launcher with slots appended, so every build joins two independently versioned halves: the builder writing the metadata and the launcher binary prepended to it. Nothing made them agree.

When the builder stops writing a field the embedded launcher requires, **the build succeeds and the package fails at run time**, wherever it has reached by then.

## Found while building the test for #37

Removing `execution.primary_slot` is a live example. Nothing reads the value, but `v0.4.6 src/flavor-rs/src/psp/format_2025/metadata.rs:68` declares it:

```rust
pub struct ExecutionInfo {
    pub primary_slot: usize,          // no #[serde(default)], no Option
    pub command: String,
    #[serde(default)]
    pub env: HashMap<String, String>,
}
```

Required to deserialize. A package built by current `main` and run under that launcher:

```
❌ Launch error: JSON error: missing field `primary_slot` at line 39 column 3   (exit 104)
```

Go survives the same package — `encoding/json` defaults the absent field — so the break is Rust-only and invisible to every same-tree test.

## The fix

After building, the orchestrator runs the package's own launcher against it:

```
FLAVOR_LAUNCHER_CLI=1 ./pkg.psp verify
```

Nonzero fails the build. The launcher under test is the one being shipped, so this needs no compatibility matrix and holds for fields nobody has defined yet.

**67ms on a 97MB package**, measured on a real `flavor pack` of this repo.

```
❌ The launcher embedded in fwd-compat.psp cannot read the package it ships in.

   Anyone running this package would get the same failure, so the build stops here instead.

   Launcher said: Error: Verification failed: JSON error: missing field `primary_slot` at line 39 column 3

💡 This usually means the builder and the launcher are different versions:
   • rebuild the helpers so both halves match (FLAVOR_LAUNCHER_BIN overrides which launcher is used)
   • or the metadata changed in a way the launcher cannot parse
```

## Why `--verify` did not already cover it

The post-build check calls `FlavorVerifier` — the **Python** reader. Checksums, signature, magic. On the package above it returns:

```
{'valid': True, 'checksums_valid': True, 'signature_valid': True}
```

`flavor pack --verify` prints `✅ Package integrity verified` for a package nobody can run. `TestIntegrityIsNotRunnability` builds one and pins that the two checks answer different questions.

## Edges

- **Cannot run the check** (noexec mount, lost exec bit) is reported as itself, not as a rejected package — and does not pass. Being unable to check is not checking and passing.
- **Foreign launcher** (deliberate `--launcher-bin` for another platform) cannot run here, so the check stands down and logs both platforms.
- The diagnosis is taken from the *end* of launcher output — the launcher logs startup trace first, and reporting the head names a log line as the cause.

## Spec

FEP-0002 gains **§5.4 Compatibility Directions**: a newer reader accepts an older package (pinned by the committed fixtures); an older reader is promised nothing; and a reader MUST NOT make an OPTIONAL member required in its own parser, in whatever form its parser expresses requiredness. **§13** requires a producer to confirm its output before reporting success.

This is the honest answer to #37. Forward compatibility stops being a promise tested in CI and becomes a property a build cannot violate by accident.

## Verification

- 12 new tests in `tests/packaging/test_orchestrator_self_check.py`, TDD (red first, `ImportError`, then green)
- Full suite: **2787 passed**, 0 failed
- `ci/quality-checks.sh python`: ruff format, ruff lint, mypy, bandit all pass
- Real `flavor pack` of this repo end to end: check runs, passes, 67ms
- Validated against the actual 0.4.6 launcher extracted from the published release `.psp`

Four existing tests needed updating — three mock the builder subprocess so no package is written, and one asserted a warning was the *only* one (`logger` is a shared singleton, so it also caught the read-back skip). Each is annotated with why.

Closes #37.