### PR TITLE
Decompose the launch and build paths; enforce complexity as a ratchet

### DIFF
--- a/ci/quality-checks.sh
+++ b/ci/quality-checks.sh
@@ -10,8 +10,12 @@
 #
 # Blocking status is decided by what passes on main today, not by how
 # important a check feels. golangci-lint and staticcheck report nothing on main
-# and are enforced, as is cargo machete once it could actually run. gocyclo
-# stays advisory while its backlog is open; promote it as it clears.
+# and are enforced, as is cargo machete once it could actually run.
+#
+# The two complexity checks are enforced as ratchets: the blocking threshold is
+# what the tree holds today, so nothing may get worse, and an advisory check
+# beside it reports the distance to the target. Tighten the blocking one as the
+# advisory one clears.
 #
 # Note on exit codes: checks redirect to a log rather than piping to tee. In a
 # pipeline it is tee's status that survives, not the tool's, which is one of
@@ -87,7 +91,13 @@ case "$LANGUAGE" in
     check blocking "Ruff lint"    ruff check src/ tests/
     check blocking "Mypy"         mypy src/flavor
     check blocking "Bandit"       bandit -r src -ll
-    check advisory "Xenon complexity" xenon --max-absolute B --max-modules A --max-average A src/
+    # Two thresholds. The blocking one is a ratchet: it is set to what the tree
+    # holds today, so nothing may get worse, and it is meant to be tightened as
+    # the advisory one is cleared. The advisory one is the target -- B absolute,
+    # A modules and average -- and reports the 16 B-rank and 22 C-rank blocks
+    # still between here and there.
+    check blocking "Xenon complexity" xenon --max-absolute C --max-modules C --max-average B src/
+    check advisory "Xenon complexity (target)" xenon --max-absolute B --max-modules A --max-average A src/
     check blocking "Vulture dead code" vulture
     ;;
   go)
@@ -97,7 +107,11 @@ case "$LANGUAGE" in
     check blocking "Go vet"       go vet ./...
     check blocking "GolangCI-Lint" golangci-lint run
     check blocking "Staticcheck"  staticcheck ./...
-    check advisory "Gocyclo"      gocyclo -over 15 .
+    # Ratchet, as for xenon above: 32 is the worst function in the tree today
+    # (runBundleWithCwd), so this fails on anything worse. 15 is the target and
+    # lists what is still between the two.
+    check blocking "Gocyclo"      gocyclo -over 32 .
+    check advisory "Gocyclo (target)" gocyclo -over 15 .
     ;;
   rust)
     cd src/flavor-rs || exit 1

--- a/src/flavor-go/pkg/psp/format_2025/builder.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder.go
@@ -4,16 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"crypto/sha256"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"hash/adler32"
 	"io"
 	"log/slog"
 	"math"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -110,67 +107,15 @@ var buildImpl = doBuild
 // doBuild performs the actual build
 func doBuild(logger *slog.Logger, manifestPath, outputPath, launcherBin, privateKeyPath, publicKeyPath, keySeed string) {
 
-	// Read manifest
-	manifestData, err := readFileValidated(manifestPath)
-	if err != nil {
-		logger.Error("❌ Failed to read manifest", "error", err)
-		buildExitFn(1)
+	config, ok := loadBuildManifest(manifestPath, logger)
+	if !ok {
 		return
 	}
 
-	var config BuildOptions
-	if err := json.Unmarshal(manifestData, &config); err != nil {
-		logger.Error("❌ Failed to parse manifest", "error", err)
-		buildExitFn(1)
-		return
-	}
-
-	// 🚀 Get launcher binary path
-	// Priority: 1. Command-line arg, 2. FLAVOR_LAUNCHER_BIN env var
-	launcherPath := launcherBin
-	if launcherPath == "" {
-		launcherPath = getLauncherPath("")
-	}
-	if launcherPath == "" {
-		logger.Error("❌ Launcher binary path must be specified via --launcher-bin or FLAVOR_LAUNCHER_BIN environment variable")
-		buildExitFn(1)
-	}
-	logger.Info("🚀 Loading launcher", "path", launcherPath)
+	launcherData, launcherPath := loadLauncherBinary(launcherBin, logger)
 	// BuildConfig.Launcher was declared and logged but never assigned, so every
 	// build reported an empty launcher. Record the launcher actually embedded.
 	config.Launcher = launcherPath
-
-	// Check launcher version.
-	// Launchers deliberately never intercept arguments outside CLI mode -- every
-	// argument belongs to the packaged application -- so probing with --version
-	// was executed as the package and always failed. CLI mode is the supported
-	// channel, and its "version" command does not touch the bundle.
-	// Read stdout only; the launcher logs to stderr.
-	versionCmd := exec.Command(launcherPath, "version") // #nosec G204 -- launcherPath is operator-supplied and executed directly without shell expansion for a version probe.
-	versionCmd.Env = append(os.Environ(), EnvLauncherCLI+"=1")
-	versionOutput, err := versionCmd.Output()
-	if err != nil {
-		logger.Warn("⚠️ Failed to get launcher version", "error", err)
-	} else {
-		versionStr := strings.TrimSpace(string(versionOutput))
-		logger.Info("🔍 Launcher version", "version", versionStr)
-	}
-
-	logger.Debug("🔍 Launcher path", "path", launcherPath)
-	launcherData, err := readFileValidated(launcherPath)
-	if err != nil {
-		logger.Error("❌ Failed to read launcher", "error", err, "path", launcherPath)
-		buildExitFn(1)
-	}
-	logger.Debug("✅ Launcher loaded", "size", len(launcherData))
-
-	// Process launcher for Windows PE compatibility if needed
-	launcherData, err = processLauncherFn(launcherData, logger)
-	if err != nil {
-		logger.Error("❌ Failed to process launcher for PSPF", "error", err)
-		buildExitFn(1)
-	}
-	logger.Debug("✅ Launcher processed for PSPF", "size", len(launcherData))
 
 	// 📁 Create output directory if it doesn't exist
 	outputDir := filepath.Dir(outputPath)
@@ -226,74 +171,10 @@ func doBuild(logger *slog.Logger, manifestPath, outputPath, launcherBin, private
 	// Add slot metadata to package metadata
 	metadata.Slots = slotMetadataList
 
-	// 📜 Create and write metadata (gzipped JSON) - RIGHT AFTER LAUNCHER
-	metadataPos, err := out.Seek(0, io.SeekCurrent)
-	if err != nil {
-		logger.Error("❌ Failed to get file position", "error", err)
-		buildExitFn(1)
-	}
-	logger.Debug("📜 Writing metadata (gzipped JSON)", "position", metadataPos)
-	metadataSize, signature, err := writeMetadataFn(out, metadata, privateKey, publicKey)
-	if err != nil {
-		logger.Error("❌ Failed to write metadata", "error", err)
-		buildExitFn(1)
-	}
-	logger.Debug("✅ Metadata written", "size", metadataSize)
+	// Metadata sits immediately after the launcher; its signature goes in the index.
+	signature := writePackageMetadata(out, metadata, privateKey, publicKey, index, logger)
 
-	index.MetadataOffset, err = int64ToUint64Checked(metadataPos, "metadata offset")
-	if err != nil {
-		logger.Error("❌ Failed to convert metadata offset", "error", err)
-		buildExitFn(1)
-	}
-	index.MetadataSize, err = intToUint64Checked(metadataSize, "metadata size")
-	if err != nil {
-		logger.Error("❌ Failed to convert metadata size", "error", err)
-		buildExitFn(1)
-	}
-
-	// Write slot table
-	currentPos, err := out.Seek(0, io.SeekCurrent)
-	if err != nil {
-		logger.Error("❌ Failed to get file position", "error", err)
-		buildExitFn(1)
-	}
-	slotTableOffset := AlignOffset(currentPos, SlotAlignment)
-	if _, err := out.Seek(slotTableOffset, 0); err != nil {
-		logger.Error("Failed to seek to slot table", "error", err)
-		buildExitFn(1)
-	}
-
-	index.SlotTableOffset, err = int64ToUint64Checked(slotTableOffset, "slot table offset")
-	if err != nil {
-		logger.Error("❌ Failed to convert slot table offset", "error", err)
-		buildExitFn(1)
-	}
-	index.SlotCount, err = intToUint32Checked(len(slotDescriptors), "slot count")
-	if err != nil {
-		logger.Error("❌ Failed to convert slot count", "error", err)
-		buildExitFn(1)
-	}
-	slotCount64, err := intToUint64Checked(len(slotDescriptors), "slot count")
-	if err != nil {
-		logger.Error("❌ Failed to convert slot count", "error", err)
-		buildExitFn(1)
-	}
-	index.SlotTableSize, err = multiplyUint64Checked(slotCount64, SlotDescriptorSize, "slot table size")
-	if err != nil {
-		logger.Error("❌ Failed to calculate slot table size", "error", err)
-		buildExitFn(1)
-	}
-
-	// Reserve space for slot table (we'll write it after calculating slot offsets)
-	slotTableSizeInt64, err := uint64ToInt64Checked(index.SlotTableSize, "slot table size")
-	if err != nil {
-		logger.Error("❌ Failed to convert slot table size", "error", err)
-		buildExitFn(1)
-	}
-	if _, err := out.Seek(slotTableOffset+slotTableSizeInt64, 0); err != nil {
-		logger.Error("Failed to seek past slot table", "error", err)
-		buildExitFn(1)
-	}
+	slotTableOffset := reserveSlotTable(out, index, len(slotDescriptors), logger)
 
 	// Now write the actual slot data and update descriptors with correct offsets
 	for i, compressed := range slotDataToWrite {
@@ -362,48 +243,8 @@ func doBuild(logger *slog.Logger, manifestPath, outputPath, launcherBin, private
 	// Store signature in index (first 64 bytes of 512-byte field)
 	copy(index.IntegritySignature[:64], signature)
 
-	// Calculate metadata checksum (SHA-256 of compressed data)
-	// Need to seek back and read the compressed data
-	savedPos, err := out.Seek(0, io.SeekCurrent)
-	if err != nil {
-		logger.Error("❌ Failed to get file position", "error", err)
-		buildExitFn(1)
-	}
-	if _, err := out.Seek(int64(metadataPos), 0); err != nil {
-		logger.Error("❌ Failed to seek to metadata position", "error", err)
-		buildExitFn(1)
-	}
-	compressedData := make([]byte, metadataSize)
-	if _, err := out.Read(compressedData); err != nil {
-		logger.Error("❌ Failed to read compressed metadata", "error", err)
-		buildExitFn(1)
-	}
-	if _, err := out.Seek(savedPos, 0); err != nil {
-		logger.Error("❌ Failed to restore seek position", "error", err)
-		buildExitFn(1)
-	}
-
-	// Compute full SHA-256 checksum (32 bytes)
-	metadataHash := sha256.Sum256(compressedData)
-	copy(index.MetadataChecksum[:], metadataHash[:])
-
-	// Update package size before writing MagicTrailer
-	// (add 8200 for the trailer that will be written)
-	currentPos, err = out.Seek(0, io.SeekCurrent)
-	if err != nil {
-		logger.Error("❌ Failed to get file position", "error", err)
-		buildExitFn(1)
-	}
-	currentPosUint64, err := int64ToUint64Checked(currentPos, "package size")
-	if err != nil {
-		logger.Error("❌ Failed to convert package size", "error", err)
-		buildExitFn(1)
-	}
-	index.PackageSize, err = addUint64Checked(currentPosUint64, MagicTrailerSize, "package size")
-	if err != nil {
-		logger.Error("❌ Failed to calculate package size", "error", err)
-		buildExitFn(1)
-	}
+	recordMetadataChecksum(out, index, logger)
+	recordPackageSize(out, index, logger)
 
 	// 🔐 Calculate index checksum (with checksum field as 0)
 	indexData := index.Pack()

--- a/src/flavor-go/pkg/psp/format_2025/builder.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
@@ -17,7 +16,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -208,128 +206,10 @@ func doBuild(logger *slog.Logger, manifestPath, outputPath, launcherBin, private
 	}
 	logger.Debug("📈 Index details", "format", "PSPF2025", "version", fmt.Sprintf("0x%08x", index.FormatVersion), "launcher_size", index.LauncherSize)
 
-	// 🔐 Get or generate Ed25519 keys
-	var publicKey ed25519.PublicKey
-	var privateKey ed25519.PrivateKey
+	publicKey, privateKey := resolveSigningKeys(privateKeyPath, publicKeyPath, keySeed, logger)
+	recordSigningKeyInIndex(index, publicKey, logger)
 
-	if privateKeyPath != "" {
-		// Priority 1: Load keys from files
-		logger.Debug("🔐 Loading keys from files", "private", privateKeyPath, "public", publicKeyPath)
-		privateKey, publicKey, err = loadKeysFromFiles(privateKeyPath, publicKeyPath)
-		if err != nil {
-			logger.Error("❌ Failed to load keys", "error", err)
-			buildExitFn(1)
-		}
-		logger.Info("🔑 Using provided keys")
-	} else if keySeed != "" {
-		// Priority 2: Use deterministic seed
-		logger.Debug("🔐 Generating deterministic key pair from seed")
-
-		// Allow seed from environment variable
-		actualSeed := keySeed
-		if keySeed == "env" {
-			actualSeed = os.Getenv(EnvKeySeed)
-			if actualSeed == "" {
-				logger.Error("❌ FLAVOR_KEY_SEED environment variable not set")
-				buildExitFn(1)
-			}
-		}
-
-		seed := sha256.Sum256([]byte(actualSeed))
-		privateKey = ed25519.NewKeyFromSeed(seed[:])
-		publicKey = privateKey.Public().(ed25519.PublicKey)
-		logger.Info("🔑 Using seed-based key generation", "seed_hash", fmt.Sprintf("%x", seed[:8]))
-	} else {
-		// Priority 3: Generate random ephemeral keys
-		logger.Debug("🔐 Generating random ephemeral key pair")
-		publicKey, privateKey, err = ed25519GenerateKeyFn(cryptorand.Reader)
-		if err != nil {
-			logger.Error("❌ Failed to generate ephemeral keys", "error", err)
-			buildExitFn(1)
-		}
-		logger.Debug("🎲 Using random key generation")
-	}
-	copy(index.PublicKey[:], publicKey[:32])
-	if fingerprint, err := ComputeKeyFingerprint(publicKey); err != nil {
-		logger.Error("❌ Failed to compute signing key fingerprint", "error", err)
-		buildExitFn(1)
-	} else {
-		copy(index.AttestationKeyFp[:], fingerprint)
-	}
-
-	// Build metadata
-	var buildTimestamp string
-	var buildHost string
-
-	// Check for SOURCE_DATE_EPOCH for reproducible timestamps
-	if epochStr := os.Getenv("SOURCE_DATE_EPOCH"); epochStr != "" {
-		if epochInt, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
-			buildTimestamp = time.Unix(epochInt, 0).UTC().Format(time.RFC3339)
-		} else {
-			buildTimestamp = time.Now().UTC().Format(time.RFC3339)
-		}
-		buildHost = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-	} else {
-		hostname, err := hostnameFunc()
-		buildTimestamp = time.Now().UTC().Format(time.RFC3339)
-		if err != nil {
-			logger.Warn("⚠️ Failed to resolve hostname, using platform-only build host", "error", err)
-			buildHost = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-		} else {
-			buildHost = fmt.Sprintf("%s/%s %s", runtime.GOOS, runtime.GOARCH, hostname)
-		}
-	}
-
-	// Convert cache validation config if present
-	var cacheValidation *CacheValidationInfo
-	if config.CacheValidation != nil {
-		cacheValidation = &CacheValidationInfo{
-			CheckFile:       config.CacheValidation.CheckFile,
-			ExpectedContent: config.CacheValidation.ExpectedContent,
-		}
-	}
-
-	// Convert runtime config if present
-	var runtimeInfo *RuntimeInfo
-	if config.Runtime != nil {
-		runtimeInfo = &RuntimeInfo{
-			Env: config.Runtime.Env,
-		}
-	}
-
-	metadata := &Metadata{
-		Format: "PSPF/2025",
-		Package: PackageInfo{
-			Name:        config.Package.Name,
-			Version:     config.Package.Version,
-			Description: config.Package.Description,
-		},
-		CacheValidation: cacheValidation,
-		SetupCommands:   config.SetupCommands,
-		Slots:           []SlotMetadata{},
-		Execution: &ExecutionInfo{
-			Command:     config.Execution.Command,
-			Environment: config.Execution.Environment,
-		},
-		Runtime: runtimeInfo,
-		Verification: &VerificationInfo{
-			IntegritySeal: IntegritySealInfo{
-				Required:  true,
-				Algorithm: "ed25519",
-			},
-		},
-		Build: &BuildInfo{
-			Tool:          "flavor-go",
-			ToolVersion:   "1.0.0",
-			Timestamp:     buildTimestamp,
-			Deterministic: false,
-			Platform: PlatformInfo{
-				OS:   runtime.GOOS,
-				Arch: runtime.GOARCH,
-				Host: buildHost,
-			},
-		},
-	}
+	metadata := buildPackageMetadata(&config, logger)
 
 	// 📦 Process slots using SlotProcessor (aligns with Rust implementation)
 	slotProcessor := NewSlotProcessor(config.Slots, logger)

--- a/src/flavor-go/pkg/psp/format_2025/builder_inputs.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_inputs.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// loadBuildManifest reads and parses the manifest describing the package.
+func loadBuildManifest(manifestPath string, logger *slog.Logger) (BuildOptions, bool) {
+	var config BuildOptions
+
+	manifestData, err := readFileValidated(manifestPath)
+	if err != nil {
+		logger.Error("❌ Failed to read manifest", "error", err)
+		buildExitFn(1)
+		return config, false
+	}
+
+	if err := json.Unmarshal(manifestData, &config); err != nil {
+		logger.Error("❌ Failed to parse manifest", "error", err)
+		buildExitFn(1)
+		return config, false
+	}
+
+	return config, true
+}
+
+// resolveLauncherPath picks the launcher to embed: the command-line argument
+// first, then FLAVOR_LAUNCHER_BIN.
+func resolveLauncherPath(launcherBin string, logger *slog.Logger) string {
+	launcherPath := launcherBin
+	if launcherPath == "" {
+		launcherPath = getLauncherPath("")
+	}
+	if launcherPath == "" {
+		logger.Error("❌ Launcher binary path must be specified via --launcher-bin or FLAVOR_LAUNCHER_BIN environment variable")
+		buildExitFn(1)
+	}
+	return launcherPath
+}
+
+// logLauncherVersion records which launcher this package is being built with.
+//
+// The probe goes through CLI mode. Launchers never intercept arguments outside
+// it -- every argument belongs to the packaged application -- so probing a
+// launcher with --version ran it as the package and always failed. CLI mode's
+// "version" command does not touch the bundle. Only stdout is read; the
+// launcher logs to stderr.
+//
+// A launcher that will not report its version is not a reason to stop: the
+// version is provenance, not a prerequisite.
+func logLauncherVersion(launcherPath string, logger *slog.Logger) {
+	versionCmd := exec.Command(launcherPath, "version") // #nosec G204 -- launcherPath is operator-supplied and executed directly without shell expansion for a version probe.
+	versionCmd.Env = append(os.Environ(), EnvLauncherCLI+"=1")
+
+	versionOutput, err := versionCmd.Output()
+	if err != nil {
+		logger.Warn("⚠️ Failed to get launcher version", "error", err)
+		return
+	}
+	logger.Info("🔍 Launcher version", "version", strings.TrimSpace(string(versionOutput)))
+}
+
+// loadLauncherBinary resolves, probes and reads the launcher, returning the
+// bytes to prepend and the path they came from.
+func loadLauncherBinary(launcherBin string, logger *slog.Logger) ([]byte, string) {
+	launcherPath := resolveLauncherPath(launcherBin, logger)
+	logger.Info("🚀 Loading launcher", "path", launcherPath)
+
+	logLauncherVersion(launcherPath, logger)
+
+	logger.Debug("🔍 Launcher path", "path", launcherPath)
+	launcherData, err := readFileValidated(launcherPath)
+	if err != nil {
+		logger.Error("❌ Failed to read launcher", "error", err, "path", launcherPath)
+		buildExitFn(1)
+	}
+	logger.Debug("✅ Launcher loaded", "size", len(launcherData))
+
+	// Windows PE needs the launcher rewritten before anything is appended.
+	launcherData, err = processLauncherFn(launcherData, logger)
+	if err != nil {
+		logger.Error("❌ Failed to process launcher for PSPF", "error", err)
+		buildExitFn(1)
+	}
+	logger.Debug("✅ Launcher processed for PSPF", "size", len(launcherData))
+
+	return launcherData, launcherPath
+}

--- a/src/flavor-go/pkg/psp/format_2025/builder_keys.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_keys.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// resolveSigningKeys produces the Ed25519 pair this build signs with, in
+// descending order of preference: a key pair on disk, a deterministic pair
+// derived from a seed, or a random ephemeral pair.
+//
+// Failures call buildExitFn rather than returning, matching the rest of the
+// builder: a build that cannot sign does not produce a package.
+func resolveSigningKeys(
+	privateKeyPath string,
+	publicKeyPath string,
+	keySeed string,
+	logger *slog.Logger,
+) (ed25519.PublicKey, ed25519.PrivateKey) {
+	switch {
+	case privateKeyPath != "":
+		logger.Debug("🔐 Loading keys from files", "private", privateKeyPath, "public", publicKeyPath)
+		privateKey, publicKey, err := loadKeysFromFiles(privateKeyPath, publicKeyPath)
+		if err != nil {
+			logger.Error("❌ Failed to load keys", "error", err)
+			buildExitFn(1)
+		}
+		logger.Info("🔑 Using provided keys")
+		return publicKey, privateKey
+
+	case keySeed != "":
+		logger.Debug("🔐 Generating deterministic key pair from seed")
+
+		actualSeed := keySeed
+		if keySeed == "env" {
+			actualSeed = os.Getenv(EnvKeySeed)
+			if actualSeed == "" {
+				logger.Error("❌ FLAVOR_KEY_SEED environment variable not set")
+				buildExitFn(1)
+			}
+		}
+
+		seed := sha256.Sum256([]byte(actualSeed))
+		privateKey := ed25519.NewKeyFromSeed(seed[:])
+		logger.Info("🔑 Using seed-based key generation", "seed_hash", fmt.Sprintf("%x", seed[:8]))
+		return privateKey.Public().(ed25519.PublicKey), privateKey
+
+	default:
+		logger.Debug("🔐 Generating random ephemeral key pair")
+		publicKey, privateKey, err := ed25519GenerateKeyFn(cryptorand.Reader)
+		if err != nil {
+			logger.Error("❌ Failed to generate ephemeral keys", "error", err)
+			buildExitFn(1)
+		}
+		logger.Debug("🎲 Using random key generation")
+		return publicKey, privateKey
+	}
+}
+
+// recordSigningKeyInIndex stores the public key and its fingerprint, which is
+// what a launcher checks the package's attestation against.
+func recordSigningKeyInIndex(index *PSPFIndex, publicKey ed25519.PublicKey, logger *slog.Logger) {
+	copy(index.PublicKey[:], publicKey[:32])
+
+	fingerprint, err := ComputeKeyFingerprint(publicKey)
+	if err != nil {
+		logger.Error("❌ Failed to compute signing key fingerprint", "error", err)
+		buildExitFn(1)
+		return
+	}
+	copy(index.AttestationKeyFp[:], fingerprint)
+}

--- a/src/flavor-go/pkg/psp/format_2025/builder_layout.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_layout.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"crypto/sha256"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// mustSeek returns the current offset, ending the build if the file will not
+// report it. A package cannot be laid out without knowing where it is.
+func mustSeek(out *os.File, logger *slog.Logger) int64 {
+	pos, err := out.Seek(0, io.SeekCurrent)
+	if err != nil {
+		logger.Error("❌ Failed to get file position", "error", err)
+		buildExitFn(1)
+	}
+	return pos
+}
+
+// mustConvert ends the build when a value does not fit the index field it is
+// bound for. The converters carry the field name in their error, so this adds
+// only the decision to stop.
+//
+// These are all width checks on values the builder computed, so a failure is a
+// package that cannot be described rather than a condition to recover from.
+// Go will not take a multi-value call alongside another argument, so callers
+// pass the value and error separately -- still half the four lines each of
+// these checks used to cost.
+func mustConvert[T any](v T, err error, logger *slog.Logger) T {
+	if err != nil {
+		logger.Error("❌ Failed to convert value for index", "error", err)
+		buildExitFn(1)
+	}
+	return v
+}
+
+// writePackageMetadata writes the gzipped metadata immediately after the
+// launcher and records where it landed. It returns the Ed25519 signature over
+// the bytes as written, which the index carries.
+func writePackageMetadata(
+	out *os.File,
+	metadata *Metadata,
+	privateKey []byte,
+	publicKey []byte,
+	index *PSPFIndex,
+	logger *slog.Logger,
+) []byte {
+	metadataPos := mustSeek(out, logger)
+	logger.Debug("📜 Writing metadata (gzipped JSON)", "position", metadataPos)
+
+	metadataSize, signature, err := writeMetadataFn(out, metadata, privateKey, publicKey)
+	if err != nil {
+		logger.Error("❌ Failed to write metadata", "error", err)
+		buildExitFn(1)
+	}
+	logger.Debug("✅ Metadata written", "size", metadataSize)
+
+	offset, err := int64ToUint64Checked(metadataPos, "metadata offset")
+	index.MetadataOffset = mustConvert(offset, err, logger)
+
+	size, err := intToUint64Checked(metadataSize, "metadata size")
+	index.MetadataSize = mustConvert(size, err, logger)
+
+	return signature
+}
+
+// reserveSlotTable positions the slot table on its alignment boundary, records
+// its geometry in the index, and leaves the file positioned past it so slot
+// data can be written first.
+//
+// The table is written last because a descriptor cannot name a slot's offset
+// until that slot has been placed.
+func reserveSlotTable(out *os.File, index *PSPFIndex, slotCount int, logger *slog.Logger) int64 {
+	slotTableOffset := AlignOffset(mustSeek(out, logger), SlotAlignment)
+	if _, err := out.Seek(slotTableOffset, 0); err != nil {
+		logger.Error("Failed to seek to slot table", "error", err)
+		buildExitFn(1)
+	}
+
+	tableOffset, err := int64ToUint64Checked(slotTableOffset, "slot table offset")
+	index.SlotTableOffset = mustConvert(tableOffset, err, logger)
+
+	count32, err := intToUint32Checked(slotCount, "slot count")
+	index.SlotCount = mustConvert(count32, err, logger)
+
+	count64, err := intToUint64Checked(slotCount, "slot count")
+	count64 = mustConvert(count64, err, logger)
+
+	tableSize, err := multiplyUint64Checked(count64, SlotDescriptorSize, "slot table size")
+	index.SlotTableSize = mustConvert(tableSize, err, logger)
+
+	tableSizeInt64, err := uint64ToInt64Checked(index.SlotTableSize, "slot table size")
+	tableSizeInt64 = mustConvert(tableSizeInt64, err, logger)
+
+	if _, err := out.Seek(slotTableOffset+tableSizeInt64, 0); err != nil {
+		logger.Error("Failed to seek past slot table", "error", err)
+		buildExitFn(1)
+	}
+
+	return slotTableOffset
+}
+
+// recordMetadataChecksum hashes the metadata as it was stored and records the
+// digest in the index.
+//
+// The bytes are read back from the file rather than hashed on the way out: the
+// checksum has to cover the gzip stream a reader will find, and re-compressing
+// the document is not guaranteed to reproduce it byte for byte.
+func recordMetadataChecksum(out *os.File, index *PSPFIndex, logger *slog.Logger) {
+	savedPos := mustSeek(out, logger)
+
+	metadataOffset, err := uint64ToInt64Checked(index.MetadataOffset, "metadata offset")
+	metadataOffset = mustConvert(metadataOffset, err, logger)
+
+	if _, err := out.Seek(metadataOffset, 0); err != nil {
+		logger.Error("❌ Failed to seek to metadata position", "error", err)
+		buildExitFn(1)
+	}
+
+	compressedData := make([]byte, index.MetadataSize)
+	if _, err := out.Read(compressedData); err != nil {
+		logger.Error("❌ Failed to read compressed metadata", "error", err)
+		buildExitFn(1)
+	}
+
+	if _, err := out.Seek(savedPos, 0); err != nil {
+		logger.Error("❌ Failed to restore seek position", "error", err)
+		buildExitFn(1)
+	}
+
+	metadataHash := sha256.Sum256(compressedData)
+	copy(index.MetadataChecksum[:], metadataHash[:])
+}
+
+// recordPackageSize sets the package size, which counts the MagicTrailer that
+// has not been written yet.
+func recordPackageSize(out *os.File, index *PSPFIndex, logger *slog.Logger) {
+	endOfContent, err := int64ToUint64Checked(mustSeek(out, logger), "package size")
+	endOfContent = mustConvert(endOfContent, err, logger)
+
+	size, err := addUint64Checked(endOfContent, MagicTrailerSize, "package size")
+	index.PackageSize = mustConvert(size, err, logger)
+}

--- a/src/flavor-go/pkg/psp/format_2025/builder_metadata.go
+++ b/src/flavor-go/pkg/psp/format_2025/builder_metadata.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+// resolveBuildProvenance produces the timestamp and host recorded in the
+// package's build block.
+//
+// SOURCE_DATE_EPOCH pins the timestamp for a reproducible build, and its
+// presence also drops the hostname from the build host, since a name that
+// varies per machine defeats the reproducibility being asked for. An epoch
+// that will not parse falls back to now rather than failing the build.
+func resolveBuildProvenance(logger *slog.Logger) (timestamp string, host string) {
+	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	if epochStr := os.Getenv("SOURCE_DATE_EPOCH"); epochStr != "" {
+		if epochInt, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
+			return time.Unix(epochInt, 0).UTC().Format(time.RFC3339), platform
+		}
+		return time.Now().UTC().Format(time.RFC3339), platform
+	}
+
+	timestamp = time.Now().UTC().Format(time.RFC3339)
+
+	hostname, err := hostnameFunc()
+	if err != nil {
+		logger.Warn("⚠️ Failed to resolve hostname, using platform-only build host", "error", err)
+		return timestamp, platform
+	}
+	return timestamp, fmt.Sprintf("%s %s", platform, hostname)
+}
+
+// buildPackageMetadata assembles the metadata document from the manifest. The
+// slots array is filled in later, once the slot processor has run.
+func buildPackageMetadata(config *BuildOptions, logger *slog.Logger) *Metadata {
+	buildTimestamp, buildHost := resolveBuildProvenance(logger)
+
+	var cacheValidation *CacheValidationInfo
+	if config.CacheValidation != nil {
+		cacheValidation = &CacheValidationInfo{
+			CheckFile:       config.CacheValidation.CheckFile,
+			ExpectedContent: config.CacheValidation.ExpectedContent,
+		}
+	}
+
+	var runtimeInfo *RuntimeInfo
+	if config.Runtime != nil {
+		runtimeInfo = &RuntimeInfo{Env: config.Runtime.Env}
+	}
+
+	return &Metadata{
+		Format: "PSPF/2025",
+		Package: PackageInfo{
+			Name:        config.Package.Name,
+			Version:     config.Package.Version,
+			Description: config.Package.Description,
+		},
+		CacheValidation: cacheValidation,
+		SetupCommands:   config.SetupCommands,
+		Slots:           []SlotMetadata{},
+		Execution: &ExecutionInfo{
+			Command:     config.Execution.Command,
+			Environment: config.Execution.Environment,
+		},
+		Runtime: runtimeInfo,
+		Verification: &VerificationInfo{
+			IntegritySeal: IntegritySealInfo{
+				Required:  true,
+				Algorithm: "ed25519",
+			},
+		},
+		Build: &BuildInfo{
+			Tool:          "flavor-go",
+			ToolVersion:   "1.0.0",
+			Timestamp:     buildTimestamp,
+			Deterministic: false,
+			Platform: PlatformInfo{
+				OS:   runtime.GOOS,
+				Arch: runtime.GOARCH,
+				Host: buildHost,
+			},
+		},
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution.go
@@ -7,12 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"log/slog"
 
-	"github.com/provide-io/flavor/go/flavor/internal/workenv"
 	"github.com/provide-io/flavor/go/flavor/pkg/logging"
 	"github.com/provide-io/flavor/go/flavor/pkg/utils/shellparse"
 )
@@ -170,115 +168,15 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 		return nil, fmt.Errorf("failed to read index: %w", err)
 	}
 
-	// Check signing key trust status from the embedded public key.
-	// The attestation fingerprint, when present, must match the derived public-key fingerprint.
-	keyTrusted := false
-	hasPublicKey := false
-	for _, b := range index.PublicKey {
-		if b != 0 {
-			hasPublicKey = true
-			break
-		}
-	}
-	attestationFP := strings.TrimRight(string(index.AttestationKeyFp[:]), "\x00")
-	if hasPublicKey {
-		fp, err := ComputeKeyFingerprint(index.PublicKey[:])
-		if err != nil {
-			logger.Warn("⚠️ Failed to derive signing key fingerprint", "error", err)
-		} else {
-			if attestationFP != "" && attestationFP != fp {
-				return nil, fmt.Errorf("attestation key fingerprint does not match embedded public key")
-			}
-
-			trusted, err := IsKeyTrusted(fp, true)
-			if err != nil {
-				logger.Warn("⚠️ Failed to check trusted key store", "error", err)
-			} else if trusted == nil {
-				logger.Warn("⚠️ No trusted-keys store found; requiring a trusted key will fail closed", "fingerprint", fp)
-			} else if *trusted {
-				keyTrusted = true
-			} else {
-				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package signing key is not in the trusted store\n")
-				fmt.Fprintf(os.Stderr, "⚠️ Key fingerprint: %s\n", fp)
-				fmt.Fprintf(os.Stderr, "⚠️ Use 'flavor trust add <key-file>' to trust this key\n")
-				logger.Warn("⚠️ Package signing key not in trusted store", "fingerprint", fp)
-			}
-		}
-	} else if attestationFP != "" {
-		return nil, fmt.Errorf("attestation key fingerprint is present but public key is missing")
+	// The attestation fingerprint, when present, must match the derived
+	// public-key fingerprint. keyTrusted is an input to EnforcePolicy below.
+	keyTrusted, err := checkSigningKeyTrust(index, logger)
+	if err != nil {
+		return nil, err
 	}
 
-	validationLevel := getValidationLevel()
-
-	switch validationLevel {
-	case ValidationNone:
-		fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Skipping all integrity verification (FLAVOR_VALIDATION=none)\n")
-		fmt.Fprintf(os.Stderr, "⚠️ This is NOT RECOMMENDED for production use\n")
-		logger.Warn("⚠️ VALIDATION DISABLED: Skipping integrity verification", "level", validationLevel)
-	default:
-		logger.Debug("🔍 Verifying package integrity", "level", validationLevel)
-		valid, err := verifyIntegritySealFn(reader)
-		if err != nil {
-			switch validationLevel {
-			case ValidationMinimal, ValidationRelaxed:
-				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Failed to verify integrity seal: %v\n", err)
-				fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", validationLevel)
-				logger.Warn("⚠️ Failed to verify integrity seal, continuing", "error", err, "level", validationLevel)
-			default: // ValidationStrict, ValidationStandard
-				logger.Error("❌ Failed to verify integrity seal", "error", err)
-				return nil, fmt.Errorf("failed to verify integrity seal: %w", err)
-			}
-		} else if !valid {
-			switch validationLevel {
-			case ValidationMinimal, ValidationRelaxed:
-				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package integrity verification failed\n")
-				fmt.Fprintf(os.Stderr, "⚠️ Package may be corrupted or tampered with\n")
-				fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", validationLevel)
-				logger.Warn("⚠️ Package integrity verification failed, continuing", "level", validationLevel)
-			case ValidationStandard:
-				fmt.Fprintf(os.Stderr, "🚨 SECURITY WARNING: Package integrity verification failed\n")
-				fmt.Fprintf(os.Stderr, "🚨 Package may be corrupted or tampered with\n")
-				fmt.Fprintf(os.Stderr, "🚨 Continuing with standard validation (use FLAVOR_VALIDATION=strict to enforce)\n")
-				logger.Warn("⚠️ Package integrity verification failed, continuing with standard validation")
-			default: // ValidationStrict
-				logger.Error("❌ Package integrity verification failed")
-				return nil, errors.New("package integrity verification failed")
-			}
-		} else {
-			logger.Debug("✅ Package integrity verified")
-		}
-
-		// Verify attestation SBOM digest (fail-closed: digest present but slot absent = error)
-		logger.Debug("🔍 Verifying attestation SBOM digest", "level", validationLevel)
-		if err := reader.VerifyAttestationSbomDigest(); err != nil {
-			switch validationLevel {
-			case ValidationMinimal, ValidationRelaxed:
-				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Failed to verify attestation SBOM digest: %v\n", err)
-				fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", validationLevel)
-				logger.Warn("⚠️ Failed to verify attestation SBOM digest, continuing", "error", err, "level", validationLevel)
-			default: // ValidationStrict, ValidationStandard
-				logger.Error("❌ Failed to verify attestation SBOM digest", "error", err)
-				return nil, fmt.Errorf("failed to verify attestation SBOM digest: %w", err)
-			}
-		} else {
-			logger.Debug("✅ Attestation SBOM digest verified")
-		}
-
-		// Verify attestation policy hash (fail-closed: hash present but no policy = error)
-		logger.Debug("🔍 Verifying attestation policy hash", "level", validationLevel)
-		if err := reader.VerifyAttestationPolicyHash(); err != nil {
-			switch validationLevel {
-			case ValidationMinimal, ValidationRelaxed:
-				fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Failed to verify attestation policy hash: %v\n", err)
-				fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", validationLevel)
-				logger.Warn("⚠️ Failed to verify attestation policy hash, continuing", "error", err, "level", validationLevel)
-			default: // ValidationStrict, ValidationStandard
-				logger.Error("❌ Failed to verify attestation policy hash", "error", err)
-				return nil, fmt.Errorf("failed to verify attestation policy hash: %w", err)
-			}
-		} else {
-			logger.Debug("✅ Attestation policy hash verified")
-		}
+	if err := verifyPackageIntegrity(reader, getValidationLevel(), logger); err != nil {
+		return nil, err
 	}
 
 	metadata, err := reader.ReadMetadata()
@@ -294,96 +192,21 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 		logger.Debug("⚠️ No execution configuration present in metadata")
 	}
 
-	// Policy enforcement
-	opPolicy, policyErr := LoadOperatorPolicy()
-	if policyErr != nil {
-		logger.Error("❌ Failed to load operator policy", "error", policyErr)
-		return nil, fmt.Errorf("failed to load operator policy: %w", policyErr)
+	if err := enforcePackagePolicy(metadata, index, keyTrusted, logger); err != nil {
+		return nil, err
 	}
 
-	var pkgPolicy PackagePolicy
-	if metadata.Policy != nil {
-		pkgPolicy = *metadata.Policy
+	paths, workenvDir, err := resolveWorkenvPaths(exePath, logger)
+	if err != nil {
+		return nil, err
 	}
 
-	effective := MergePolicy(pkgPolicy, opPolicy)
-
-	hasSBOM := false
-	for _, slot := range metadata.Slots {
-		if slot.Lifecycle == "attestation" {
-			hasSBOM = true
-			break
-		}
-	}
-
-	buildTimestamp, tsErr := uint64ToInt64Checked(index.BuildTimestamp, "build timestamp")
-	if tsErr != nil {
-		logger.Error("❌ Invalid build timestamp", "error", tsErr)
-		return nil, fmt.Errorf("invalid build timestamp: %w", tsErr)
-	}
-	policyWarnings, enforceErr := EnforcePolicy(effective, buildTimestamp, hasSBOM, keyTrusted)
-	for _, w := range policyWarnings {
-		logger.Warn("⚠️  Policy warning", "message", w)
-	}
-	if enforceErr != nil {
-		logger.Error("❌ Policy violation", "error", enforceErr)
-		return nil, fmt.Errorf("policy violation: %w", enforceErr)
-	}
-	logger.Debug("✅ Policy enforcement passed")
-
-	// Create WorkenvPaths structure
-	var paths *WorkenvPaths
-	if customWorkenv := os.Getenv(EnvWorkenv); customWorkenv != "" {
-		// Use custom workenv path from environment variable
-		logger.Info("📁 Using custom work environment from FLAVOR_WORKENV", "path", customWorkenv)
-		// Extract cache dir from custom workenv (go up two levels)
-		cacheDir := filepath.Dir(filepath.Dir(customWorkenv))
-		paths = NewWorkenvPaths(cacheDir, exePath)
-	} else {
-		// Get cache directory using workenv.GetCacheRoot() for cross-platform consistency
-		cacheDir := workenv.GetCacheRoot()
-		paths = NewWorkenvPaths(cacheDir, exePath)
-	}
-
-	workenvDir := paths.Workenv()
-
-	// Convert to forward slashes for command string substitution on Windows
-	// This prevents backslashes from being treated as escape characters by the shell parser
+	// Forward slashes so the shell parser does not read Windows separators as
+	// escape characters during command substitution.
 	workenvDirForCmd := filepath.ToSlash(workenvDir)
-	if err := mkdirAllValidated(workenvDir, os.FileMode(DirPerms)); err != nil {
-		logger.Error("❌ Failed to create work environment directory", "error", err)
-		return nil, fmt.Errorf("failed to create work environment directory: %w", err)
-	}
-	logger.Info("📁 Work environment", "path", workenvDir)
 
-	// Setup workenv directories if specified
-	if metadata.Workenv != nil && metadata.Workenv.Directories != nil {
-		for _, dirSpec := range metadata.Workenv.Directories {
-			// Substitute {workenv} placeholder in the path
-			dirPath := strings.ReplaceAll(dirSpec.Path, "{workenv}", workenvDir)
-			// Path traversal protection: ensure dirPath stays within workenvDir
-			if err := ensurePathWithinWorkenv(dirPath, workenvDir, dirSpec.Path); err != nil {
-				return nil, fmt.Errorf("directory path %q escapes work environment directory", dirSpec.Path)
-			}
-			logger.Debug("📁 Creating directory", "path", dirPath)
-			if err := mkdirAllValidated(dirPath, os.FileMode(DirPerms)); err != nil {
-				logger.Error("❌ Failed to create directory", "path", dirPath, "error", err)
-				return nil, fmt.Errorf("failed to create directory %s: %w", dirPath, err)
-			}
-
-			// Set permissions if specified
-			if dirSpec.Mode != "" {
-				// Parse octal mode string (e.g., "0700")
-				mode, err := strconv.ParseUint(strings.TrimPrefix(dirSpec.Mode, "0"), 8, 32)
-				if err == nil {
-					if err := chmodValidatedFn(dirPath, os.FileMode(mode)); err != nil {
-						logger.Debug("Failed to set permissions", "path", dirPath, "mode", dirSpec.Mode, "error", err)
-					} else {
-						logger.Debug("🔒 Set permissions", "path", dirPath, "mode", dirSpec.Mode)
-					}
-				}
-			}
-		}
+	if err := createWorkenvDirectories(metadata, workenvDir, logger); err != nil {
+		return nil, err
 	}
 
 	// Check if we should use cache
@@ -407,198 +230,65 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 		logger.Info("📦 FLAVOR_WORKENV_CACHE=false, forcing fresh extraction")
 	}
 
-	slotPaths := make(map[int]string)
+	// Every branch below assigns it.
+	var slotPaths map[int]string
 
-	if !workenvValid {
-		// Check disk space before extraction
+	if workenvValid {
+		logger.Info("✅ Work environment is valid, skipping persistent slot extraction")
+		slotPaths = workenvSlotPaths(metadata, paths)
+	} else {
 		if err := checkDiskSpace(paths, metadata, logger); err != nil {
 			return nil, err
 		}
 
-		// Acquire lock before extraction
 		acquiredLock, err := tryAcquireLockFn(paths, logger)
 		if err != nil {
 			logger.Error("❌ Failed to acquire extraction lock", "error", err)
 			return nil, err
 		}
-		if !acquiredLock {
-			// Another process is extracting, wait for it
+
+		if acquiredLock {
+			// Only a holder releases. ReleaseLock removes the lock file without
+			// checking who owns it, so releasing one this process never took
+			// deletes whichever process's lock is there.
+			defer ReleaseLock(paths, logger)
+
+			slotPaths, err = extractAndMergeSlotsToWorkenv(reader, metadata, paths, index, logger)
+			if err != nil {
+				return nil, err
+			}
+
+			// Recorded for the next launch's cache check.
+			if err := savePackageChecksum(paths, index.IndexChecksum, logger); err != nil {
+				logger.Warn("⚠️ Failed to save package checksum", "error", err)
+			}
+		} else {
+			// Another process holds the lock. Wait for its extraction and use
+			// it: extracting into the same work environment alongside it is
+			// what the lock exists to prevent.
 			logger.Info("⏳ Another process is extracting, waiting...")
 			if err := waitForExtractionFn(paths, 60, logger); err != nil {
 				return nil, err
 			}
-			// Re-check validity after waiting
+
 			valid, err := checkWorkenvValidityAfterWaitFn(paths, index, metadata, logger)
 			if err != nil {
 				return nil, err
 			}
 			if !valid {
-				return nil, fmt.Errorf("cache extraction by another process failed validation")
+				return nil, errors.New("cache extraction by another process failed validation")
 			}
+
 			workenvValid = true
-		}
-		defer ReleaseLock(paths, logger)
-
-		// Extract and merge slots to workenv
-		slotPaths, err = extractAndMergeSlotsToWorkenv(reader, metadata, paths, index, logger)
-		if err != nil {
-			return nil, err
-		}
-
-		// Save package checksum for future cache validation
-		if err := savePackageChecksum(paths, index.IndexChecksum, logger); err != nil {
-			logger.Warn("⚠️ Failed to save package checksum", "error", err)
-		}
-	} else {
-		logger.Info("✅ Work environment is valid, skipping persistent slot extraction")
-		for _, slot := range metadata.Slots {
-			slotPaths[slot.Slot] = paths.Workenv()
+			slotPaths = workenvSlotPaths(metadata, paths)
 		}
 	}
 
-	// Run setup commands if cache is invalid
+	// Setup commands run once, against a freshly extracted work environment.
 	if !workenvValid && len(metadata.SetupCommands) > 0 {
-		logger.Info("🔧 Running setup commands", "count", len(metadata.SetupCommands))
-		metadataDir := filepath.Join(workenvDir, "metadata")
-		if err := mkdirAllValidated(metadataDir, os.FileMode(DirPerms)); err != nil {
-			logger.Error("❌ Failed to create metadata directory", "error", err)
-			return nil, fmt.Errorf("failed to create metadata directory: %w", err)
+		if err := runSetupCommands(metadata, workenvDir, workenvDirForCmd, userCwd, slotPaths, logger); err != nil {
+			return nil, err
 		}
-
-		for i, setupCmdInterface := range metadata.SetupCommands {
-			logger.Debug("🔧 Processing setup command", "index", i)
-			var cmdToRun string
-			var cmdArgs []string
-
-			switch cmd := setupCmdInterface.(type) {
-			case string:
-				cmdToRun = cmd
-			case map[string]interface{}:
-				cmdType, _ := cmd["type"].(string)
-				command, _ := cmd["command"].(string)
-
-				command = strings.ReplaceAll(command, "{workenv}", workenvDirForCmd)
-				command = strings.ReplaceAll(command, "{package_name}", metadata.Package.Name)
-				command = strings.ReplaceAll(command, "{version}", metadata.Package.Version)
-
-				if cmdType == "enumerate_and_execute" {
-					if enumerate, ok := cmd["enumerate"].(map[string]interface{}); ok {
-						path, _ := enumerate["path"].(string)
-						pattern, _ := enumerate["pattern"].(string)
-
-						path = strings.ReplaceAll(path, "{workenv}", workenvDir)
-						if err := ensurePathWithinWorkenv(path, workenvDir, path); err != nil {
-							logger.Error("❌ Enumerate path escapes work environment directory", "path", path, "error", err)
-							return nil, err
-						}
-
-						matches, err := filepath.Glob(filepath.Join(path, pattern))
-						if err != nil {
-							logger.Warn("⚠️ Failed to enumerate files", "error", err)
-						}
-
-						parts := strings.Fields(command)
-						if len(parts) > 0 && len(matches) > 0 {
-							cmdArgs = append(parts[1:], matches...)
-							cmdToRun = parts[0]
-						} else {
-							cmdToRun = command
-						}
-					}
-				} else if cmdType == "write_file" {
-					path, _ := cmd["path"].(string)
-					content, _ := cmd["content"].(string)
-
-					path = strings.ReplaceAll(path, "{workenv}", workenvDir)
-					path = strings.ReplaceAll(path, "{package_name}", metadata.Package.Name)
-					path = strings.ReplaceAll(path, "{version}", metadata.Package.Version)
-					if err := ensurePathWithinWorkenv(path, workenvDir, path); err != nil {
-						logger.Error("❌ Write-file path escapes work environment directory", "path", path, "error", err)
-						return nil, err
-					}
-
-					content = strings.ReplaceAll(content, "{workenv}", workenvDirForCmd)
-					content = strings.ReplaceAll(content, "{package_name}", metadata.Package.Name)
-					content = strings.ReplaceAll(content, "{version}", metadata.Package.Version)
-
-					mode := os.FileMode(0644)
-					if modeFloat, ok := cmd["mode"].(float64); ok {
-						modeChecked, modeErr := float64ToFileModeChecked(modeFloat, "setup command mode")
-						if modeErr != nil {
-							logger.Error("❌ Invalid setup file mode", "mode", modeFloat, "error", modeErr)
-							return nil, modeErr
-						}
-						mode = modeChecked
-					}
-
-					if err := writeFileValidated(path, []byte(content+"\n"), mode); err != nil {
-						logger.Error("❌ Failed to write file", "path", path, "error", err)
-						return nil, fmt.Errorf("failed to write file %s: %w", path, err)
-					}
-
-					continue
-				} else {
-					cmdToRun = command
-				}
-			default:
-				logger.Warn("⚠️ Unknown setup command type", "type", fmt.Sprintf("%T", setupCmdInterface))
-				continue
-			}
-
-			if cmdToRun != "" {
-				if len(cmdArgs) == 0 {
-					cmdToRun = strings.ReplaceAll(cmdToRun, "{workenv}", workenvDirForCmd)
-					cmdToRun = strings.ReplaceAll(cmdToRun, "{package_name}", metadata.Package.Name)
-					cmdToRun = strings.ReplaceAll(cmdToRun, "{version}", metadata.Package.Version)
-				}
-
-				var setupExec *exec.Cmd
-				if len(cmdArgs) > 0 {
-					// Resolve executable for cross-platform compatibility
-					resolvedCmd := resolveExecutable(cmdToRun, logger)
-					setupExec = execCommandValidated(resolvedCmd, cmdArgs...)
-				} else {
-					// Use shell-aware parser to handle quoted arguments
-					parts, err := shellparse.Split(cmdToRun)
-					if err != nil {
-						logger.Error("❌ Failed to parse setup command", "command", cmdToRun, "error", err)
-						return nil, fmt.Errorf("failed to parse setup command %q: %w", cmdToRun, err)
-					}
-					if len(parts) == 0 {
-						continue
-					}
-					// Resolve executable for cross-platform compatibility
-					resolvedExec := resolveExecutable(parts[0], logger)
-					setupExec = execCommandValidated(resolvedExec, parts[1:]...)
-				}
-
-				setupExec.Dir = userCwd
-
-				setupExec.Env = os.Environ()
-				setupExec.Env = setEnv(setupExec.Env, EnvWorkenv, workenvDir)
-
-				for i, env := range setupExec.Env {
-					if strings.HasPrefix(env, "PATH=") {
-						binDir := "bin"
-						if runtime.GOOS == "windows" {
-							binDir = "Scripts"
-						}
-						setupExec.Env[i] = fmt.Sprintf("PATH=%s%s%s", filepath.Join(workenvDir, binDir), string(os.PathListSeparator), strings.TrimPrefix(env, "PATH="))
-						break
-					}
-				}
-
-				logger.Debug("🏃 Running setup command", "command", cmdToRun, "args", cmdArgs, "cwd", userCwd)
-				if output, err := setupExec.CombinedOutput(); err != nil {
-					logger.Error("❌ Setup command failed", "command", cmdToRun, "output", string(output))
-					return nil, fmt.Errorf("setup command %s failed: %w", cmdToRun, err)
-				}
-			}
-		}
-
-		// Clean up init lifecycle slots after setup commands have run
-		logger.Info("🧹 Cleaning up lifecycle slots...")
-		cleanupLifecycleSlots(workenvDir, metadata, slotPaths, logger)
 	}
 
 	if metadata.Execution == nil {

--- a/src/flavor-go/pkg/psp/format_2025/execution.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution.go
@@ -6,13 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"log/slog"
 
 	"github.com/provide-io/flavor/go/flavor/pkg/logging"
-	"github.com/provide-io/flavor/go/flavor/pkg/utils/shellparse"
 )
 
 var (
@@ -302,109 +300,22 @@ func runBundleWithCwd(exePath string, args []string, userCwd string, logger *slo
 	// workenv root. Derive them from the targets instead.
 	commandSlotPaths := buildSlotPaths(metadata, workenvDirForCmd, logger)
 
-	command := metadata.Execution.Command
-	for idx, path := range commandSlotPaths {
-		placeholder := fmt.Sprintf("{slot:%d}", idx)
-		// Convert slot paths to forward slashes for command string on Windows
-		command = strings.ReplaceAll(command, placeholder, filepath.ToSlash(path))
-	}
-	command = strings.ReplaceAll(command, "{workenv}", workenvDirForCmd)
-	command = strings.ReplaceAll(command, "{package_name}", metadata.Package.Name)
-	command = strings.ReplaceAll(command, "{version}", metadata.Package.Version)
-
-	if strings.Contains(command, "{slot:") {
-		for i := 0; i < len(metadata.Slots); i++ {
-			placeholder := fmt.Sprintf("{slot:%d}", i)
-			if strings.Contains(command, placeholder) {
-				logger.Error("❌ Missing slot reference", "slot", i, "error", ErrMissingSlot)
-				return nil, fmt.Errorf("%w: slot %d", ErrMissingSlot, i)
-			}
-		}
-	}
-
-	// Use shell-aware parser to handle quoted arguments
-	parts, err := shellparse.Split(command)
+	command, err := resolveCommandPlaceholders(metadata, commandSlotPaths, workenvDirForCmd, logger)
 	if err != nil {
-		logger.Error("❌ Failed to parse command", "command", command, "error", err)
-		return nil, fmt.Errorf("failed to parse command %q: %w", command, err)
-	}
-	if len(parts) == 0 {
-		logger.Error("Empty command")
-		return nil, errors.New("empty command")
+		return nil, err
 	}
 
-	cmdArgs := parts[1:]
-	if len(args) > 0 {
-		cmdArgs = append(cmdArgs, args...)
+	cmd, cmdArgs, err := buildExecCommand(command, args, logger)
+	if err != nil {
+		return nil, err
 	}
-
-	// Resolve executable for cross-platform compatibility
-	resolvedExec := resolveExecutable(parts[0], logger)
-	cmd := execCommandValidated(resolvedExec, cmdArgs...)
 
 	originalCmd := os.Args[0]
 	binaryName := filepath.Base(originalCmd)
-
 	cmd.Args = append([]string{binaryName}, cmdArgs...)
 	logger.Debug("🏷️ Attempted to set argv[0] (Go limitation: won't work)", "argv0", binaryName, "original", originalCmd, "fullArgs", cmd.Args)
 
-	// Setup environment variables in proper layering order
-	parentEnv := os.Environ()
-	logger.Debug("🌍 Inheriting parent environment", "vars_count", len(parentEnv))
-	cmd.Env = parentEnv
-
-	// Set FLAVOR_CACHE BEFORE workenv environment (which overwrites HOME)
-	cmd.Env = setFlavorCacheBeforeWorkenv(cmd.Env, logger)
-
-	// Add FLAVOR_* variables
-	cmd.Env = setEnv(cmd.Env, EnvWorkenv, workenvDir)
-	logger.Debug("➕ Added FLAVOR_WORKENV", "path", workenvDir)
-
-	cmd.Env = setEnv(cmd.Env, EnvOriginalCommand, originalCmd)
-	cmd.Env = setEnv(cmd.Env, EnvCommandName, binaryName)
-	logger.Debug("🏷️ Added command name environment variables",
-		EnvOriginalCommand, originalCmd,
-		EnvCommandName, binaryName)
-
-	// Prepend workenv/bin to PATH
-	pathFound := false
-	for i, env := range cmd.Env {
-		if strings.HasPrefix(env, "PATH=") {
-			binDir := "bin"
-			if runtime.GOOS == "windows" {
-				binDir = "Scripts"
-			}
-			cmd.Env[i] = fmt.Sprintf("PATH=%s%s%s", filepath.Join(workenvDir, binDir), string(os.PathListSeparator), strings.TrimPrefix(env, "PATH="))
-			pathFound = true
-			break
-		}
-	}
-	if !pathFound {
-		binDir := "bin"
-		if runtime.GOOS == "windows" {
-			binDir = "Scripts"
-		}
-		cmd.Env = setEnv(cmd.Env, "PATH", filepath.Join(workenvDir, binDir))
-	}
-
-	// Process runtime.env configuration
-	if metadata.Runtime != nil && metadata.Runtime.Env != nil {
-		logger.Debug("🔄 Processing runtime.env configuration")
-		cmd.Env = processRuntimeEnv(cmd.Env, metadata.Runtime.Env, logger)
-	}
-
-	// Add package-defined environment variables
-	if metadata.Execution.Environment != nil {
-		logger.Debug("➕ Adding package-defined environment variables", "count", len(metadata.Execution.Environment))
-		for k, v := range metadata.Execution.Environment {
-			for idx, path := range commandSlotPaths {
-				placeholder := fmt.Sprintf("{slot:%d}", idx)
-				v = strings.ReplaceAll(v, placeholder, filepath.ToSlash(path))
-			}
-			cmd.Env = setEnv(cmd.Env, k, v)
-			logging.Trace(logger, "➕ Added package env var", "key", k, "value", v)
-		}
-	}
+	cmd.Env = buildCommandEnvironment(metadata, commandSlotPaths, workenvDir, originalCmd, binaryName, logger)
 
 	cmd.Dir = userCwd
 	logger.Debug("📂 Setting working directory", "path", userCwd)

--- a/src/flavor-go/pkg/psp/format_2025/execution_command.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_command.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+	"github.com/provide-io/flavor/go/flavor/pkg/utils/shellparse"
+)
+
+// substituteSlotPlaceholders replaces {slot:N} with the slot's path, in the
+// forward-slash form a shell parser will not read as escapes.
+func substituteSlotPlaceholders(text string, slotPaths map[int]string) string {
+	for idx, path := range slotPaths {
+		text = strings.ReplaceAll(text, fmt.Sprintf("{slot:%d}", idx), filepath.ToSlash(path))
+	}
+	return text
+}
+
+// resolveCommandPlaceholders fills every placeholder the execution command
+// accepts, and refuses a command still naming a slot afterwards.
+//
+// An unresolved {slot:N} means the command refers to a slot the package does
+// not carry. Running it would substitute nothing and pass the literal text to
+// the shell.
+func resolveCommandPlaceholders(
+	metadata *Metadata,
+	slotPaths map[int]string,
+	workenvDirForCmd string,
+	logger *slog.Logger,
+) (string, error) {
+	command := substituteSlotPlaceholders(metadata.Execution.Command, slotPaths)
+	command = substituteSetupPlaceholders(command, workenvDirForCmd, metadata.Package)
+
+	if !strings.Contains(command, "{slot:") {
+		return command, nil
+	}
+	for i := range metadata.Slots {
+		if strings.Contains(command, fmt.Sprintf("{slot:%d}", i)) {
+			logger.Error("❌ Missing slot reference", "slot", i, "error", ErrMissingSlot)
+			return "", fmt.Errorf("%w: slot %d", ErrMissingSlot, i)
+		}
+	}
+	return command, nil
+}
+
+// buildExecCommand parses the resolved command and appends the caller's own
+// arguments.
+func buildExecCommand(command string, args []string, logger *slog.Logger) (*exec.Cmd, []string, error) {
+	// Shell-aware so quoted arguments survive.
+	parts, err := shellparse.Split(command)
+	if err != nil {
+		logger.Error("❌ Failed to parse command", "command", command, "error", err)
+		return nil, nil, fmt.Errorf("failed to parse command %q: %w", command, err)
+	}
+	if len(parts) == 0 {
+		logger.Error("Empty command")
+		return nil, nil, errors.New("empty command")
+	}
+
+	cmdArgs := append(parts[1:], args...)
+	return execCommandValidated(resolveExecutable(parts[0], logger), cmdArgs...), cmdArgs, nil
+}
+
+// workenvBinDir is where a package's executables live, which Windows names
+// differently.
+func workenvBinDir(workenvDir string) string {
+	binDir := "bin"
+	if runtime.GOOS == "windows" {
+		binDir = "Scripts"
+	}
+	return filepath.Join(workenvDir, binDir)
+}
+
+// prependWorkenvBinToPath puts the package's own executables ahead of the
+// host's, so a package runs what it shipped.
+func prependWorkenvBinToPath(env []string, workenvDir string) []string {
+	binDir := workenvBinDir(workenvDir)
+
+	for i, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			env[i] = fmt.Sprintf("PATH=%s%s%s", binDir, string(os.PathListSeparator), strings.TrimPrefix(entry, "PATH="))
+			return env
+		}
+	}
+	return setEnv(env, "PATH", binDir)
+}
+
+// buildCommandEnvironment layers the environment the package runs with, in the
+// order later layers are meant to win: the parent's, then FLAVOR_*, then PATH,
+// then the package's declared runtime operations, then its literal variables.
+func buildCommandEnvironment(
+	metadata *Metadata,
+	slotPaths map[int]string,
+	workenvDir string,
+	originalCmd string,
+	binaryName string,
+	logger *slog.Logger,
+) []string {
+	env := os.Environ()
+	logger.Debug("🌍 Inheriting parent environment", "vars_count", len(env))
+
+	// Before the workenv variables, which overwrite HOME.
+	env = setFlavorCacheBeforeWorkenv(env, logger)
+
+	env = setEnv(env, EnvWorkenv, workenvDir)
+	logger.Debug("➕ Added FLAVOR_WORKENV", "path", workenvDir)
+
+	env = setEnv(env, EnvOriginalCommand, originalCmd)
+	env = setEnv(env, EnvCommandName, binaryName)
+	logger.Debug("🏷️ Added command name environment variables",
+		EnvOriginalCommand, originalCmd,
+		EnvCommandName, binaryName)
+
+	env = prependWorkenvBinToPath(env, workenvDir)
+
+	if metadata.Runtime != nil && metadata.Runtime.Env != nil {
+		logger.Debug("🔄 Processing runtime.env configuration")
+		env = processRuntimeEnv(env, metadata.Runtime.Env, logger)
+	}
+
+	if metadata.Execution.Environment != nil {
+		logger.Debug("➕ Adding package-defined environment variables", "count", len(metadata.Execution.Environment))
+		for k, v := range metadata.Execution.Environment {
+			v = substituteSlotPlaceholders(v, slotPaths)
+			env = setEnv(env, k, v)
+			logging.Trace(logger, "➕ Added package env var", "key", k, "value", v)
+		}
+	}
+
+	return env
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_lock_ownership_test.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_lock_ownership_test.go
@@ -1,0 +1,79 @@
+package format_2025
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+// A launch that could not take the extraction lock must not release it.
+//
+// ReleaseLock removes the lock file unconditionally -- it takes no owner and
+// checks none -- so releasing a lock this process never held deletes whichever
+// process's lock is there at the time. Two launches of the same package then
+// extract into one work environment concurrently.
+//
+// The window is real: WaitForExtraction returns as soon as the lock file
+// disappears, and another process can take the lock between that moment and
+// this one returning.
+func TestLockIsNotReleasedByAProcessThatNeverAcquiredIt(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv(EnvCacheDir, cacheRoot)
+	t.Setenv(EnvWorkenvCache, "false")
+	t.Setenv(EnvValidation, "none")
+
+	bundle := buildMultiSlotBundleForTests(t, []multiSlotBundleSpec{
+		{
+			meta:       SlotMetadata{ID: "main", Target: "{workenv}"},
+			storedData: []byte("hello"),
+		},
+	}, Metadata{
+		Execution: &ExecutionInfo{Command: "/bin/true"},
+		Build:     &BuildInfo{Tool: "test"},
+	})
+
+	// This process never gets the lock.
+	oldAcquire := tryAcquireLockFn
+	t.Cleanup(func() { tryAcquireLockFn = oldAcquire })
+	tryAcquireLockFn = func(_ *WorkenvPaths, _ *slog.Logger) (bool, error) {
+		return false, nil
+	}
+
+	// The holder finishes, so waiting succeeds.
+	oldWait := waitForExtractionFn
+	t.Cleanup(func() { waitForExtractionFn = oldWait })
+	var lockPath string
+	waitForExtractionFn = func(paths *WorkenvPaths, _ int, _ *slog.Logger) error {
+		// Stand in for the next process taking the lock the instant the
+		// previous holder drops it.
+		lockPath = paths.LockFile()
+		if err := os.MkdirAll(paths.Extract(), 0o755); err != nil {
+			t.Fatalf("MkdirAll(extract): %v", err)
+		}
+		if err := os.WriteFile(lockPath, []byte("4242\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile(lock): %v", err)
+		}
+		return nil
+	}
+
+	// The work environment another process produced checks out.
+	oldRecheck := checkWorkenvValidityAfterWaitFn
+	t.Cleanup(func() { checkWorkenvValidityAfterWaitFn = oldRecheck })
+	checkWorkenvValidityAfterWaitFn = func(_ *WorkenvPaths, _ *PSPFIndex, _ *Metadata, _ *slog.Logger) (bool, error) {
+		return true, nil
+	}
+
+	logger := logging.NewNullLogger()
+	if _, err := runBundleWithCwd(bundle, nil, t.TempDir(), logger); err != nil {
+		t.Fatalf("runBundleWithCwd() error = %v", err)
+	}
+
+	if lockPath == "" {
+		t.Fatal("test did not reach the wait path; the lock was never contended")
+	}
+	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+		t.Fatal("the other process's extraction lock was removed by a launch that never acquired it")
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_setup_commands.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_setup_commands.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/utils/shellparse"
+)
+
+// substituteSetupPlaceholders fills the three placeholders every setup-command
+// field accepts.
+//
+// Callers pass either workenvDir or its forward-slash form: a path used as a
+// filesystem path keeps the platform separator, and one embedded in a command
+// string does not, because the shell parser reads a backslash as an escape.
+func substituteSetupPlaceholders(text, workenv string, pkg PackageInfo) string {
+	text = strings.ReplaceAll(text, "{workenv}", workenv)
+	text = strings.ReplaceAll(text, "{package_name}", pkg.Name)
+	return strings.ReplaceAll(text, "{version}", pkg.Version)
+}
+
+// resolveEnumerateAndExecute expands a glob into the command's arguments.
+//
+// With no matches, or a command that is empty, the command runs as written --
+// enumerating nothing is not an error.
+func resolveEnumerateAndExecute(
+	cmd map[string]any,
+	command string,
+	workenvDir string,
+	logger *slog.Logger,
+) (string, []string, error) {
+	enumerate, ok := cmd["enumerate"].(map[string]any)
+	if !ok {
+		return "", nil, nil
+	}
+
+	path, _ := enumerate["path"].(string)
+	pattern, _ := enumerate["pattern"].(string)
+
+	path = strings.ReplaceAll(path, "{workenv}", workenvDir)
+	if err := ensurePathWithinWorkenv(path, workenvDir, path); err != nil {
+		logger.Error("❌ Enumerate path escapes work environment directory", "path", path, "error", err)
+		return "", nil, err
+	}
+
+	matches, err := filepath.Glob(filepath.Join(path, pattern))
+	if err != nil {
+		logger.Warn("⚠️ Failed to enumerate files", "error", err)
+	}
+
+	parts := strings.Fields(command)
+	if len(parts) > 0 && len(matches) > 0 {
+		return parts[0], append(parts[1:], matches...), nil
+	}
+	return command, nil, nil
+}
+
+// applyWriteFileCommand writes a file and reports that there is nothing to run.
+func applyWriteFileCommand(
+	cmd map[string]any,
+	metadata *Metadata,
+	workenvDir string,
+	workenvDirForCmd string,
+	logger *slog.Logger,
+) error {
+	path, _ := cmd["path"].(string)
+	content, _ := cmd["content"].(string)
+
+	path = substituteSetupPlaceholders(path, workenvDir, metadata.Package)
+	if err := ensurePathWithinWorkenv(path, workenvDir, path); err != nil {
+		logger.Error("❌ Write-file path escapes work environment directory", "path", path, "error", err)
+		return err
+	}
+
+	content = substituteSetupPlaceholders(content, workenvDirForCmd, metadata.Package)
+
+	mode := os.FileMode(0o644)
+	if modeFloat, ok := cmd["mode"].(float64); ok {
+		modeChecked, err := float64ToFileModeChecked(modeFloat, "setup command mode")
+		if err != nil {
+			logger.Error("❌ Invalid setup file mode", "mode", modeFloat, "error", err)
+			return err
+		}
+		mode = modeChecked
+	}
+
+	if err := writeFileValidated(path, []byte(content+"\n"), mode); err != nil {
+		logger.Error("❌ Failed to write file", "path", path, "error", err)
+		return fmt.Errorf("failed to write file %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// resolveSetupCommand turns one metadata.SetupCommands entry into a command
+// and its arguments.
+//
+// An empty command name means there is nothing left to run: the entry did its
+// work directly, as write_file does, or nothing could be made of it.
+func resolveSetupCommand(
+	entry any,
+	metadata *Metadata,
+	workenvDir string,
+	workenvDirForCmd string,
+	logger *slog.Logger,
+) (string, []string, error) {
+	switch cmd := entry.(type) {
+	case string:
+		return cmd, nil, nil
+
+	case map[string]any:
+		cmdType, _ := cmd["type"].(string)
+		command, _ := cmd["command"].(string)
+		command = substituteSetupPlaceholders(command, workenvDirForCmd, metadata.Package)
+
+		switch cmdType {
+		case "enumerate_and_execute":
+			return resolveEnumerateAndExecute(cmd, command, workenvDir, logger)
+		case "write_file":
+			return "", nil, applyWriteFileCommand(cmd, metadata, workenvDir, workenvDirForCmd, logger)
+		default:
+			return command, nil, nil
+		}
+
+	default:
+		logger.Warn("⚠️ Unknown setup command type", "type", fmt.Sprintf("%T", entry))
+		return "", nil, nil
+	}
+}
+
+// newSetupExecCommand builds the process for one setup command, with the work
+// environment's bin directory ahead of the inherited PATH.
+func newSetupExecCommand(
+	cmdToRun string,
+	cmdArgs []string,
+	userCwd string,
+	workenvDir string,
+	logger *slog.Logger,
+) (*exec.Cmd, error) {
+	var setupExec *exec.Cmd
+
+	if len(cmdArgs) > 0 {
+		setupExec = execCommandValidated(resolveExecutable(cmdToRun, logger), cmdArgs...)
+	} else {
+		// Shell-aware so quoted arguments survive.
+		parts, err := shellparse.Split(cmdToRun)
+		if err != nil {
+			logger.Error("❌ Failed to parse setup command", "command", cmdToRun, "error", err)
+			return nil, fmt.Errorf("failed to parse setup command %q: %w", cmdToRun, err)
+		}
+		if len(parts) == 0 {
+			return nil, nil
+		}
+		setupExec = execCommandValidated(resolveExecutable(parts[0], logger), parts[1:]...)
+	}
+
+	setupExec.Dir = userCwd
+	setupExec.Env = setEnv(os.Environ(), EnvWorkenv, workenvDir)
+
+	binDir := "bin"
+	if runtime.GOOS == "windows" {
+		binDir = "Scripts"
+	}
+	for i, env := range setupExec.Env {
+		if strings.HasPrefix(env, "PATH=") {
+			setupExec.Env[i] = fmt.Sprintf("PATH=%s%s%s",
+				filepath.Join(workenvDir, binDir),
+				string(os.PathListSeparator),
+				strings.TrimPrefix(env, "PATH="))
+			break
+		}
+	}
+
+	return setupExec, nil
+}
+
+// runSetupCommands runs every setup command the metadata declares, then clears
+// the init-lifecycle slots they consumed.
+func runSetupCommands(
+	metadata *Metadata,
+	workenvDir string,
+	workenvDirForCmd string,
+	userCwd string,
+	slotPaths map[int]string,
+	logger *slog.Logger,
+) error {
+	logger.Info("🔧 Running setup commands", "count", len(metadata.SetupCommands))
+
+	metadataDir := filepath.Join(workenvDir, "metadata")
+	if err := mkdirAllValidated(metadataDir, os.FileMode(DirPerms)); err != nil {
+		logger.Error("❌ Failed to create metadata directory", "error", err)
+		return fmt.Errorf("failed to create metadata directory: %w", err)
+	}
+
+	for i, entry := range metadata.SetupCommands {
+		logger.Debug("🔧 Processing setup command", "index", i)
+
+		cmdToRun, cmdArgs, err := resolveSetupCommand(entry, metadata, workenvDir, workenvDirForCmd, logger)
+		if err != nil {
+			return err
+		}
+		if cmdToRun == "" {
+			continue
+		}
+
+		if len(cmdArgs) == 0 {
+			cmdToRun = substituteSetupPlaceholders(cmdToRun, workenvDirForCmd, metadata.Package)
+		}
+
+		setupExec, err := newSetupExecCommand(cmdToRun, cmdArgs, userCwd, workenvDir, logger)
+		if err != nil {
+			return err
+		}
+		if setupExec == nil {
+			continue
+		}
+
+		logger.Debug("🏃 Running setup command", "command", cmdToRun, "args", cmdArgs, "cwd", userCwd)
+		if output, err := setupExec.CombinedOutput(); err != nil {
+			logger.Error("❌ Setup command failed", "command", cmdToRun, "output", string(output))
+			return fmt.Errorf("setup command %s failed: %w", cmdToRun, err)
+		}
+	}
+
+	logger.Info("🧹 Cleaning up lifecycle slots...")
+	cleanupLifecycleSlots(workenvDir, metadata, slotPaths, logger)
+
+	return nil
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_slots.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slots.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 
 	"log/slog"
 )
@@ -22,6 +20,12 @@ var markExtractionCompleteFn = MarkExtractionComplete
 
 // extractAndMergeSlotsToWorkenv extracts slots to temporary directory and merges them to final workenv location
 // It handles the complex slot merging logic where slot_N_* directories need to be merged (not replaced)
+// extractAndMergeSlotsToWorkenv stages every slot in a temporary directory and
+// then merges it into the work environment.
+//
+// Staging first is what makes a failed extraction leave no half-built work
+// environment behind: nothing reaches the real directory until every slot has
+// been written successfully.
 func extractAndMergeSlotsToWorkenv(
 	reader *Reader,
 	metadata *Metadata,
@@ -29,10 +33,8 @@ func extractAndMergeSlotsToWorkenv(
 	index *PSPFIndex,
 	logger *slog.Logger,
 ) (map[int]string, error) {
-	slotPaths := make(map[int]string)
 	workenvDir := paths.Workenv()
 
-	// Create temporary extraction directory
 	tempExtractDir := paths.TempExtraction(os.Getpid())
 	if err := os.MkdirAll(tempExtractDir, os.FileMode(DirPerms)); err != nil {
 		logger.Error("❌ Failed to create temp extraction directory", "error", err)
@@ -40,220 +42,30 @@ func extractAndMergeSlotsToWorkenv(
 	}
 	logger.Info("📁 Created temporary extraction directory", "path", tempExtractDir)
 
-	// Extract to temporary directory
-	logger.Info("📤 Extracting slots to temp directory", "count", len(metadata.Slots))
-
-	// Progress reporting to stderr
-	for i, slot := range metadata.Slots {
-		logger.Debug("📦 Extracting slot", "index", i, "id", slot.ID, "size", slot.Size)
-
-		// Write progress to stderr
-		fmt.Fprintf(os.Stderr, "[%d/%d] Extracting %s...\n", i+1, len(metadata.Slots), slot.ID)
-		slotPath, err := reader.ExtractSlot(i, tempExtractDir)
-		if err != nil {
-			logger.Error("❌ Failed to extract slot, cleaning up", "error", err)
+	// Every failure below leaves the staging directory behind otherwise, and it
+	// is named after this process, so nothing else will clean it up.
+	staged := false
+	defer func() {
+		if !staged {
 			_ = os.RemoveAll(tempExtractDir)
-			return nil, fmt.Errorf("%w: %v", ErrSlotExtractionFailed, err)
 		}
-		logger.Debug("✅ Extracted slot", "path", slotPath)
-		slotPaths[slot.Slot] = slotPath
-	}
+	}()
 
-	// Write metadata to package metadata directory directly in cache (not in temp)
-	// Use hidden .{workenv}.pspf/package/ structure as a sibling to workenv
-	packageMetadataDir := filepath.Join(paths.Metadata(), "package")
-	if err := os.MkdirAll(packageMetadataDir, os.FileMode(DirPerms)); err != nil {
-		logger.Error("❌ Failed to create package metadata directory", "error", err)
-		_ = os.RemoveAll(tempExtractDir)
-		return nil, fmt.Errorf("failed to create package metadata directory: %w", err)
-	}
-	metadataFile := filepath.Join(packageMetadataDir, "psp.json")
-	metadataJSON, err := jsonMarshalIndentFn(metadata, "", "  ")
+	slotPaths, err := extractSlotsToTemp(reader, metadata, tempExtractDir, logger)
 	if err != nil {
-		logger.Error("❌ Failed to marshal metadata", "error", err)
-		_ = os.RemoveAll(tempExtractDir)
-		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
-	}
-	if err := os.WriteFile(metadataFile, metadataJSON, FilePerms); err != nil {
-		logger.Error("❌ Failed to write metadata", "error", err)
-		_ = os.RemoveAll(tempExtractDir)
-		return nil, fmt.Errorf("failed to write metadata: %w", err)
-	}
-	logger.Debug("📝 Wrote metadata to cache location", "path", metadataFile)
-
-	// Atomically move extracted content from temp to final location
-	logger.Info("🔄 Moving extracted content to final location...")
-
-	// List all top-level items in temp directory
-	entries, err := osReadDirFn(tempExtractDir)
-	if err != nil {
-		logger.Error("❌ Failed to read temp directory", "error", err)
-		_ = os.RemoveAll(tempExtractDir)
-		return nil, fmt.Errorf("failed to read temp directory: %w", err)
+		return nil, err
 	}
 
-	// Process slots in reverse order (highest index first) so earlier slots don't get overwritten
-	// This ensures slot_N_* directories are merged before slot_0_* and regular files
-	sort.SliceStable(entries, func(i, j int) bool {
-		nameI := entries[i].Name()
-		nameJ := entries[j].Name()
-
-		// Extract slot numbers for slot_N_* directories
-		slotI, slotJ := -1, -1
-		if _, err := fmt.Sscanf(nameI, "slot_%d_", &slotI); err == nil && entries[i].IsDir() {
-			// nameI is a slot directory
-		} else {
-			slotI = -1
-		}
-		if _, err := fmt.Sscanf(nameJ, "slot_%d_", &slotJ); err == nil && entries[j].IsDir() {
-			// nameJ is a slot directory
-		} else {
-			slotJ = -1
-		}
-
-		// Both are slot directories - sort by slot number in reverse (higher first)
-		if slotI >= 0 && slotJ >= 0 {
-			return slotI > slotJ
-		}
-		// Only one is a slot directory - slot directories come first
-		if slotI >= 0 {
-			return true
-		}
-		if slotJ >= 0 {
-			return false
-		}
-		// Neither are slot directories - keep original order
-		return false
-	})
-
-	for _, entry := range entries {
-		fileName := entry.Name()
-		source := filepath.Join(tempExtractDir, fileName)
-
-		// Special handling for slot 0 - move contents to workenv root
-		if strings.HasPrefix(fileName, "slot_0_") && entry.IsDir() {
-			logger.Debug("🎯 Moving slot 0 contents to workenv root", "slotDir", fileName)
-			// Read contents of slot 0 directory
-			slotEntries, err := os.ReadDir(source)
-			if err != nil {
-				logger.Error("❌ Failed to read slot 0 directory", "error", err)
-				_ = os.RemoveAll(tempExtractDir)
-				return nil, fmt.Errorf("failed to read slot 0 directory: %w", err)
-			}
-
-			// Move each item from slot 0 directory to workenv root
-			for _, slotEntry := range slotEntries {
-				slotSource := filepath.Join(source, slotEntry.Name())
-				slotDest := filepath.Join(workenvDir, slotEntry.Name())
-
-				logger.Debug("Moving slot 0 content", "from", slotSource, "to", slotDest)
-
-				// For directories, merge instead of replacing
-				if slotEntry.IsDir() {
-					// Always use copyDirAll which merges directories
-					if err := copyDirAll(slotSource, slotDest); err != nil {
-						logger.Error("❌ Failed to copy slot 0 directory", "error", err)
-						_ = os.RemoveAll(tempExtractDir)
-						return nil, fmt.Errorf("failed to copy slot 0 directory: %w", err)
-					}
-					_ = os.RemoveAll(slotSource)
-				} else {
-					// For files, remove destination and move
-					_ = os.Remove(slotDest) // Remove existing file if any
-					if err := osRenameFn(slotSource, slotDest); err != nil {
-						// If rename fails (e.g., cross-filesystem), fall back to copy
-						logger.Warn("Rename failed, falling back to copy", "error", err)
-						if err := copyFile(slotSource, slotDest); err != nil {
-							logger.Error("❌ Failed to copy slot 0 file", "error", err)
-							_ = os.RemoveAll(tempExtractDir)
-							return nil, fmt.Errorf("failed to copy slot 0 file: %w", err)
-						}
-						_ = os.Remove(slotSource)
-					}
-				}
-			}
-			// Remove empty slot 0 directory
-			_ = os.RemoveAll(source)
-		} else if strings.HasPrefix(fileName, "slot_") && entry.IsDir() {
-			// Handle other slot_N_* directories (where target was {workenv}) - merge to root
-			logger.Debug("🎯 Moving slot contents to workenv root", "slotDir", fileName)
-			// Read contents of slot directory
-			slotEntries, err := os.ReadDir(source)
-			if err != nil {
-				logger.Error("❌ Failed to read slot directory", "error", err)
-				_ = os.RemoveAll(tempExtractDir)
-				return nil, fmt.Errorf("failed to read slot directory: %w", err)
-			}
-
-			// Move each item from slot directory to workenv root
-			for _, slotEntry := range slotEntries {
-				slotSource := filepath.Join(source, slotEntry.Name())
-				slotDest := filepath.Join(workenvDir, slotEntry.Name())
-
-				logger.Debug("Moving slot content", "from", slotSource, "to", slotDest)
-
-				// For directories, merge instead of replacing
-				if slotEntry.IsDir() {
-					// Always use copyDirAll which merges directories
-					if err := copyDirAll(slotSource, slotDest); err != nil {
-						logger.Error("❌ Failed to copy slot directory", "error", err)
-						_ = os.RemoveAll(tempExtractDir)
-						return nil, fmt.Errorf("failed to copy slot directory: %w", err)
-					}
-					_ = os.RemoveAll(slotSource)
-				} else {
-					// For files, remove destination and move
-					_ = os.Remove(slotDest) // Remove existing file if any
-					if err := osRenameFn(slotSource, slotDest); err != nil {
-						// If rename fails (e.g., cross-filesystem), fall back to copy
-						logger.Warn("Rename failed, falling back to copy", "error", err)
-						if err := copyFile(slotSource, slotDest); err != nil {
-							logger.Error("❌ Failed to copy slot file", "error", err)
-							_ = os.RemoveAll(tempExtractDir)
-							return nil, fmt.Errorf("failed to copy slot file: %w", err)
-						}
-						_ = os.Remove(slotSource)
-					}
-				}
-			}
-			// Remove empty slot directory
-			_ = os.RemoveAll(source)
-		} else {
-			// Regular handling for other files/directories
-			dest := filepath.Join(workenvDir, fileName)
-
-			logger.Debug("Moving", "from", source, "to", dest)
-
-			if entry.IsDir() {
-				// For directories, always merge using copyDirAll (handles existing destinations)
-				if err := copyDirAll(source, dest); err != nil {
-					logger.Error("❌ Failed to copy directory", "error", err)
-					_ = os.RemoveAll(tempExtractDir)
-					return nil, fmt.Errorf("failed to copy directory: %w", err)
-				}
-				_ = os.RemoveAll(source)
-			} else {
-				if err := mkdirAllParentFn(filepath.Dir(dest), os.FileMode(DirPerms)); err != nil {
-					logger.Error("❌ Failed to create parent directory for file", "dest", dest, "error", err)
-					_ = os.RemoveAll(tempExtractDir)
-					return nil, fmt.Errorf("failed to create parent directory for file: %w", err)
-				}
-				// For files, try rename first, then copy
-				if err := osRenameFn(source, dest); err != nil {
-					// If rename fails (e.g., cross-filesystem or destination exists), fall back to copy
-					logger.Warn("Rename failed, falling back to copy", "error", err)
-					if err := copyFile(source, dest); err != nil {
-						logger.Error("❌ Failed to copy file", "error", err)
-						_ = os.RemoveAll(tempExtractDir)
-						return nil, fmt.Errorf("failed to copy file: %w", err)
-					}
-					_ = os.Remove(source)
-				}
-			}
-		}
+	if err := writePackageMetadataFile(metadata, paths, logger); err != nil {
+		return nil, err
 	}
 
-	// Fix shebangs in bin directory
+	if err := mergeTempIntoWorkenv(tempExtractDir, workenvDir, logger); err != nil {
+		return nil, err
+	}
+	staged = true
+
+	// Scripts carry the interpreter path from wherever they were built.
 	binDir := filepath.Join(workenvDir, "bin")
 	if _, err := os.Stat(binDir); err == nil {
 		logger.Info("🔧 Fixing shebangs in scripts...")
@@ -262,17 +74,14 @@ func extractAndMergeSlotsToWorkenv(
 		}
 	}
 
-	// Remove the now-empty temp directory
 	if err := osRemoveAllFn(tempExtractDir); err != nil {
 		logger.Debug("⚠️ Failed to remove temp directory", "error", err)
 	}
 
-	// Save index metadata for inspection
+	// None of the following is required for the package to run.
 	if err := saveIndexMetadataFn(paths, index, logger); err != nil {
 		logger.Debug("⚠️ Failed to save index metadata", "error", err)
 	}
-
-	// Mark extraction as complete
 	if err := markExtractionCompleteFn(paths, logger); err != nil {
 		logger.Debug("⚠️ Failed to mark extraction complete", "error", err)
 	}

--- a/src/flavor-go/pkg/psp/format_2025/execution_slots_merge.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_slots_merge.go
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// slotDirIndex reports the slot number a "slot_N_*" directory carries, or -1
+// for anything else.
+func slotDirIndex(entry os.DirEntry) int {
+	if !entry.IsDir() {
+		return -1
+	}
+	n := -1
+	if _, err := fmt.Sscanf(entry.Name(), "slot_%d_", &n); err != nil {
+		return -1
+	}
+	return n
+}
+
+// sortSlotDirectoriesFirst orders extracted entries so slot directories are
+// merged before anything else, highest slot number first.
+//
+// Later slots are meant to be overwritten by earlier ones, so they have to land
+// first; regular files come last and win outright.
+func sortSlotDirectoriesFirst(entries []os.DirEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		slotI, slotJ := slotDirIndex(entries[i]), slotDirIndex(entries[j])
+		switch {
+		case slotI >= 0 && slotJ >= 0:
+			return slotI > slotJ
+		case slotI >= 0:
+			return true
+		case slotJ >= 0:
+			return false
+		default:
+			return false
+		}
+	})
+}
+
+// moveIntoWorkenv moves one extracted item to its place in the work
+// environment.
+//
+// Directories are merged rather than replaced, so a later slot's tree does not
+// erase an earlier one's. Files are renamed where the filesystem allows it and
+// copied when it does not -- the temp directory and the work environment can
+// sit on different filesystems.
+//
+// replaceExisting clears the destination first. Slot contents merge into a
+// shared root and are expected to land on each other, so they replace. A
+// top-level entry does not: a destination already occupied there is a conflict
+// the build should hear about, and clearing it first would turn a directory in
+// the way into a silent success.
+func moveIntoWorkenv(source, dest string, isDir, replaceExisting bool, what string, logger *slog.Logger) error {
+	// "file" / "directory", or "slot file" / "slot directory".
+	noun := "file"
+	if isDir {
+		noun = "directory"
+	}
+	if what != "" {
+		noun = what + " " + noun
+	}
+
+	if isDir {
+		if err := copyDirAll(source, dest); err != nil {
+			logger.Error("❌ Failed to copy "+noun, "error", err)
+			return fmt.Errorf("failed to copy %s: %w", noun, err)
+		}
+		_ = os.RemoveAll(source)
+		return nil
+	}
+
+	if replaceExisting {
+		_ = os.Remove(dest)
+	}
+	if err := osRenameFn(source, dest); err == nil {
+		return nil
+	}
+
+	logger.Warn("Rename failed, falling back to copy", "source", source, "dest", dest)
+	if err := copyFile(source, dest); err != nil {
+		logger.Error("❌ Failed to copy "+noun, "error", err)
+		return fmt.Errorf("failed to copy %s: %w", noun, err)
+	}
+	_ = os.Remove(source)
+	return nil
+}
+
+// mergeSlotDirectory empties one "slot_N_*" directory into the work environment
+// root, which is where a slot whose target is {workenv} belongs.
+func mergeSlotDirectory(source, workenvDir string, logger *slog.Logger) error {
+	slotEntries, err := os.ReadDir(source)
+	if err != nil {
+		logger.Error("❌ Failed to read slot directory", "error", err, "path", source)
+		return fmt.Errorf("failed to read slot directory: %w", err)
+	}
+
+	for _, slotEntry := range slotEntries {
+		slotSource := filepath.Join(source, slotEntry.Name())
+		slotDest := filepath.Join(workenvDir, slotEntry.Name())
+		logger.Debug("Moving slot content", "from", slotSource, "to", slotDest)
+
+		if err := moveIntoWorkenv(slotSource, slotDest, slotEntry.IsDir(), true, "slot", logger); err != nil {
+			return err
+		}
+	}
+
+	_ = os.RemoveAll(source) // now empty
+	return nil
+}
+
+// mergeExtractedEntry places one top-level extracted entry.
+func mergeExtractedEntry(entry os.DirEntry, tempExtractDir, workenvDir string, logger *slog.Logger) error {
+	fileName := entry.Name()
+	source := filepath.Join(tempExtractDir, fileName)
+
+	// Every slot_N_* directory merges to the root the same way, slot 0 included.
+	if entry.IsDir() && strings.HasPrefix(fileName, "slot_") {
+		logger.Debug("🎯 Moving slot contents to workenv root", "slotDir", fileName)
+		return mergeSlotDirectory(source, workenvDir, logger)
+	}
+
+	dest := filepath.Join(workenvDir, fileName)
+	logger.Debug("Moving", "from", source, "to", dest)
+
+	if !entry.IsDir() {
+		if err := mkdirAllParentFn(filepath.Dir(dest), os.FileMode(DirPerms)); err != nil {
+			logger.Error("❌ Failed to create parent directory for file", "dest", dest, "error", err)
+			return fmt.Errorf("failed to create parent directory for file: %w", err)
+		}
+	}
+
+	return moveIntoWorkenv(source, dest, entry.IsDir(), false, "", logger)
+}
+
+// mergeTempIntoWorkenv moves everything extracted into the work environment.
+func mergeTempIntoWorkenv(tempExtractDir, workenvDir string, logger *slog.Logger) error {
+	logger.Info("🔄 Moving extracted content to final location...")
+
+	entries, err := osReadDirFn(tempExtractDir)
+	if err != nil {
+		logger.Error("❌ Failed to read temp directory", "error", err)
+		return fmt.Errorf("failed to read temp directory: %w", err)
+	}
+
+	sortSlotDirectoriesFirst(entries)
+
+	for _, entry := range entries {
+		if err := mergeExtractedEntry(entry, tempExtractDir, workenvDir, logger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// extractSlotsToTemp writes every slot into a staging directory, reporting
+// progress on stderr as it goes.
+func extractSlotsToTemp(
+	reader *Reader,
+	metadata *Metadata,
+	tempExtractDir string,
+	logger *slog.Logger,
+) (map[int]string, error) {
+	logger.Info("📤 Extracting slots to temp directory", "count", len(metadata.Slots))
+
+	slotPaths := make(map[int]string, len(metadata.Slots))
+	for i, slot := range metadata.Slots {
+		logger.Debug("📦 Extracting slot", "index", i, "id", slot.ID, "size", slot.Size)
+		_, _ = fmt.Fprintf(os.Stderr, "[%d/%d] Extracting %s...\n", i+1, len(metadata.Slots), slot.ID)
+
+		slotPath, err := reader.ExtractSlot(i, tempExtractDir)
+		if err != nil {
+			logger.Error("❌ Failed to extract slot", "error", err)
+			return nil, fmt.Errorf("%w: %v", ErrSlotExtractionFailed, err)
+		}
+		logger.Debug("✅ Extracted slot", "path", slotPath)
+		slotPaths[slot.Slot] = slotPath
+	}
+
+	return slotPaths, nil
+}
+
+// writePackageMetadataFile records the metadata document beside the work
+// environment, where an inspection can read it without opening the package.
+func writePackageMetadataFile(metadata *Metadata, paths *WorkenvPaths, logger *slog.Logger) error {
+	packageMetadataDir := filepath.Join(paths.Metadata(), "package")
+	if err := os.MkdirAll(packageMetadataDir, os.FileMode(DirPerms)); err != nil {
+		logger.Error("❌ Failed to create package metadata directory", "error", err)
+		return fmt.Errorf("failed to create package metadata directory: %w", err)
+	}
+
+	metadataJSON, err := jsonMarshalIndentFn(metadata, "", "  ")
+	if err != nil {
+		logger.Error("❌ Failed to marshal metadata", "error", err)
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	metadataFile := filepath.Join(packageMetadataDir, "psp.json")
+	if err := os.WriteFile(metadataFile, metadataJSON, FilePerms); err != nil {
+		logger.Error("❌ Failed to write metadata", "error", err)
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+
+	logger.Debug("📝 Wrote metadata to cache location", "path", metadataFile)
+	return nil
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_verify.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_verify.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// checkSigningKeyTrust reports whether the package's signing key is in the
+// trusted store, and fails closed on an attestation fingerprint that does not
+// describe the embedded key.
+//
+// An untrusted key is not fatal here: it warns, and EnforcePolicy decides what
+// the operator policy makes of it.
+func checkSigningKeyTrust(index *PSPFIndex, logger *slog.Logger) (bool, error) {
+	hasPublicKey := false
+	for _, b := range index.PublicKey {
+		if b != 0 {
+			hasPublicKey = true
+			break
+		}
+	}
+
+	attestationFP := strings.TrimRight(string(index.AttestationKeyFp[:]), "\x00")
+
+	if !hasPublicKey {
+		if attestationFP != "" {
+			return false, errors.New("attestation key fingerprint is present but public key is missing")
+		}
+		return false, nil
+	}
+
+	fp, err := ComputeKeyFingerprint(index.PublicKey[:])
+	if err != nil {
+		logger.Warn("⚠️ Failed to derive signing key fingerprint", "error", err)
+		return false, nil
+	}
+
+	if attestationFP != "" && attestationFP != fp {
+		return false, errors.New("attestation key fingerprint does not match embedded public key")
+	}
+
+	trusted, err := IsKeyTrusted(fp, true)
+	switch {
+	case err != nil:
+		logger.Warn("⚠️ Failed to check trusted key store", "error", err)
+	case trusted == nil:
+		logger.Warn("⚠️ No trusted-keys store found; requiring a trusted key will fail closed", "fingerprint", fp)
+	case *trusted:
+		return true, nil
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package signing key is not in the trusted store\n")
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ Key fingerprint: %s\n", fp)
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ Use 'flavor trust add <key-file>' to trust this key\n")
+		logger.Warn("⚠️ Package signing key not in trusted store", "fingerprint", fp)
+	}
+
+	return false, nil
+}
+
+// tolerateVerificationError decides what a check that could not complete means
+// at this validation level: minimal and relaxed continue with a warning, and
+// standard and strict stop. Returning nil means the caller carries on.
+//
+// The three integrity checks differ only in what they name, so subject is the
+// caller's phrase for the thing it failed to verify.
+func tolerateVerificationError(level ValidationLevel, subject string, err error, logger *slog.Logger) error {
+	switch level {
+	case ValidationMinimal, ValidationRelaxed:
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Failed to verify %s: %v\n", subject, err)
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", level)
+		logger.Warn("⚠️ Failed to verify "+subject+", continuing", "error", err, "level", level)
+		return nil
+	default: // ValidationStrict, ValidationStandard
+		logger.Error("❌ Failed to verify "+subject, "error", err)
+		return fmt.Errorf("failed to verify %s: %w", subject, err)
+	}
+}
+
+// tolerateIntegrityFailure decides what a seal that verified cleanly and came
+// back invalid means. It is separate from tolerateVerificationError because a
+// package that fails its seal is a different event from one whose seal could
+// not be read, and standard treats the two differently.
+func tolerateIntegrityFailure(level ValidationLevel, logger *slog.Logger) error {
+	switch level {
+	case ValidationMinimal, ValidationRelaxed:
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Package integrity verification failed\n")
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ Package may be corrupted or tampered with\n")
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ Continuing due to validation level: %v\n", level)
+		logger.Warn("⚠️ Package integrity verification failed, continuing", "level", level)
+		return nil
+	case ValidationStandard:
+		_, _ = fmt.Fprintf(os.Stderr, "🚨 SECURITY WARNING: Package integrity verification failed\n")
+		_, _ = fmt.Fprintf(os.Stderr, "🚨 Package may be corrupted or tampered with\n")
+		_, _ = fmt.Fprintf(os.Stderr, "🚨 Continuing with standard validation (use FLAVOR_VALIDATION=strict to enforce)\n")
+		logger.Warn("⚠️ Package integrity verification failed, continuing with standard validation")
+		return nil
+	default: // ValidationStrict
+		logger.Error("❌ Package integrity verification failed")
+		return errors.New("package integrity verification failed")
+	}
+}
+
+// verifyPackageIntegrity runs the three integrity checks a launch depends on:
+// the Ed25519 seal, the attestation SBOM digest, and the attestation policy
+// hash. Each one's failure is referred to the validation level rather than
+// decided here.
+func verifyPackageIntegrity(reader *Reader, level ValidationLevel, logger *slog.Logger) error {
+	if level == ValidationNone {
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ SECURITY WARNING: Skipping all integrity verification (FLAVOR_VALIDATION=none)\n")
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️ This is NOT RECOMMENDED for production use\n")
+		logger.Warn("⚠️ VALIDATION DISABLED: Skipping integrity verification", "level", level)
+		return nil
+	}
+
+	logger.Debug("🔍 Verifying package integrity", "level", level)
+	valid, err := verifyIntegritySealFn(reader)
+	switch {
+	case err != nil:
+		if tolerated := tolerateVerificationError(level, "integrity seal", err, logger); tolerated != nil {
+			return tolerated
+		}
+	case !valid:
+		if tolerated := tolerateIntegrityFailure(level, logger); tolerated != nil {
+			return tolerated
+		}
+	default:
+		logger.Debug("✅ Package integrity verified")
+	}
+
+	// Fail-closed: a digest present with the slot absent is an error.
+	logger.Debug("🔍 Verifying attestation SBOM digest", "level", level)
+	if err := reader.VerifyAttestationSbomDigest(); err != nil {
+		if tolerated := tolerateVerificationError(level, "attestation SBOM digest", err, logger); tolerated != nil {
+			return tolerated
+		}
+	} else {
+		logger.Debug("✅ Attestation SBOM digest verified")
+	}
+
+	// Fail-closed: a hash present with no policy is an error.
+	logger.Debug("🔍 Verifying attestation policy hash", "level", level)
+	if err := reader.VerifyAttestationPolicyHash(); err != nil {
+		if tolerated := tolerateVerificationError(level, "attestation policy hash", err, logger); tolerated != nil {
+			return tolerated
+		}
+	} else {
+		logger.Debug("✅ Attestation policy hash verified")
+	}
+
+	return nil
+}
+
+// enforcePackagePolicy merges the package's policy with the operator's and
+// applies the result. Warnings are logged; a violation stops the launch.
+func enforcePackagePolicy(metadata *Metadata, index *PSPFIndex, keyTrusted bool, logger *slog.Logger) error {
+	opPolicy, err := LoadOperatorPolicy()
+	if err != nil {
+		logger.Error("❌ Failed to load operator policy", "error", err)
+		return fmt.Errorf("failed to load operator policy: %w", err)
+	}
+
+	var pkgPolicy PackagePolicy
+	if metadata.Policy != nil {
+		pkgPolicy = *metadata.Policy
+	}
+	effective := MergePolicy(pkgPolicy, opPolicy)
+
+	hasSBOM := false
+	for _, slot := range metadata.Slots {
+		if slot.Lifecycle == "attestation" {
+			hasSBOM = true
+			break
+		}
+	}
+
+	buildTimestamp, err := uint64ToInt64Checked(index.BuildTimestamp, "build timestamp")
+	if err != nil {
+		logger.Error("❌ Invalid build timestamp", "error", err)
+		return fmt.Errorf("invalid build timestamp: %w", err)
+	}
+
+	policyWarnings, enforceErr := EnforcePolicy(effective, buildTimestamp, hasSBOM, keyTrusted)
+	for _, w := range policyWarnings {
+		logger.Warn("⚠️  Policy warning", "message", w)
+	}
+	if enforceErr != nil {
+		logger.Error("❌ Policy violation", "error", enforceErr)
+		return fmt.Errorf("policy violation: %w", enforceErr)
+	}
+
+	logger.Debug("✅ Policy enforcement passed")
+	return nil
+}

--- a/src/flavor-go/pkg/psp/format_2025/execution_workenv_setup.go
+++ b/src/flavor-go/pkg/psp/format_2025/execution_workenv_setup.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/internal/workenv"
+)
+
+// resolveWorkenvPaths decides where this package extracts to and creates the
+// root directory. FLAVOR_WORKENV names the workenv directly; its cache root is
+// two levels up, because NewWorkenvPaths derives the rest of the layout.
+func resolveWorkenvPaths(exePath string, logger *slog.Logger) (*WorkenvPaths, string, error) {
+	var paths *WorkenvPaths
+	if customWorkenv := os.Getenv(EnvWorkenv); customWorkenv != "" {
+		logger.Info("📁 Using custom work environment from FLAVOR_WORKENV", "path", customWorkenv)
+		cacheDir := filepath.Dir(filepath.Dir(customWorkenv))
+		paths = NewWorkenvPaths(cacheDir, exePath)
+	} else {
+		// workenv.GetCacheRoot keeps the location consistent across platforms.
+		paths = NewWorkenvPaths(workenv.GetCacheRoot(), exePath)
+	}
+
+	workenvDir := paths.Workenv()
+	if err := mkdirAllValidated(workenvDir, os.FileMode(DirPerms)); err != nil {
+		logger.Error("❌ Failed to create work environment directory", "error", err)
+		return nil, "", fmt.Errorf("failed to create work environment directory: %w", err)
+	}
+	logger.Info("📁 Work environment", "path", workenvDir)
+
+	return paths, workenvDir, nil
+}
+
+// createWorkenvDirectory creates one directory the metadata asked for, after
+// checking the substituted path has not escaped the work environment.
+//
+// A mode that will not parse, or will not apply, is logged and not fatal: the
+// directory exists, which is what the package needs.
+func createWorkenvDirectory(dirSpec DirectorySpec, workenvDir string, logger *slog.Logger) error {
+	dirPath := strings.ReplaceAll(dirSpec.Path, "{workenv}", workenvDir)
+
+	if err := ensurePathWithinWorkenv(dirPath, workenvDir, dirSpec.Path); err != nil {
+		return fmt.Errorf("directory path %q escapes work environment directory", dirSpec.Path)
+	}
+
+	logger.Debug("📁 Creating directory", "path", dirPath)
+	if err := mkdirAllValidated(dirPath, os.FileMode(DirPerms)); err != nil {
+		logger.Error("❌ Failed to create directory", "path", dirPath, "error", err)
+		return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
+	}
+
+	if dirSpec.Mode == "" {
+		return nil
+	}
+
+	mode, err := strconv.ParseUint(strings.TrimPrefix(dirSpec.Mode, "0"), 8, 32)
+	if err != nil {
+		return nil
+	}
+	if err := chmodValidatedFn(dirPath, os.FileMode(mode)); err != nil {
+		logger.Debug("Failed to set permissions", "path", dirPath, "mode", dirSpec.Mode, "error", err)
+	} else {
+		logger.Debug("🔒 Set permissions", "path", dirPath, "mode", dirSpec.Mode)
+	}
+
+	return nil
+}
+
+// createWorkenvDirectories creates every directory the metadata declares.
+func createWorkenvDirectories(metadata *Metadata, workenvDir string, logger *slog.Logger) error {
+	if metadata.Workenv == nil || metadata.Workenv.Directories == nil {
+		return nil
+	}
+	for _, dirSpec := range metadata.Workenv.Directories {
+		if err := createWorkenvDirectory(dirSpec, workenvDir, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// workenvSlotPaths maps every slot to the work environment root, which is
+// where a validated extraction has already placed its contents.
+func workenvSlotPaths(metadata *Metadata, paths *WorkenvPaths) map[int]string {
+	slotPaths := make(map[int]string, len(metadata.Slots))
+	for _, slot := range metadata.Slots {
+		slotPaths[slot.Slot] = paths.Workenv()
+	}
+	return slotPaths
+}

--- a/src/flavor-go/pkg/psp/format_2025/launcher.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher.go
@@ -1,7 +1,6 @@
 package format_2025
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -28,48 +27,10 @@ var launcherStderrWriter io.Writer = os.Stderr
 
 // LaunchWithLogLevel launches with explicit log level control
 func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource string) {
-	// Determine log level and source
-	var logLevel string
-	var logSource string
+	logger, actualLevel, logSource, closeLog := setupLauncherLogging(cliLogLevel, cliLogSource)
+	defer closeLog()
 
-	if cliLogLevel != "" {
-		logLevel = cliLogLevel
-		logSource = cliLogSource
-	} else if envLevel := os.Getenv(EnvLauncherLogLevel); envLevel != "" {
-		logLevel = envLevel
-		logSource = EnvLauncherLogLevel
-	} else if envLevel := os.Getenv(EnvLogLevel); envLevel != "" {
-		logLevel = envLevel
-		logSource = EnvLogLevel
-	} else {
-		logLevel = "warn" // Default to warn for production; set FLAVOR_LOG_LEVEL for more detail
-		logSource = "default"
-	}
-
-	// Parse the actual level string for logging the configured level in debug output.
-	actualLevel := logLevel
-	if strings.HasPrefix(logLevel, "json:") {
-		actualLevel = logLevel[len("json:"):]
-	} else if logLevel == "json" {
-		actualLevel = "info"
-	}
-
-	setUTF8ConsoleOutput()
-
-	// Determine log output destination.
-	var logOutput io.Writer
-	if logPath := os.Getenv(EnvLogPath); logPath != "" {
-		if file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, FilePerms); err == nil {
-			defer func() { _ = file.Close() }()
-			logOutput = file
-		}
-	} else if !logging.IsJSONFormat(logLevel) {
-		logOutput = logging.NewPrefixWriter("🐹 ", launcherStderrWriter)
-	}
-	logging.Setup(logLevel, logOutput)
-	logger := logging.NewLogger(context.Background(), "flavor-go.launcher")
-
-	// Only log startup messages in CLI mode
+	// Startup chatter belongs to CLI mode; otherwise stdout is the package's.
 	if isEnvTrue(EnvLauncherCLI) {
 		logger.Info("🐹🐹🐹 Hello from Flavor's Go Launcher 🐹🐹🐹")
 		logger.Debug("Log level", "level", actualLevel, "source", logSource)
@@ -77,17 +38,7 @@ func LaunchWithLogLevel(exePath string, args []string, cliLogLevel, cliLogSource
 	}
 	logger.Debug("📖 Reading PSPF bundle")
 
-	envVars := os.Environ()
-	logger.Debug("🔧 Environment variables received from parent process", "count", len(envVars))
-
-	if logging.IsEnabled(logger, logging.LevelTrace) {
-		for _, env := range envVars {
-			parts := strings.SplitN(env, "=", 2)
-			if len(parts) == 2 {
-				logging.Trace(logger, "📝 Environment variable", "key", parts[0], "value", parts[1])
-			}
-		}
-	}
+	traceEnvironment(logger)
 
 	userCwd, err := osGetWdFn()
 	if err != nil {

--- a/src/flavor-go/pkg/psp/format_2025/launcher_logging.go
+++ b/src/flavor-go/pkg/psp/format_2025/launcher_logging.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+// resolveLogLevel picks the log level and records where it came from, so a
+// launcher that is quieter than expected can say which setting made it so.
+//
+// The default is warn: a launcher's own logging is not the packaged
+// application's output, and production runs should not mix the two.
+func resolveLogLevel(cliLogLevel, cliLogSource string) (level, source string) {
+	switch {
+	case cliLogLevel != "":
+		return cliLogLevel, cliLogSource
+	case os.Getenv(EnvLauncherLogLevel) != "":
+		return os.Getenv(EnvLauncherLogLevel), EnvLauncherLogLevel
+	case os.Getenv(EnvLogLevel) != "":
+		return os.Getenv(EnvLogLevel), EnvLogLevel
+	default:
+		return "warn", "default"
+	}
+}
+
+// describeLogLevel strips the json: transport prefix, leaving the severity the
+// operator actually chose. Bare "json" carries no severity and means info.
+func describeLogLevel(logLevel string) string {
+	if after, found := strings.CutPrefix(logLevel, "json:"); found {
+		return after
+	}
+	if logLevel == "json" {
+		return "info"
+	}
+	return logLevel
+}
+
+// openLogOutput chooses where launcher logging goes. It returns a close
+// function, which is a no-op unless a log file was opened.
+//
+// A log file that will not open is not fatal: logging falls back to the
+// default destination rather than stopping the launch.
+func openLogOutput(logLevel string) (io.Writer, func()) {
+	if logPath := os.Getenv(EnvLogPath); logPath != "" {
+		file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, FilePerms)
+		if err == nil {
+			return file, func() { _ = file.Close() }
+		}
+		return nil, func() {}
+	}
+
+	if !logging.IsJSONFormat(logLevel) {
+		// The prefix marks launcher output apart from the package's own.
+		return logging.NewPrefixWriter("🐹 ", launcherStderrWriter), func() {}
+	}
+
+	return nil, func() {}
+}
+
+// setupLauncherLogging configures logging and returns the launcher's logger,
+// the severity to report, and a close function for any log file opened.
+func setupLauncherLogging(cliLogLevel, cliLogSource string) (*slog.Logger, string, string, func()) {
+	logLevel, logSource := resolveLogLevel(cliLogLevel, cliLogSource)
+	actualLevel := describeLogLevel(logLevel)
+
+	setUTF8ConsoleOutput()
+
+	logOutput, closeLog := openLogOutput(logLevel)
+	logging.Setup(logLevel, logOutput)
+
+	return logging.NewLogger(context.Background(), "flavor-go.launcher"), actualLevel, logSource, closeLog
+}
+
+// traceEnvironment records every inherited variable, which is the only way to
+// see what a package actually started with.
+func traceEnvironment(logger *slog.Logger) {
+	envVars := os.Environ()
+	logger.Debug("🔧 Environment variables received from parent process", "count", len(envVars))
+
+	if !logging.IsEnabled(logger, logging.LevelTrace) {
+		return
+	}
+	for _, env := range envVars {
+		if parts := strings.SplitN(env, "=", 2); len(parts) == 2 {
+			logging.Trace(logger, "📝 Environment variable", "key", parts[0], "value", parts[1])
+		}
+	}
+}

--- a/src/flavor-go/pkg/psp/format_2025/reader_slots.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_slots.go
@@ -1,7 +1,6 @@
 package format_2025
 
 import (
-	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
@@ -9,8 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"log/slog"
 
@@ -175,168 +172,28 @@ func (r *Reader) ExtractSlot(slotIndex int, destDir string) (string, error) {
 		return "", fmt.Errorf("%w: failed to read slot %d: %v", ErrSlotExtractionFailed, slotIndex, err)
 	}
 
-	// Read slot descriptor to get permissions
 	index, err := r.ReadIndex()
 	if err != nil {
 		return "", err
 	}
 
-	// Read slot table entry (64 bytes per entry) to get permissions
-	slotTableEntryOffset := int64(index.SlotTableOffset) + int64(slotIndex*64)
-	if _, err := fileSeekFn(r.file, slotTableEntryOffset, io.SeekStart); err != nil {
+	slotPermissions, err := r.readSlotPermissions(index, slotIndex)
+	if err != nil {
 		return "", err
 	}
 
-	var entryData [64]byte
-	if _, err := fileReadFn(r.file, entryData[:]); err != nil {
-		return "", err
-	}
-
-	// Extract permissions field (bytes 62-64)
-	slotPermissions := binary.LittleEndian.Uint16(entryData[62:64])
-
-	// Target field specifies where to extract (relative to workenv)
-	// Substitute {workenv} placeholder with the actual destDir
-	targetPath := slotMeta.Target
-	if strings.Contains(targetPath, "{workenv}") {
-		// Remove {workenv}/ prefix if present, as we're already extracting to destDir
-		targetPath = strings.ReplaceAll(targetPath, "{workenv}/", "")
-		targetPath = strings.ReplaceAll(targetPath, "{workenv}", "")
-	}
-
-	// Determine extraction paths based on target and whether it's a TAR archive
-	var destPath, extractDir string
-
-	// Check if this is a tarball first (needed for logic below)
+	targetPath := resolveSlotTarget(slotMeta.Target)
 	isTar := isTarball(decompressed)
 
-	if isTar {
-		// TAR slots always extract to destDir regardless of target — the tar entries encode the
-		// directory structure (e.g., "wheels/foo.whl"). This matches Rust launcher behavior
-		// where extract_tarball ignores slot_target and extracts directly to the workenv path.
-		// Using targetPath as an extraction subdirectory would double-nest the content:
-		// e.g., target="wheels" + tar entry "wheels/foo.whl" → wheels/wheels/foo.whl (wrong).
-		destPath = destDir
-		extractDir = destDir
-	} else if targetPath == "" || targetPath == "." {
-		// Non-TAR slots targeting {workenv}: extract to slot-specific subdirectory for atomic move
-		slotSubdir := fmt.Sprintf("slot_%d_%s", slotIndex, slotMeta.ID)
-		destPath = filepath.Join(destDir, slotSubdir)
-		extractDir = destPath
-	} else {
-		// Non-TAR (single file) slots with explicit target path
-		destPath = filepath.Join(destDir, targetPath)
-		// Ensure the target path does not escape the destination directory
-		cleanBase := filepath.Clean(destDir)
-		if !strings.HasPrefix(destPath, cleanBase+string(os.PathSeparator)) && destPath != cleanBase {
-			return "", fmt.Errorf("target path %q escapes extraction directory", targetPath)
-		}
-		extractDir = destPath
+	destPath, err := slotDestination(destDir, targetPath, slotIndex, slotMeta.ID, isTar)
+	if err != nil {
+		return "", err
 	}
 
 	logging.Trace(logger, "🔍 Slot data check", "isTarball", isTar, "dataLen", len(decompressed), "destPath", destPath)
 
 	if isTar {
-
-		// Ensure extraction directory exists
-		if err := tarMkdirAllFn(extractDir, os.FileMode(DirPerms)); err != nil {
-			return "", fmt.Errorf("%w: failed to create extraction directory for slot %d: %v", ErrSlotExtractionFailed, slotIndex, err)
-		}
-
-		tr := tar.NewReader(bytes.NewReader(decompressed))
-		for {
-			hdr, err := tr.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return "", fmt.Errorf("%w: tar extraction failed for slot %d: %v", ErrSlotExtractionFailed, slotIndex, err)
-			}
-
-			target := filepath.Join(extractDir, hdr.Name)
-			cleanTarget := filepath.Clean(target)
-			cleanBase := filepath.Clean(extractDir)
-			if !strings.HasPrefix(cleanTarget, cleanBase+string(os.PathSeparator)) && cleanTarget != cleanBase {
-				return "", fmt.Errorf("tar entry %q escapes extraction directory", hdr.Name)
-			}
-
-			switch hdr.Typeflag {
-			case tar.TypeDir:
-				if err := tarMkdirAllFn(target, os.FileMode(hdr.Mode)); err != nil {
-					return "", fmt.Errorf("%w: failed to create directory during extraction: %v", ErrSlotExtractionFailed, err)
-				}
-			case tar.TypeReg:
-				// Ensure parent directory exists
-				if err := tarMkdirAllFn(filepath.Dir(target), os.FileMode(DirPerms)); err != nil {
-					return "", err
-				}
-
-				out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
-				if err != nil {
-					return "", err
-				}
-
-				if _, err := tarIoCopyFn(out, tr); err != nil {
-					if closeErr := tarOutCloseFn(out); closeErr != nil {
-						// Log but don't mask the original error
-						_ = closeErr
-					}
-					return "", err
-				}
-				if err := tarOutCloseFn(out); err != nil {
-					return "", fmt.Errorf("failed to close output file: %w", err)
-				}
-
-				// Set executable bit if needed
-				if hdr.Mode&0111 != 0 {
-					if err := tarChmodFn(target, os.FileMode(hdr.Mode)); err != nil {
-						// Best effort - log but don't fail
-						_ = err
-					}
-				}
-			case tar.TypeSymlink:
-				return "", fmt.Errorf("tar entry %q contains a symlink — symlinks are not permitted in PSPF packages", hdr.Name)
-			}
-		}
-
-		// Return the directory where we extracted
-		return extractDir, nil
+		return extractTarball(decompressed, destPath, slotIndex)
 	}
-
-	// Single file - write directly
-	// Special case: if destPath is a directory (like for Python going to cache root),
-	// write to a file inside it
-	if info, err := os.Stat(destPath); err == nil && info.IsDir() {
-		// This is the case where Python tarball goes to cache root
-		// Just return the directory since it's a tarball that will be extracted
-		logging.Trace(logger, "🔍 Destination is existing directory, skipping write", "destPath", destPath)
-		return destPath, nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(destPath), os.FileMode(DirPerms)); err != nil {
-		return "", err
-	}
-
-	// Use permissions from slot descriptor if available, otherwise use defaults
-	var perm os.FileMode
-	if slotPermissions != 0 {
-		perm = os.FileMode(slotPermissions)
-	} else {
-		perm = os.FileMode(FilePerms) // 0600 - secure by default
-	}
-
-	// Log what we're about to write
-	logging.Trace(logger, "📝 Writing single file", "destPath", destPath, "dataLen", len(decompressed), "permissions", fmt.Sprintf("%04o", perm))
-
-	// Check first few bytes to see if it's still compressed
-	if len(decompressed) >= 3 && decompressed[0] == 0x1f && decompressed[1] == 0x8b && decompressed[2] == 0x08 {
-		logger.Warn("⚠️ Data appears to still be gzipped!", "firstBytes", fmt.Sprintf("%x", decompressed[:10]))
-	}
-
-	if err := os.WriteFile(destPath, decompressed, perm); err != nil {
-		return "", fmt.Errorf("%w: failed to write slot %d to disk: %v", ErrSlotExtractionFailed, slotIndex, err)
-	}
-
-	logging.Trace(logger, "✅ Wrote file", "path", destPath, "size", len(decompressed))
-	return destPath, nil
+	return writeSlotFile(decompressed, destPath, slotPermissions, slotIndex, logger)
 }

--- a/src/flavor-go/pkg/psp/format_2025/reader_slots_extract.go
+++ b/src/flavor-go/pkg/psp/format_2025/reader_slots_extract.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+// readSlotPermissions reads the permission bits from a slot's 64-byte table
+// entry, where they occupy the last two bytes.
+func (r *Reader) readSlotPermissions(index *PSPFIndex, slotIndex int) (uint16, error) {
+	entryOffset := int64(index.SlotTableOffset) + int64(slotIndex*SlotDescriptorSize)
+	if _, err := fileSeekFn(r.file, entryOffset, io.SeekStart); err != nil {
+		return 0, err
+	}
+
+	var entryData [SlotDescriptorSize]byte
+	if _, err := fileReadFn(r.file, entryData[:]); err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint16(entryData[62:64]), nil
+}
+
+// resolveSlotTarget strips the {workenv} placeholder from a slot's target.
+// Extraction is already rooted at the work environment, so the placeholder
+// would otherwise nest a second copy of it inside.
+func resolveSlotTarget(target string) string {
+	if !strings.Contains(target, "{workenv}") {
+		return target
+	}
+	target = strings.ReplaceAll(target, "{workenv}/", "")
+	return strings.ReplaceAll(target, "{workenv}", "")
+}
+
+// escapesDir reports whether a path resolves outside base.
+func escapesDir(path, base string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanBase := filepath.Clean(base)
+	return !strings.HasPrefix(cleanPath, cleanBase+string(os.PathSeparator)) && cleanPath != cleanBase
+}
+
+// slotDestination decides where a slot's contents land.
+//
+// A tar slot always extracts to destDir whatever its target says, because the
+// archive's own entries carry the directory structure: honouring the target as
+// well would nest it twice (target "wheels" plus entry "wheels/foo.whl" gives
+// wheels/wheels/foo.whl). The Rust launcher ignores the target here for the
+// same reason.
+//
+// A non-tar slot aimed at the work environment root goes to a slot-specific
+// subdirectory instead, so the merge afterwards can move it atomically.
+func slotDestination(destDir, targetPath string, slotIndex int, slotID string, isTar bool) (string, error) {
+	switch {
+	case isTar:
+		return destDir, nil
+
+	case targetPath == "" || targetPath == ".":
+		return filepath.Join(destDir, fmt.Sprintf("slot_%d_%s", slotIndex, slotID)), nil
+
+	default:
+		destPath := filepath.Join(destDir, targetPath)
+		if escapesDir(destPath, destDir) {
+			return "", fmt.Errorf("target path %q escapes extraction directory", targetPath)
+		}
+		return destPath, nil
+	}
+}
+
+// extractTarEntry writes one archive member.
+func extractTarEntry(tr *tar.Reader, hdr *tar.Header, target string) error {
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if err := tarMkdirAllFn(target, os.FileMode(hdr.Mode)); err != nil {
+			return fmt.Errorf("%w: failed to create directory during extraction: %v", ErrSlotExtractionFailed, err)
+		}
+		return nil
+
+	case tar.TypeReg:
+		if err := tarMkdirAllFn(filepath.Dir(target), os.FileMode(DirPerms)); err != nil {
+			return err
+		}
+
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+		if err != nil {
+			return err
+		}
+		if _, err := tarIoCopyFn(out, tr); err != nil {
+			// Close, but report the copy failure rather than the close.
+			_ = tarOutCloseFn(out)
+			return err
+		}
+		if err := tarOutCloseFn(out); err != nil {
+			return fmt.Errorf("failed to close output file: %w", err)
+		}
+
+		if hdr.Mode&0o111 != 0 {
+			// Best effort: a file that is not executable is still extracted.
+			_ = tarChmodFn(target, os.FileMode(hdr.Mode))
+		}
+		return nil
+
+	case tar.TypeSymlink:
+		return fmt.Errorf("tar entry %q contains a symlink — symlinks are not permitted in PSPF packages", hdr.Name)
+
+	default:
+		return nil
+	}
+}
+
+// extractTarball unpacks a tar slot, refusing any entry that would write
+// outside the extraction directory.
+func extractTarball(data []byte, extractDir string, slotIndex int) (string, error) {
+	if err := tarMkdirAllFn(extractDir, os.FileMode(DirPerms)); err != nil {
+		return "", fmt.Errorf("%w: failed to create extraction directory for slot %d: %v", ErrSlotExtractionFailed, slotIndex, err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("%w: tar extraction failed for slot %d: %v", ErrSlotExtractionFailed, slotIndex, err)
+		}
+
+		target := filepath.Join(extractDir, hdr.Name)
+		if escapesDir(target, extractDir) {
+			return "", fmt.Errorf("tar entry %q escapes extraction directory", hdr.Name)
+		}
+
+		if err := extractTarEntry(tr, hdr, target); err != nil {
+			return "", err
+		}
+	}
+
+	return extractDir, nil
+}
+
+// writeSlotFile writes a single-file slot.
+//
+// A destination that is already a directory is left alone: that is the shape a
+// tarball bound for the cache root takes, and it has its own extraction.
+func writeSlotFile(
+	data []byte,
+	destPath string,
+	slotPermissions uint16,
+	slotIndex int,
+	logger *slog.Logger,
+) (string, error) {
+	if info, err := os.Stat(destPath); err == nil && info.IsDir() {
+		logging.Trace(logger, "🔍 Destination is existing directory, skipping write", "destPath", destPath)
+		return destPath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), os.FileMode(DirPerms)); err != nil {
+		return "", err
+	}
+
+	perm := os.FileMode(FilePerms) // 0600 - secure by default
+	if slotPermissions != 0 {
+		perm = os.FileMode(slotPermissions)
+	}
+
+	logging.Trace(logger, "📝 Writing single file", "destPath", destPath, "dataLen", len(data), "permissions", fmt.Sprintf("%04o", perm))
+
+	// A gzip header here means the decompression chain did not run.
+	if len(data) >= 3 && data[0] == 0x1f && data[1] == 0x8b && data[2] == 0x08 {
+		logger.Warn("⚠️ Data appears to still be gzipped!", "firstBytes", fmt.Sprintf("%x", data[:10]))
+	}
+
+	if err := os.WriteFile(destPath, data, perm); err != nil {
+		return "", fmt.Errorf("%w: failed to write slot %d to disk: %v", ErrSlotExtractionFailed, slotIndex, err)
+	}
+
+	logging.Trace(logger, "✅ Wrote file", "path", destPath, "size", len(data))
+	return destPath, nil
+}

--- a/src/flavor-go/pkg/psp/format_2025/runtime.go
+++ b/src/flavor-go/pkg/psp/format_2025/runtime.go
@@ -1,183 +1,27 @@
 package format_2025
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	"log/slog"
-
-	"github.com/provide-io/flavor/go/flavor/pkg/logging"
 )
 
+// processRuntimeEnv applies the package's declared environment operations to
+// the host environment, in the order the format defines: pass decides what is
+// protected, unset removes, map renames, set assigns.
 func processRuntimeEnv(env []string, runtimeEnv map[string]interface{}, logger *slog.Logger) []string {
-	envMap := make(map[string]string)
-	for _, e := range env {
-		parts := strings.SplitN(e, "=", 2)
-		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
-		}
-	}
+	envMap := envToMap(env)
 
-	// On Windows, automatically add critical system variables to pass list
-	// These are required for Python and other programs to initialize properly
 	if currentGOOS == "windows" {
-		windowsCriticalVars := []string{"SYSTEMROOT", "WINDIR", "TEMP", "TMP", "PATHEXT", "COMSPEC"}
-
-		if passList, ok := runtimeEnv["pass"].([]interface{}); ok {
-			// Create a set of existing pass patterns for deduplication
-			existingPatterns := make(map[string]bool)
-			for _, pattern := range passList {
-				if patternStr, ok := pattern.(string); ok {
-					existingPatterns[patternStr] = true
-				}
-			}
-
-			// Add missing critical vars
-			for _, criticalVar := range windowsCriticalVars {
-				if !existingPatterns[criticalVar] {
-					logger.Debug("💻 Auto-adding Windows critical variable", "var", criticalVar)
-					passList = append(passList, criticalVar)
-				}
-			}
-			runtimeEnv["pass"] = passList
-		} else {
-			// No pass list exists, create one with critical vars
-			logger.Debug("💻 Creating pass list with Windows critical variables")
-			passListInterface := make([]interface{}, len(windowsCriticalVars))
-			for i, v := range windowsCriticalVars {
-				passListInterface[i] = v
-			}
-			runtimeEnv["pass"] = passListInterface
-		}
+		addWindowsCriticalVars(runtimeEnv, logger)
 	}
 
-	// Build list of variables to preserve from pass patterns first
-	preserveVars := make(map[string]bool)
-	if passList, ok := runtimeEnv["pass"].([]interface{}); ok {
-		logger.Debug("🔍 Building preserve list from pass patterns", "count", len(passList))
-		for _, pattern := range passList {
-			if patternStr, ok := pattern.(string); ok {
-				if strings.Contains(patternStr, "*") || strings.Contains(patternStr, "?") {
-					// Glob pattern - find matching vars
-					for key := range envMap {
-						if matched, _ := filepath.Match(patternStr, key); matched {
-							preserveVars[key] = true
-							logging.Trace(logger, "  ✅ Preserving env var (pattern match)", "key", key, "pattern", patternStr)
-						}
-					}
-				} else {
-					// Exact variable name
-					if _, exists := envMap[patternStr]; exists {
-						preserveVars[patternStr] = true
-						logging.Trace(logger, "  ✅ Preserving env var (exact)", "key", patternStr)
-					}
-				}
-			}
-		}
-	}
+	// Built before any removal, so "unset everything except what passes" works.
+	preserveVars := buildPreserveList(runtimeEnv, envMap, logger)
 
-	if unsetList, ok := runtimeEnv["unset"].([]interface{}); ok {
-		logger.Debug("🗑️ Processing unset operations", "count", len(unsetList))
-		for _, pattern := range unsetList {
-			if patternStr, ok := pattern.(string); ok {
-				if patternStr == "*" {
-					// Special case: unset all except those in preserve list
-					logger.Debug("🗑️ Whitelist mode: removing all variables except preserved")
-					toDelete := []string{}
-					for key := range envMap {
-						if !preserveVars[key] {
-							toDelete = append(toDelete, key)
-						}
-					}
-					for _, key := range toDelete {
-						delete(envMap, key)
-						logging.Trace(logger, "  🗑️ Removed env var", "key", key)
-					}
-					logger.Debug("  Removed variables", "count", len(toDelete), "preserved", len(preserveVars))
-				} else if strings.Contains(patternStr, "*") || strings.Contains(patternStr, "?") {
-					// Glob pattern
-					toDelete := []string{}
-					for key := range envMap {
-						if matched, _ := filepath.Match(patternStr, key); matched && !preserveVars[key] {
-							toDelete = append(toDelete, key)
-						}
-					}
-					for _, key := range toDelete {
-						delete(envMap, key)
-						logging.Trace(logger, "🗑️ Unset env var (pattern)", "key", key, "pattern", patternStr)
-					}
-				} else {
-					// Exact variable name
-					if _, exists := envMap[patternStr]; exists && !preserveVars[patternStr] {
-						delete(envMap, patternStr)
-						logging.Trace(logger, "🗑️ Unset env var", "key", patternStr)
-					}
-				}
-			}
-		}
-	}
+	applyUnsetOps(runtimeEnv, envMap, preserveVars, logger)
+	applyMapOps(runtimeEnv, envMap, logger)
+	applySetOps(runtimeEnv, envMap, logger)
 
-	if mapOps, ok := runtimeEnv["map"].(map[string]interface{}); ok {
-		logger.Debug("🔄 Processing map operations", "count", len(mapOps))
-		for from, to := range mapOps {
-			if toStr, ok := to.(string); ok {
-				if value, exists := envMap[from]; exists {
-					envMap[toStr] = value
-					if from != toStr {
-						delete(envMap, from)
-						logging.Trace(logger, "🔄 Mapped env var", "from", from, "to", toStr, "value", value)
-					}
-				}
-			}
-		}
-	}
+	verifyPassPatterns(runtimeEnv, envMap, logger)
 
-	if setOps, ok := runtimeEnv["set"].(map[string]interface{}); ok {
-		logger.Debug("✏️ Processing set operations", "count", len(setOps))
-		for key, value := range setOps {
-			if valueStr, ok := value.(string); ok {
-				envMap[key] = valueStr
-				logging.Trace(logger, "✏️ Set env var", "key", key, "value", valueStr)
-			}
-		}
-	}
-
-	// Verify pass patterns after all operations
-	if passList, ok := runtimeEnv["pass"].([]interface{}); ok {
-		logger.Debug("✅ Verifying pass patterns", "count", len(passList))
-		for _, pattern := range passList {
-			if patternStr, ok := pattern.(string); ok {
-				if strings.Contains(patternStr, "*") || strings.Contains(patternStr, "?") {
-					// Glob pattern - check if any vars match
-					found := false
-					for key := range envMap {
-						if matched, _ := filepath.Match(patternStr, key); matched {
-							found = true
-							break
-						}
-					}
-					if !found {
-						logger.Warn("⚠️ No environment variables match required pattern", "pattern", patternStr)
-					} else {
-						logging.Trace(logger, "✅ Verified env vars match pattern", "pattern", patternStr)
-					}
-				} else {
-					// Exact variable name
-					if _, exists := envMap[patternStr]; !exists {
-						logger.Warn("⚠️ Required environment variable not found", "key", patternStr)
-					} else {
-						logging.Trace(logger, "✅ Verified env var exists", "key", patternStr)
-					}
-				}
-			}
-		}
-	}
-
-	result := make([]string, 0, len(envMap))
-	for k, v := range envMap {
-		result = append(result, fmt.Sprintf("%s=%s", k, v))
-	}
-
-	return result
+	return mapToEnv(envMap)
 }

--- a/src/flavor-go/pkg/psp/format_2025/runtime_env_ops.go
+++ b/src/flavor-go/pkg/psp/format_2025/runtime_env_ops.go
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package format_2025
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/provide-io/flavor/go/flavor/pkg/logging"
+)
+
+// windowsCriticalVars are needed for Python and other runtimes to start on
+// Windows, so they are passed whether or not the package asked for them.
+var windowsCriticalVars = []string{"SYSTEMROOT", "WINDIR", "TEMP", "TMP", "PATHEXT", "COMSPEC"}
+
+// isGlobPattern reports whether a name is a pattern rather than a literal.
+func isGlobPattern(s string) bool {
+	return strings.Contains(s, "*") || strings.Contains(s, "?")
+}
+
+// envToMap splits KEY=VALUE entries. An entry with no "=" is dropped, since
+// there is no name to key it by.
+func envToMap(env []string) map[string]string {
+	envMap := make(map[string]string, len(env))
+	for _, e := range env {
+		if parts := strings.SplitN(e, "=", 2); len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	return envMap
+}
+
+// mapToEnv renders the map back into KEY=VALUE entries.
+func mapToEnv(envMap map[string]string) []string {
+	result := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	return result
+}
+
+// stringList reads one of the runtime env operations as a list of strings,
+// dropping entries that are not strings.
+func stringList(runtimeEnv map[string]any, key string) ([]string, bool) {
+	raw, ok := runtimeEnv[key].([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out, true
+}
+
+// addWindowsCriticalVars adds the variables Windows runtimes need to the pass
+// list, creating the list when the package declared none.
+func addWindowsCriticalVars(runtimeEnv map[string]any, logger *slog.Logger) {
+	passList, ok := runtimeEnv["pass"].([]any)
+	if !ok {
+		logger.Debug("💻 Creating pass list with Windows critical variables")
+		created := make([]any, len(windowsCriticalVars))
+		for i, v := range windowsCriticalVars {
+			created[i] = v
+		}
+		runtimeEnv["pass"] = created
+		return
+	}
+
+	existing := make(map[string]bool, len(passList))
+	for _, pattern := range passList {
+		if s, ok := pattern.(string); ok {
+			existing[s] = true
+		}
+	}
+
+	for _, criticalVar := range windowsCriticalVars {
+		if !existing[criticalVar] {
+			logger.Debug("💻 Auto-adding Windows critical variable", "var", criticalVar)
+			passList = append(passList, criticalVar)
+		}
+	}
+	runtimeEnv["pass"] = passList
+}
+
+// buildPreserveList names the variables the pass patterns protect. It runs
+// before any unset operation, so "unset everything except what passes" works.
+func buildPreserveList(runtimeEnv map[string]any, envMap map[string]string, logger *slog.Logger) map[string]bool {
+	preserveVars := make(map[string]bool)
+
+	patterns, ok := stringList(runtimeEnv, "pass")
+	if !ok {
+		return preserveVars
+	}
+	logger.Debug("🔍 Building preserve list from pass patterns", "count", len(patterns))
+
+	for _, pattern := range patterns {
+		if !isGlobPattern(pattern) {
+			if _, exists := envMap[pattern]; exists {
+				preserveVars[pattern] = true
+				logging.Trace(logger, "  ✅ Preserving env var (exact)", "key", pattern)
+			}
+			continue
+		}
+		for key := range envMap {
+			if matched, _ := filepath.Match(pattern, key); matched {
+				preserveVars[key] = true
+				logging.Trace(logger, "  ✅ Preserving env var (pattern match)", "key", key, "pattern", pattern)
+			}
+		}
+	}
+
+	return preserveVars
+}
+
+// applyUnsetOps removes variables, never one the pass patterns preserved. The
+// pattern "*" means "remove everything not preserved", which is how a package
+// asks for a whitelist rather than a blacklist.
+func applyUnsetOps(
+	runtimeEnv map[string]any,
+	envMap map[string]string,
+	preserveVars map[string]bool,
+	logger *slog.Logger,
+) {
+	patterns, ok := stringList(runtimeEnv, "unset")
+	if !ok {
+		return
+	}
+	logger.Debug("🗑️ Processing unset operations", "count", len(patterns))
+
+	for _, pattern := range patterns {
+		switch {
+		case pattern == "*":
+			logger.Debug("🗑️ Whitelist mode: removing all variables except preserved")
+			removed := 0
+			for key := range envMap {
+				if !preserveVars[key] {
+					delete(envMap, key)
+					logging.Trace(logger, "  🗑️ Removed env var", "key", key)
+					removed++
+				}
+			}
+			logger.Debug("  Removed variables", "count", removed, "preserved", len(preserveVars))
+
+		case isGlobPattern(pattern):
+			for key := range envMap {
+				if matched, _ := filepath.Match(pattern, key); matched && !preserveVars[key] {
+					delete(envMap, key)
+					logging.Trace(logger, "🗑️ Unset env var (pattern)", "key", key, "pattern", pattern)
+				}
+			}
+
+		default:
+			if _, exists := envMap[pattern]; exists && !preserveVars[pattern] {
+				delete(envMap, pattern)
+				logging.Trace(logger, "🗑️ Unset env var", "key", pattern)
+			}
+		}
+	}
+}
+
+// applyMapOps renames variables, carrying the value across.
+func applyMapOps(runtimeEnv map[string]any, envMap map[string]string, logger *slog.Logger) {
+	mapOps, ok := runtimeEnv["map"].(map[string]any)
+	if !ok {
+		return
+	}
+	logger.Debug("🔄 Processing map operations", "count", len(mapOps))
+
+	for from, to := range mapOps {
+		toStr, ok := to.(string)
+		if !ok {
+			continue
+		}
+		value, exists := envMap[from]
+		if !exists {
+			continue
+		}
+		envMap[toStr] = value
+		if from != toStr {
+			delete(envMap, from)
+			logging.Trace(logger, "🔄 Mapped env var", "from", from, "to", toStr, "value", value)
+		}
+	}
+}
+
+// applySetOps assigns literal values, last so it wins over the rest.
+func applySetOps(runtimeEnv map[string]any, envMap map[string]string, logger *slog.Logger) {
+	setOps, ok := runtimeEnv["set"].(map[string]any)
+	if !ok {
+		return
+	}
+	logger.Debug("✏️ Processing set operations", "count", len(setOps))
+
+	for key, value := range setOps {
+		if valueStr, ok := value.(string); ok {
+			envMap[key] = valueStr
+			logging.Trace(logger, "✏️ Set env var", "key", key, "value", valueStr)
+		}
+	}
+}
+
+// verifyPassPatterns warns about anything the package asked to pass that is
+// not in the final environment. It only reports: a package that names a
+// variable the host does not set still runs.
+func verifyPassPatterns(runtimeEnv map[string]any, envMap map[string]string, logger *slog.Logger) {
+	patterns, ok := stringList(runtimeEnv, "pass")
+	if !ok {
+		return
+	}
+	logger.Debug("✅ Verifying pass patterns", "count", len(patterns))
+
+	for _, pattern := range patterns {
+		if !isGlobPattern(pattern) {
+			if _, exists := envMap[pattern]; !exists {
+				logger.Warn("⚠️ Required environment variable not found", "key", pattern)
+			} else {
+				logging.Trace(logger, "✅ Verified env var exists", "key", pattern)
+			}
+			continue
+		}
+
+		found := false
+		for key := range envMap {
+			if matched, _ := filepath.Match(pattern, key); matched {
+				found = true
+				break
+			}
+		}
+		if !found {
+			logger.Warn("⚠️ No environment variables match required pattern", "pattern", pattern)
+		} else {
+			logging.Trace(logger, "✅ Verified env vars match pattern", "pattern", pattern)
+		}
+	}
+}

--- a/src/flavor/commands/doctor.py
+++ b/src/flavor/commands/doctor.py
@@ -23,103 +23,124 @@ from flavor.helpers.manager import HelperManager
 log = get_command_logger("doctor")
 
 
-@click.command("doctor")
-def doctor_command() -> None:  # noqa: C901
-    """Check Flavorpack installation health and report findings."""
+# Each check prints its own section and returns what it found, so the command
+# below reads as the list of things being checked.
+Findings = tuple[list[str], list[str]]  # (errors, warnings)
 
-    errors: list[str] = []
-    warnings: list[str] = []
 
-    pout("Flavorpack Doctor")
-    pout("=================")
-    pout("")
-
-    # --- Python version ---
+def _check_python_version() -> Findings:
+    """Report the interpreter, warning below the version the project needs."""
     py_version = sys.version.split()[0]
     major, minor = sys.version_info.major, sys.version_info.minor
+
+    warnings: list[str] = []
+    marker = "OK"
     if major < 3 or (major == 3 and minor < 11):
-        py_status = "WARN"
+        marker = "WARN"
         warnings.append(f"Python {py_version} is below the required 3.11")
-    else:
-        py_status = "OK"
-    py_marker = "OK" if py_status == "OK" else "WARN"
-    pout(f"Python:        {py_version} [{py_marker}]")
 
-    # --- Flavorpack version ---
+    pout(f"Python:        {py_version} [{marker}]")
+    return [], warnings
+
+
+def _report_versions() -> None:
+    """Print what this installation is, which fixes nothing but frames the rest."""
     pout(f"Flavorpack:    {flavor_version}")
-
-    # --- Platform ---
-    arch = platform.machine()
-    pout(f"Platform:      {sys.platform} {arch}")
+    pout(f"Platform:      {sys.platform} {platform.machine()}")
     pout("")
 
-    # --- Helper binaries ---
+
+def _check_one_helper(helper: object) -> tuple[str, list[str]]:
+    """Classify one helper binary. Returns (status, errors)."""
+    path = helper.path  # type: ignore[attr-defined]
+    name = helper.name  # type: ignore[attr-defined]
+
+    if not path.exists():
+        return "MISSING", [f"Helper {name} not found at {path}"]
+    if not os.access(path, os.X_OK):
+        return "NOT-EXEC", [f"Helper {name} is not executable"]
+    return "OK", []
+
+
+def _check_helpers() -> Findings:
+    """Report every helper binary this installation can find."""
     pout("Helpers:")
-    manager = HelperManager()
-    helpers = manager.list_helpers()
+
+    helpers = HelperManager().list_helpers()
     all_helpers = helpers.get("launchers", []) + helpers.get("builders", [])
 
     if not all_helpers:
         pout("  (none found)")
-        warnings.append("No helper binaries found — run: flavor helpers build")
-    else:
-        for helper in sorted(all_helpers, key=lambda h: h.name):
-            exists = helper.path.exists()
-            executable = exists and os.access(helper.path, os.X_OK)
-            size_mb = helper.size / (1024 * 1024) if helper.size else 0
-            version_str = helper.version or "unknown"
+        pout("")
+        return [], ["No helper binaries found — run: flavor helpers build"]
 
-            if not exists:
-                status = "MISSING"
-                errors.append(f"Helper {helper.name} not found at {helper.path}")
-            elif not executable:
-                status = "NOT-EXEC"
-                errors.append(f"Helper {helper.name} is not executable")
-            else:
-                status = "OK"
-
-            pout(f"  {helper.name:<40} [{status}]  {version_str}  ({size_mb:.1f} MB)")
+    errors: list[str] = []
+    for helper in sorted(all_helpers, key=lambda h: h.name):
+        status, helper_errors = _check_one_helper(helper)
+        errors.extend(helper_errors)
+        size_mb = helper.size / (1024 * 1024) if helper.size else 0
+        pout(f"  {helper.name:<40} [{status}]  {helper.version or 'unknown'}  ({size_mb:.1f} MB)")
 
     pout("")
+    return errors, []
 
-    # --- Directories ---
+
+def _check_cache_dir() -> Findings:
+    """A cache directory that exists but cannot be written stops every build."""
+    cache_dir = get_cache_dir()
+
+    errors: list[str] = []
+    if not cache_dir.exists():
+        note = "(not created yet)"
+    elif os.access(cache_dir, os.W_OK):
+        note = "writable [OK]"
+    else:
+        note = "NOT WRITABLE [ERR]"
+        errors.append(f"Cache directory not writable: {cache_dir}")
+
+    pout(f"  Cache:        {cache_dir}  {note}")
+    return errors, []
+
+
+def _check_trusted_keys_dir() -> Findings:
+    """No trusted keys means no package can be signature-verified."""
+    keys_dir = get_trusted_keys_dir()
+
+    warnings: list[str] = []
+    if not keys_dir.exists():
+        note = "0 keys  [WARN]  (not created yet)"
+        warnings.append("Trusted keys directory does not exist — packages cannot be signature-verified")
+    elif (key_count := len(list(keys_dir.glob("*.pub")))) == 0:
+        note = "0 keys  [WARN]"
+        warnings.append("No trusted public keys found — packages cannot be signature-verified")
+    else:
+        note = f"{key_count} key(s)  [OK]"
+
+    pout(f"  Trusted keys: {keys_dir}  {note}")
+    return [], warnings
+
+
+def _check_directories() -> Findings:
+    """Report the three directories a working installation needs."""
     pout("Directories:")
 
-    # Cache dir
-    cache_dir = get_cache_dir()
-    cache_exists = cache_dir.exists()
-    cache_writable = cache_exists and os.access(cache_dir, os.W_OK)
-    if not cache_exists:
-        cache_note = "(not created yet)"
-    elif cache_writable:
-        cache_note = "writable [OK]"
-    else:
-        cache_note = "NOT WRITABLE [ERR]"
-        errors.append(f"Cache directory not writable: {cache_dir}")
-    pout(f"  Cache:        {cache_dir}  {cache_note}")
+    cache_errors, cache_warnings = _check_cache_dir()
 
-    # Config dir
     config_dir = get_config_dir()
-    config_note = "[OK]" if config_dir.exists() else "(not created yet)"
-    pout(f"  Config:       {config_dir}  {config_note}")
+    pout(f"  Config:       {config_dir}  {'[OK]' if config_dir.exists() else '(not created yet)'}")
 
-    # Trusted keys dir
-    keys_dir = get_trusted_keys_dir()
-    if keys_dir.exists():
-        key_count = len(list(keys_dir.glob("*.pub")))
-        if key_count == 0:
-            keys_note = "0 keys  [WARN]"
-            warnings.append("No trusted public keys found — packages cannot be signature-verified")
-        else:
-            keys_note = f"{key_count} key(s)  [OK]"
-    else:
-        keys_note = "0 keys  [WARN]  (not created yet)"
-        warnings.append("Trusted keys directory does not exist — packages cannot be signature-verified")
-    pout(f"  Trusted keys: {keys_dir}  {keys_note}")
+    key_errors, key_warnings = _check_trusted_keys_dir()
 
     pout("")
+    return cache_errors + key_errors, cache_warnings + key_warnings
 
-    # --- Overall status ---
+
+def _report_overall(errors: list[str], warnings: list[str]) -> None:
+    """State the verdict, and exit non-zero when the installation cannot work.
+
+    Errors exit 1 so a script can act on the result; warnings do not, because
+    the installation still runs.
+    """
     if errors:
         perr("Overall: [ERR] Not ready")
         for msg in errors:
@@ -127,12 +148,32 @@ def doctor_command() -> None:  # noqa: C901
         for msg in warnings:
             pout(f"  - {msg}")
         raise SystemExit(1)
-    elif warnings:
+
+    if warnings:
         pout("Overall: [WARN] Warnings found")
         for msg in warnings:
             pout(f"  - {msg}")
-    else:
-        pout("Overall: [OK] Ready")
+        return
+
+    pout("Overall: [OK] Ready")
+
+
+@click.command("doctor")
+def doctor_command() -> None:
+    """Check Flavorpack installation health and report findings."""
+    pout("Flavorpack Doctor")
+    pout("=================")
+    pout("")
+
+    python_errors, python_warnings = _check_python_version()
+    _report_versions()
+    helper_errors, helper_warnings = _check_helpers()
+    dir_errors, dir_warnings = _check_directories()
+
+    _report_overall(
+        python_errors + helper_errors + dir_errors,
+        python_warnings + helper_warnings + dir_warnings,
+    )
 
 
 # 🌶️📦🔚

--- a/src/flavor/commands/helpers.py
+++ b/src/flavor/commands/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 import click
 from provide.foundation.console import perr, pout
@@ -26,6 +27,42 @@ def helper_group() -> None:
     pass
 
 
+def _probe_helper_version(helper_path: Path) -> str | None:
+    """Ask a helper binary its version, giving up quickly and quietly.
+
+    This is a listing, so a helper that will not answer is reported with
+    whatever version was recorded at discovery rather than holding up the rest.
+    """
+    try:
+        result = run([str(helper_path), "--version"], capture_output=True, check=False, timeout=2)
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+    lines = result.stdout.strip().split("\n")
+    return lines[0] if lines else None
+
+
+def _print_helper_group(title: str, group: list[Any], verbose: bool) -> None:
+    """Print one group of helpers, blank-line separated."""
+    if not group:
+        return
+
+    pout(f"\n{title}")
+    for i, helper in enumerate(sorted(group, key=lambda h: h.name)):
+        if i > 0:
+            pout("")
+        size_mb = helper.size / (1024 * 1024)
+        version = _probe_helper_version(helper.path) or helper.version or "unknown"
+        pout(f"  • {helper.name} ({helper.language}, {size_mb:.1f} MB) - {version}")
+        pout(f"    Path: {helper.path}")
+        if helper.checksum:
+            pout(f"    SHA256: {helper.checksum}")
+        if verbose and helper.built_from:
+            pout(f"    Source: {helper.built_from}")
+
+
 @helper_group.command("list")
 @click.option(
     "--verbose",
@@ -33,12 +70,11 @@ def helper_group() -> None:
     is_flag=True,
     help="Show detailed information",
 )
-def helper_list(verbose: bool) -> None:  # noqa: C901
+def helper_list(verbose: bool) -> None:
     """List available helper binaries."""
     from flavor.helpers.manager import HelperManager
 
-    manager = HelperManager()
-    helpers = manager.list_helpers()
+    helpers = HelperManager().list_helpers()
 
     if not helpers["launchers"] and not helpers["builders"]:
         pout("No helpers found. Build them with: flavor helpers build")
@@ -47,53 +83,8 @@ def helper_list(verbose: bool) -> None:  # noqa: C901
     pout("🔧 Available Flavor Helpers")
     pout("=" * 60)
 
-    # Helper function to get version
-    def get_version(helper_path: Path) -> str | None:
-        try:
-            result = run(
-                [str(helper_path), "--version"],
-                capture_output=True,
-                check=False,
-                timeout=2,
-            )
-            if result.returncode == 0:
-                # Parse version from output (first line usually)
-                lines = result.stdout.strip().split("\n")
-                if lines:
-                    return lines[0]
-        except Exception:
-            pass
-        return None
-
-    if helpers["launchers"]:
-        pout("\n📦 Launchers:")
-        launchers = sorted(helpers["launchers"], key=lambda h: h.name)
-        for i, launcher in enumerate(launchers):
-            if i > 0:
-                pout("")  # Add newline between entries
-            size_mb = launcher.size / (1024 * 1024)
-            version = get_version(launcher.path) or launcher.version or "unknown"
-            pout(f"  • {launcher.name} ({launcher.language}, {size_mb:.1f} MB) - {version}")
-            pout(f"    Path: {launcher.path}")
-            if launcher.checksum:
-                pout(f"    SHA256: {launcher.checksum}")
-            if verbose and launcher.built_from:
-                pout(f"    Source: {launcher.built_from}")
-
-    if helpers["builders"]:
-        pout("\n🔨 Builders:")
-        builders = sorted(helpers["builders"], key=lambda h: h.name)
-        for i, builder in enumerate(builders):
-            if i > 0:
-                pout("")  # Add newline between entries
-            size_mb = builder.size / (1024 * 1024)
-            version = get_version(builder.path) or builder.version or "unknown"
-            pout(f"  • {builder.name} ({builder.language}, {size_mb:.1f} MB) - {version}")
-            pout(f"    Path: {builder.path}")
-            if builder.checksum:
-                pout(f"    SHA256: {builder.checksum}")
-            if verbose and builder.built_from:
-                pout(f"    Source: {builder.built_from}")
+    _print_helper_group("📦 Launchers:", helpers["launchers"], verbose)
+    _print_helper_group("🔨 Builders:", helpers["builders"], verbose)
 
 
 @helper_group.command("build")

--- a/src/flavor/commands/workenv.py
+++ b/src/flavor/commands/workenv.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import datetime
+from typing import Any
 
 import click
 from provide.foundation.console import perr, pout
@@ -149,6 +150,70 @@ def workenv_remove(package_id: str, yes: bool) -> None:
         perr(f"❌ Package '{package_id}' not found")
 
 
+def _print_index_metadata(metadata_dir: str) -> None:
+    """Print the binary index as recorded at extraction, if it was recorded.
+
+    An index that will not read is reported and skipped: this is an inspection
+    command, and the rest of what it found is still worth showing.
+    """
+    from pathlib import Path
+
+    index_file = Path(metadata_dir) / "instance" / "index.json"
+    if not index_file.exists():
+        return
+
+    try:
+        index_data = read_json(index_file)
+    except Exception as e:
+        pout(f"  ⚠️  Error reading index.json: {e}")
+        return
+
+    pout("\n📋 Index Metadata:")
+    pout(f"  Format Version: 0x{index_data.get('format_version', 0):08x}")
+    pout(f"  Package Size: {index_data.get('package_size', 0):,} bytes")
+    pout(f"  Launcher Size: {index_data.get('launcher_size', 0):,} bytes")
+    pout(f"  Slot Count: {index_data.get('slot_count', 0)}")
+    pout(f"  Index Checksum: {index_data.get('index_checksum', 'N/A')}")
+
+    if (timestamp := index_data.get("build_timestamp", 0)) > 0:
+        dt = datetime.datetime.fromtimestamp(timestamp)
+        pout(f"  Build Time: {dt.strftime('%Y-%m-%d %H:%M:%S')}")
+
+    if index_data.get("capabilities"):
+        pout(f"  Capabilities: 0x{index_data['capabilities']:016x}")
+    if index_data.get("requirements"):
+        pout(f"  Requirements: 0x{index_data['requirements']:016x}")
+
+
+def _print_workenv_summary(package_id: str, info: dict[str, Any]) -> None:
+    """Print what the cache knows about one extracted package."""
+    pout("=" * 60)
+    pout(f"📦 Package: {package_id}")
+    pout("-" * 60)
+
+    pout(f"📁 Location: {info['content_dir']}")
+    pout(f"🗂️  Metadata Type: {info.get('metadata_type', 'none')}")
+
+    if info.get("extraction_complete"):
+        pout("✅ Extraction: Complete")
+    else:
+        pout("⚠️  Extraction: Incomplete")
+
+    if info.get("checksum"):
+        pout(f"🔐 Checksum: {info['checksum']}")
+
+    if metadata_dir := info.get("metadata_dir"):
+        _print_index_metadata(metadata_dir)
+
+    if pkg := info.get("package_info"):
+        pout(f"  Name: {pkg.get('name', 'unknown')}")
+        pout(f"  Version: {pkg.get('version', 'unknown')}")
+        if pkg.get("builder"):
+            pout(f"  Builder: {pkg.get('builder')}")
+
+    pout("")
+
+
 @workenv_group.command("inspect")
 @click.argument("package_id")
 @click.option(
@@ -157,77 +222,21 @@ def workenv_remove(package_id: str, yes: bool) -> None:
     is_flag=True,
     help="Output as JSON format",
 )
-def workenv_inspect(package_id: str, output_json: bool) -> None:  # noqa: C901
+def workenv_inspect(package_id: str, output_json: bool) -> None:
     """Inspect detailed metadata for a cached package extraction."""
     from flavor.cache import CacheManager
 
-    manager = CacheManager()
-    info = manager.inspect_workenv(package_id)
+    info = CacheManager().inspect_workenv(package_id)
 
     if not info.get("exists"):
         perr(f"❌ Package '{package_id}' not found")
         return
 
     if output_json:
-        # Output as JSON
         pout(json_dumps(info, indent=2, default=str))
-    else:
-        # Human-readable output
-        pout("=" * 60)
-        pout(f"📦 Package: {package_id}")
-        pout("-" * 60)
+        return
 
-        # Basic info
-        pout(f"📁 Location: {info['content_dir']}")
-        pout(f"🗂️  Metadata Type: {info.get('metadata_type', 'none')}")
-
-        if info.get("extraction_complete"):
-            pout("✅ Extraction: Complete")
-        else:
-            pout("⚠️  Extraction: Incomplete")
-
-        if info.get("checksum"):
-            pout(f"🔐 Checksum: {info['checksum']}")
-
-        # Index metadata from index.json
-        if info.get("metadata_dir"):
-            from pathlib import Path
-
-            index_file = Path(info["metadata_dir"]) / "instance" / "index.json"
-            if index_file.exists():
-                try:
-                    index_data = read_json(index_file)
-
-                    pout("\n📋 Index Metadata:")
-                    pout(f"  Format Version: 0x{index_data.get('format_version', 0):08x}")
-                    pout(f"  Package Size: {index_data.get('package_size', 0):,} bytes")
-                    pout(f"  Launcher Size: {index_data.get('launcher_size', 0):,} bytes")
-                    pout(f"  Slot Count: {index_data.get('slot_count', 0)}")
-                    pout(f"  Index Checksum: {index_data.get('index_checksum', 'N/A')}")
-
-                    if index_data.get("build_timestamp"):
-                        timestamp = index_data["build_timestamp"]
-                        if timestamp > 0:
-                            dt = datetime.datetime.fromtimestamp(timestamp)
-                            pout(f"  Build Time: {dt.strftime('%Y-%m-%d %H:%M:%S')}")
-
-                    # Capabilities and requirements
-                    if index_data.get("capabilities"):
-                        pout(f"  Capabilities: 0x{index_data['capabilities']:016x}")
-                    if index_data.get("requirements"):
-                        pout(f"  Requirements: 0x{index_data['requirements']:016x}")
-                except Exception as e:
-                    pout(f"  ⚠️  Error reading index.json: {e}")
-
-        # Package metadata
-        if info.get("package_info"):
-            pkg = info["package_info"]
-            pout(f"  Name: {pkg.get('name', 'unknown')}")
-            pout(f"  Version: {pkg.get('version', 'unknown')}")
-            if pkg.get("builder"):
-                pout(f"  Builder: {pkg.get('builder')}")
-
-        pout("")
+    _print_workenv_summary(package_id, info)
 
 
 # 🌶️📦🔚

--- a/src/flavor/helpers/manager.py
+++ b/src/flavor/helpers/manager.py
@@ -11,7 +11,7 @@ import contextlib
 from dataclasses import dataclass
 import hashlib
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from provide.foundation.file.directory import ensure_dir
 from provide.foundation.platform import get_platform_string
@@ -62,8 +62,50 @@ class HelperManager:
 
         self._binary_loader = BinaryLoader(self)
 
-    def list_helpers(self, platform_filter: bool = False) -> dict[str, list[HelperInfo]]:  # noqa: C901
+    _HELPER_BUCKETS: ClassVar[dict[str, str]] = {"launcher": "launchers", "builder": "builders"}
+
+    def _collect_helpers_from(
+        self,
+        directory: Path,
+        platform_filter: bool,
+        helpers: dict[str, list[HelperInfo]],
+        skip_known: bool,
+    ) -> None:
+        """Add every helper in one directory to the collection.
+
+        skip_known drops a helper whose name is already present. The first
+        directory searched does not skip: there is nothing before it, and a
+        name repeated inside a single directory is a different problem from the
+        same helper appearing in both a dev build and a wheel.
+        """
+        if not directory.exists():
+            return
+
+        for helper_path in directory.iterdir():
+            if not helper_path.is_file():
+                continue
+            if platform_filter and not self._is_platform_compatible(helper_path.name):
+                continue
+
+            info = self._get_helper_info(helper_path)
+            if info is None:
+                continue
+
+            bucket = self._HELPER_BUCKETS.get(info.type)
+            if bucket is None:
+                continue
+
+            if skip_known and any(known.name == info.name for group in helpers.values() for known in group):
+                continue
+
+            helpers[bucket].append(info)
+
+    def list_helpers(self, platform_filter: bool = False) -> dict[str, list[HelperInfo]]:
         """List all available helpers.
+
+        A dev build in dist/bin takes precedence over the copy embedded in an
+        installed wheel, so it is searched first and the wheel's copy of the
+        same helper is skipped.
 
         Args:
             platform_filter: Only show helpers compatible with current platform
@@ -73,37 +115,8 @@ class HelperManager:
         """
         helpers: dict[str, list[HelperInfo]] = {"launchers": [], "builders": []}
 
-        # Search for helpers in bin directory
-        if self.helpers_bin.exists():
-            for helper_path in self.helpers_bin.iterdir():
-                if helper_path.is_file():
-                    if platform_filter and not self._is_platform_compatible(helper_path.name):
-                        continue
-
-                    info = self._get_helper_info(helper_path)
-                    if info:
-                        if info.type == "launcher":
-                            helpers["launchers"].append(info)
-                        elif info.type == "builder":
-                            helpers["builders"].append(info)
-
-        # Also check embedded helpers from wheel installation
-        embedded_bin = Path(__file__).parent / "bin"
-        if embedded_bin.exists():
-            for helper_path in embedded_bin.iterdir():
-                if helper_path.is_file():
-                    if platform_filter and not self._is_platform_compatible(helper_path.name):
-                        continue
-
-                    info = self._get_helper_info(helper_path)
-                    if info:
-                        # Check if we already have this helper from dev build
-                        existing_names = [i.name for sublist in helpers.values() for i in sublist]
-                        if info.name not in existing_names:
-                            if info.type == "launcher":
-                                helpers["launchers"].append(info)
-                            elif info.type == "builder":
-                                helpers["builders"].append(info)
+        self._collect_helpers_from(self.helpers_bin, platform_filter, helpers, skip_known=False)
+        self._collect_helpers_from(Path(__file__).parent / "bin", platform_filter, helpers, skip_known=True)
 
         return helpers
 

--- a/src/flavor/packaging/orchestrator_helpers.py
+++ b/src/flavor/packaging/orchestrator_helpers.py
@@ -107,6 +107,157 @@ def create_slot_tarballs(temp_dir: Path, artifacts: dict[str, Path]) -> dict[str
     return slots
 
 
+def _runtime_command(package_name: str, build_config: dict[str, Any], windows: bool) -> str:
+    """The command the launcher runs once the package is installed.
+
+    Windows invokes python.exe -m <module> rather than the Scripts/*.exe distlib
+    launcher: pip embeds the temporary python.exe path inside that launcher at
+    install time, and the Rust launcher moves the tree to its final work
+    environment afterwards, so the embedded path is stale. The entry-point
+    module is used rather than the script name, since `python -m taster` needs
+    taster/__main__.py, which may not exist.
+    """
+    if windows:
+        return f"{{workenv}}/python.exe -m {get_cli_module_for_windows(package_name, build_config)}"
+    return f"{{workenv}}/bin/{get_cli_executable_name(package_name, build_config, windows)}"
+
+
+def _workenv_layout() -> dict[str, Any]:
+    """The directories a package gets, and the variables pointing at them.
+
+    Every path a program would otherwise take from the host -- temp, cache,
+    config, home -- is redirected inside the work environment, so a package
+    leaves nothing behind and picks nothing up.
+    """
+    return {
+        "directories": [
+            {"path": "{workenv}/tmp", "mode": "0700"},
+            {"path": "{workenv}/var", "mode": "0755"},
+            {"path": "{workenv}/var/log", "mode": "0755"},
+            {"path": "{workenv}/var/cache", "mode": "0755"},
+            {"path": "{workenv}/var/run", "mode": "0755"},
+            {"path": "{workenv}/etc", "mode": "0755"},
+            {"path": "{workenv}/home", "mode": "0700"},
+            {"path": "{workenv}/state", "mode": "0755"},
+        ],
+        "env": {
+            "TMPDIR": "{workenv}/tmp",
+            "TEMP": "{workenv}/tmp",
+            "TMP": "{workenv}/tmp",
+            "XDG_RUNTIME_DIR": "{workenv}/var/run",
+            "XDG_CACHE_HOME": "{workenv}/var/cache",
+            "XDG_DATA_HOME": "{workenv}/share",
+            "XDG_STATE_HOME": "{workenv}/state",
+            "XDG_CONFIG_HOME": "{workenv}/etc",
+            "HOME": "{workenv}/home",
+        },
+    }
+
+
+def _setup_commands(windows: bool, python_path: str) -> list[dict[str, Any]]:
+    """Install the bundled wheels, then record that the install happened.
+
+    The marker file is what the launcher's cache check reads to decide whether
+    this work environment is already built.
+    """
+    install = (
+        "{workenv}/python.exe -m pip install --no-deps"
+        if windows
+        else f"{{workenv}}/bin/uv --no-config pip install --python {python_path} --no-deps"
+    )
+    return [
+        {
+            "type": "enumerate_and_execute",
+            "command": install,
+            "enumerate": {"path": "{workenv}/wheels", "pattern": "*.whl"},
+        },
+        {
+            "type": "write_file",
+            "path": "{workenv}/metadata/installed",
+            "content": "{package_name}-{version}",
+        },
+    ]
+
+
+def _package_slots(slots: dict[str, Path], bin_dir: str, uv_exe: str) -> list[dict[str, Any]]:
+    """The three slots a Python package ships: its installer, runtime, payload."""
+    return [
+        {
+            "id": "uv",
+            "source": str(slots["uv"]),
+            "operations": "gzip",
+            "purpose": "tool",
+            "lifecycle": "cache",
+            # For gzip encoding, this is treated as a full file path.
+            "target": f"{bin_dir}/{uv_exe}",
+            "type": "file",
+            "permissions": "0700",  # Owner-only executable permissions
+        },
+        {
+            "id": "python",
+            "source": str(slots["python"]),
+            "operations": "tgz",
+            "purpose": "runtime",
+            "lifecycle": "cache",
+            "target": "{workenv}",
+        },
+        {
+            "id": "wheels",
+            "source": str(slots["wheels"]),
+            "operations": "tgz",
+            "purpose": "payload",
+            "lifecycle": "init",
+            "target": "wheels",
+        },
+    ]
+
+
+def _merge_preserving_order(defaults: list[str], extra: list[str]) -> list[str]:
+    """Defaults first, then anything new, with no duplicates."""
+    seen = set(defaults)
+    return defaults + [item for item in extra if item not in seen]
+
+
+def _runtime_env_config(build_config: dict[str, Any], windows: bool) -> dict[str, Any]:
+    """Build the runtime env operations, isolating the package by default.
+
+    Isolation is on unless the package sets ``isolated: false``. Without it a
+    host virtualenv leaks into the package's Python and quietly changes which
+    interpreter and site-packages it uses.
+
+    Windows keeps its system variables either way: they are needed for DLL
+    loading and process creation, so isolating them breaks the package rather
+    than protecting it.
+    """
+    runtime_env_config = build_config.get("execution", {}).get("runtime", {}).get("env", {})
+    isolated = runtime_env_config.get("isolated", True)  # Safe by default
+    windows_pass = WINDOWS_SYSTEM_PASS if windows else []
+
+    operations: dict[str, Any] = {
+        "pass": _merge_preserving_order(list(windows_pass), runtime_env_config.get("pass", [])),
+        "set": runtime_env_config.get("set", {}),
+        "map": runtime_env_config.get("map", {}),
+    }
+
+    if isolated is False:
+        logger.debug("🔓 Environment isolation disabled via isolated=false flag")
+    else:
+        logger.debug("🔒 Applying default environment isolation for Python/UV")
+        user_unset = runtime_env_config.get("unset", [])
+        merged_unset = _merge_preserving_order(list(DEFAULT_ENV_ISOLATION_UNSET), user_unset)
+        if user_unset:
+            logger.debug(f"Merging user unset vars {user_unset} with defaults")
+            logger.debug(f"Final merged unset list: {merged_unset}")
+        operations["unset"] = merged_unset
+        logger.info(
+            f"✅ Runtime environment configured with isolation: "
+            f"unset={merged_unset[:3]}... ({len(merged_unset)} vars)"
+        )
+
+    # An operation with nothing in it is noise in the manifest.
+    return {key: value for key, value in operations.items() if value}
+
+
 def create_builder_manifest(
     package_name: str,
     version: str,
@@ -118,166 +269,28 @@ def create_builder_manifest(
     windows = is_windows()
     uv_exe = "uv.exe" if windows else "uv"
     bin_dir = "Scripts" if windows else "bin"
-    # On Windows, cpython-build-standalone places python.exe at the root of the install
-    # dir (not inside Scripts/).  On Unix it lives in bin/.
+    # cpython-build-standalone puts python.exe at the install root on Windows,
+    # and in bin/ on Unix.
     python_path = "{workenv}/python.exe" if windows else "{workenv}/bin/python3"
-    package_exe = get_cli_executable_name(package_name, build_config, windows)
-    # On Windows the runtime command uses python.exe -m <module> instead of the
-    # Scripts/*.exe distlib launcher.  The Rust launcher runs setup commands in
-    # the TEMP extraction directory and then moves the tree to the final workenv.
-    # pip embeds the temp python.exe path inside the distlib launcher at install
-    # time, so the launcher's embedded path is stale after the move.  Invoking
-    # python.exe directly avoids the stale-path problem entirely.
-    # Use the entry-point module (e.g. 'taster.cli') not the script name ('taster'),
-    # since 'python -m taster' requires taster/__main__.py which may not exist.
-    if windows:
-        cli_module = get_cli_module_for_windows(package_name, build_config)
-        runtime_command = f"{{workenv}}/python.exe -m {cli_module}"
-    else:
-        runtime_command = f"{{workenv}}/{bin_dir}/{package_exe}"
 
-    manifest = {
+    manifest: dict[str, Any] = {
         "package": {"name": package_name, "version": version},
-        "execution": {"command": runtime_command},
+        "execution": {"command": _runtime_command(package_name, build_config, windows)},
         "cache_validation": {
             "check_file": "{workenv}/metadata/installed",
             "expected_content": f"{package_name}-{version}",
         },
-        "workenv": {
-            "directories": [
-                {"path": "{workenv}/tmp", "mode": "0700"},
-                {"path": "{workenv}/var", "mode": "0755"},
-                {"path": "{workenv}/var/log", "mode": "0755"},
-                {"path": "{workenv}/var/cache", "mode": "0755"},
-                {"path": "{workenv}/var/run", "mode": "0755"},
-                {"path": "{workenv}/etc", "mode": "0755"},
-                {"path": "{workenv}/home", "mode": "0700"},
-                {"path": "{workenv}/state", "mode": "0755"},
-            ],
-            "env": {
-                "TMPDIR": "{workenv}/tmp",
-                "TEMP": "{workenv}/tmp",
-                "TMP": "{workenv}/tmp",
-                "XDG_RUNTIME_DIR": "{workenv}/var/run",
-                "XDG_CACHE_HOME": "{workenv}/var/cache",
-                "XDG_DATA_HOME": "{workenv}/share",
-                "XDG_STATE_HOME": "{workenv}/state",
-                "XDG_CONFIG_HOME": "{workenv}/etc",
-                "HOME": "{workenv}/home",
-            },
-        },
-        "setup_commands": [
-            {
-                "type": "enumerate_and_execute",
-                "command": (
-                    "{workenv}/python.exe -m pip install --no-deps"
-                    if windows
-                    else f"{{workenv}}/bin/uv --no-config pip install --python {python_path} --no-deps"
-                ),
-                "enumerate": {"path": "{workenv}/wheels", "pattern": "*.whl"},
-            },
-            {
-                "type": "write_file",
-                "path": "{workenv}/metadata/installed",
-                "content": "{package_name}-{version}",
-            },
-        ],
-        "slots": [
-            {
-                "id": "uv",
-                "source": str(slots["uv"]),
-                "operations": "gzip",
-                "purpose": "tool",
-                "lifecycle": "cache",
-                "target": f"{bin_dir}/{uv_exe}",  # For gzip encoding, this is treated as full file path
-                "type": "file",
-                "permissions": "0700",  # Owner-only executable permissions
-            },
-            {
-                "id": "python",
-                "source": str(slots["python"]),
-                "operations": "tgz",
-                "purpose": "runtime",
-                "lifecycle": "cache",
-                "target": "{workenv}",
-            },
-            {
-                "id": "wheels",
-                "source": str(slots["wheels"]),
-                "operations": "tgz",
-                "purpose": "payload",
-                "lifecycle": "init",
-                "target": "wheels",
-            },
-        ],
+        "workenv": _workenv_layout(),
+        "setup_commands": _setup_commands(windows, python_path),
+        "slots": _package_slots(slots, bin_dir, uv_exe),
         "signature": {
             "private_key": key_paths.get("private"),
             "public_key": key_paths.get("public"),
         },
     }
 
-    # Default environment isolation for Python/UV to prevent host venv interference
-    execution_config = build_config.get("execution", {})
-    runtime_env_config = execution_config.get("runtime", {}).get("env", {})
-
-    # Check for explicit opt-out via isolated flag
-    isolated = runtime_env_config.get("isolated", True)  # Default to True (safe by default)
-
-    # On Windows, always preserve system vars required for DLL loading and process
-    # creation regardless of isolation mode (merging before dedup below).
-    windows_pass = WINDOWS_SYSTEM_PASS if windows else []
-
-    if isolated is False:
-        logger.debug("🔓 Environment isolation disabled via isolated=false flag")
-        # User has explicitly opted out of isolation - don't add runtime section
-        # unless they provided other env config
-        user_pass = runtime_env_config.get("pass", [])
-        merged_pass = windows_pass + [v for v in user_pass if v not in set(windows_pass)]
-        manifest_runtime_env = {
-            key: value
-            for key, value in {
-                "pass": merged_pass,
-                "set": runtime_env_config.get("set", {}),
-                "map": runtime_env_config.get("map", {}),
-            }.items()
-            if value
-        }
-        if manifest_runtime_env:
-            logger.debug(f"Adding user-specified runtime config (no isolation): {manifest_runtime_env}")
-            manifest["runtime"] = {"env": manifest_runtime_env}
-    else:
-        # Apply default isolation (safe by default)
-        logger.debug("🔒 Applying default environment isolation for Python/UV")
-
-        # Merge user unset vars with defaults (defaults first, then user vars, preserve order)
-        user_unset = runtime_env_config.get("unset", [])
-        # Remove duplicates while preserving order: defaults first, then new user vars
-        seen = set(DEFAULT_ENV_ISOLATION_UNSET)
-        merged_unset = DEFAULT_ENV_ISOLATION_UNSET + [var for var in user_unset if var not in seen]
-
-        if user_unset:
-            logger.debug(f"Merging user unset vars {user_unset} with defaults")
-            logger.debug(f"Final merged unset list: {merged_unset}")
-
-        user_pass = runtime_env_config.get("pass", [])
-        merged_pass = windows_pass + [v for v in user_pass if v not in set(windows_pass)]
-
-        manifest_runtime_env = {
-            key: value
-            for key, value in {
-                "unset": merged_unset,
-                "pass": merged_pass,
-                "set": runtime_env_config.get("set", {}),
-                "map": runtime_env_config.get("map", {}),
-            }.items()
-            if value
-        }
-
-        if manifest_runtime_env:
-            manifest["runtime"] = {"env": manifest_runtime_env}
-            logger.info(
-                f"✅ Runtime environment configured with isolation: unset={merged_unset[:3]}... ({len(merged_unset)} vars)"
-            )
+    if runtime_env := _runtime_env_config(build_config, windows):
+        manifest["runtime"] = {"env": runtime_env}
 
     return manifest
 

--- a/src/flavor/packaging/python/slot_builder.py
+++ b/src/flavor/packaging/python/slot_builder.py
@@ -202,7 +202,67 @@ class PythonSlotBuilder:
 
         return artifacts
 
-    def resolve_transitive_dependencies(  # noqa: C901
+    @staticmethod
+    def _declared_sub_dependencies(dep_path: Path, depth: int) -> list[str]:
+        """Read the local dependencies a package declares under [tool.flavor.build].
+
+        A pyproject.toml that will not parse is reported and treated as
+        declaring nothing: one unreadable dependency should not stop the build
+        of everything else.
+        """
+        pyproject_path = dep_path / "pyproject.toml"
+        if not pyproject_path.exists():
+            if logger.is_trace_enabled():
+                logger.trace(f"No pyproject.toml found in {dep_path}")
+            return []
+
+        try:
+            logger.debug("📋 Reading pyproject.toml", path=str(pyproject_path), depth=depth)
+            with pyproject_path.open("rb") as f:
+                pyproject = tomllib.load(f)
+        except Exception as e:
+            logger.warning(
+                "⚠️ Error reading pyproject.toml",
+                path=str(pyproject_path),
+                error=str(e),
+                depth=depth,
+            )
+            return []
+
+        sub_deps: list[str] = (
+            pyproject.get("tool", {}).get("flavor", {}).get("build", {}).get("dependencies", [])
+        )
+        if sub_deps:
+            logger.info(
+                "🔗 Found sub-dependencies",
+                count=len(sub_deps),
+                parent=dep_path.name,
+                depth=depth,
+            )
+        return sub_deps
+
+    def _resolve_sub_dependencies(
+        self, dep_path: Path, sub_deps: list[str], seen: set[Path], depth: int
+    ) -> list[Path]:
+        """Resolve each declared sub-dependency, in declaration order."""
+        resolved: list[Path] = []
+
+        for sub_dep in sub_deps:
+            sub_dep_path = dep_path / sub_dep
+            if not sub_dep_path.exists():
+                logger.warning("⚠️ Sub-dependency not found", path=str(sub_dep_path), depth=depth)
+                continue
+
+            logger.debug(
+                "🔄🔍📋 Recursing into sub-dependency",
+                name=sub_dep_path.name,
+                depth=depth + 1,
+            )
+            resolved.extend(self.resolve_transitive_dependencies(sub_dep_path, seen, depth + 1))
+
+        return resolved
+
+    def resolve_transitive_dependencies(
         self, dep_path: Path, seen: set[Path] | None = None, depth: int = 0
     ) -> list[Path]:
         """
@@ -220,101 +280,28 @@ class PythonSlotBuilder:
             seen = set()
             logger.info("🔍🔄🚀 Starting transitive dependency resolution")
 
-        # Normalize the path to avoid duplicates
+        # Resolved so two spellings of one path are recognised as the same
+        # dependency, which is also what stops a cycle here.
         dep_path = dep_path.resolve()
 
-        logger.debug(
-            "🔍 Checking dependency",
-            name=dep_path.name,
-            path=str(dep_path),
-            depth=depth,
-        )
+        logger.debug("🔍 Checking dependency", name=dep_path.name, path=str(dep_path), depth=depth)
 
-        # Check if we've already processed this dependency
         if dep_path in seen:
-            logger.debug(
-                "⏭️ Dependency already processed",
-                name=dep_path.name,
-                depth=depth,
-            )
+            logger.debug("⏭️ Dependency already processed", name=dep_path.name, depth=depth)
             return []
-
         seen.add(dep_path)
 
-        # Result list - dependencies will be added in reverse order (deepest first)
-        all_deps = []
+        sub_deps = self._declared_sub_dependencies(dep_path, depth)
+        all_deps = self._resolve_sub_dependencies(dep_path, sub_deps, seen, depth)
 
-        # Check if this dependency has a pyproject.toml
-        pyproject_path = dep_path / "pyproject.toml"
-        if pyproject_path.exists():
-            try:
-                logger.debug(
-                    "📋 Reading pyproject.toml",
-                    path=str(pyproject_path),
-                    depth=depth,
-                )
-                with pyproject_path.open("rb") as f:
-                    pyproject = tomllib.load(f)
-
-                # Look for flavor build dependencies
-                flavor_build = pyproject.get("tool", {}).get("flavor", {}).get("build", {})
-                sub_deps = flavor_build.get("dependencies", [])
-
-                if sub_deps:
-                    logger.info(
-                        "🔗 Found sub-dependencies",
-                        count=len(sub_deps),
-                        parent=dep_path.name,
-                        depth=depth,
-                    )
-
-                # Recursively process each sub-dependency
-                for sub_dep in sub_deps:
-                    sub_dep_path = dep_path / sub_dep
-                    if sub_dep_path.exists():
-                        logger.debug(
-                            "🔄🔍📋 Recursing into sub-dependency",
-                            name=sub_dep_path.name,
-                            depth=depth + 1,
-                        )
-                        # Get all transitive dependencies of this sub-dependency
-                        transitive = self.resolve_transitive_dependencies(sub_dep_path, seen, depth + 1)
-                        all_deps.extend(transitive)
-                    else:
-                        logger.warning(
-                            "⚠️ Sub-dependency not found",
-                            path=str(sub_dep_path),
-                            depth=depth,
-                        )
-
-            except Exception as e:
-                logger.warning(
-                    "⚠️ Error reading pyproject.toml",
-                    path=str(pyproject_path),
-                    error=str(e),
-                    depth=depth,
-                )
-        else:
-            if logger.is_trace_enabled():
-                logger.trace(f"No pyproject.toml found in {dep_path}")
-
-        # Add this dependency after its dependencies (post-order)
+        # Post-order: a dependency is built after everything it depends on.
         if dep_path not in all_deps:
             all_deps.append(dep_path)
-            logger.info(
-                "✅ Added dependency to build order",
-                name=dep_path.name,
-                depth=depth,
-            )
+            logger.info("✅ Added dependency to build order", name=dep_path.name, depth=depth)
 
         if depth == 0:
             for i, dep in enumerate(all_deps, 1):
-                logger.info(
-                    "📋 Dependency build order",
-                    index=i,
-                    name=dep.name,
-                    path=str(dep),
-                )
+                logger.info("📋 Dependency build order", index=i, name=dep.name, path=str(dep))
 
         return all_deps
 

--- a/src/flavor/psp/format_2025/handlers.py
+++ b/src/flavor/psp/format_2025/handlers.py
@@ -115,6 +115,56 @@ def _apply_single_operation(data: bytes, op: FoundationOp, compression_level: in
     return data
 
 
+def _reverse_single_operation(data: bytes, op: FoundationOp) -> bytes:
+    """Reverse a single compression operation.
+
+    The counterpart to _apply_single_operation. Compression levels are not
+    passed: a decompressor reads the level from the stream, so the value used
+    on the way in has no bearing here.
+
+    Args:
+        data: Compressed data
+        op: Foundation operation to reverse
+
+    Returns:
+        Decompressed data
+
+    Raises:
+        ArchiveError: If ZSTD is needed and the library is absent
+    """
+    if op == FoundationOp.TAR:
+        # TAR extraction is handled separately by extract_archive().
+        return data
+    if op == FoundationOp.GZIP:
+        result = GzipCompressor(level=6).decompress_bytes(data)
+        logger.trace("🗜️ Reversed GZIP compression", output_size=len(result))
+        return result
+    if op == FoundationOp.BZIP2:
+        result = Bzip2Compressor(level=9).decompress_bytes(data)
+        logger.trace("🗜️ Reversed BZIP2 compression", output_size=len(result))
+        return result
+    if op == FoundationOp.XZ:
+        result = XzCompressor().decompress_bytes(data)
+        logger.trace("🗜️ Reversed XZ compression", output_size=len(result))
+        return result
+    if op == FoundationOp.ZSTD:
+        try:
+            result = ZstdCompressor().decompress_bytes(data)
+        except ImportError as e:
+            # Unlike compression, this cannot be skipped: the data is already
+            # ZSTD and no other path reads it.
+            logger.error("❌ ZSTD library not available for decompression")
+            raise ArchiveError(
+                "ZSTD decompression required but zstandard library not installed. "
+                "Install with: pip install provide-foundation[compression]"
+            ) from e
+        logger.trace("🗜️ Reversed ZSTD compression", output_size=len(result))
+        return result
+
+    logger.warning(f"⚠️ Unsupported operation for reversal: {op}")
+    return data
+
+
 def apply_operations(
     data: bytes,
     packed_ops: int,
@@ -186,7 +236,7 @@ def apply_operations(
         raise ArchiveError(f"Operation application failed: {e}") from e
 
 
-def reverse_operations(data: bytes, packed_ops: int) -> bytes:  # noqa: C901
+def reverse_operations(data: bytes, packed_ops: int) -> bytes:
     """Reverse PSPF operation chain for extraction using Foundation tools.
 
     Args:
@@ -215,37 +265,10 @@ def reverse_operations(data: bytes, packed_ops: int) -> bytes:  # noqa: C901
         # Map to Foundation operations
         foundation_ops = map_operations(pspf_ops)
 
-        # Reverse operations in reverse order
+        # Applied in order on the way in, so undone in reverse on the way out.
         result = data
         for op in reversed(foundation_ops):
-            if op == FoundationOp.TAR:
-                # TAR extraction is handled separately by extract_archive()
-                continue
-            elif op == FoundationOp.GZIP:
-                gzip_compressor = GzipCompressor(level=6)  # level doesn't matter for decompression
-                result = gzip_compressor.decompress_bytes(result)
-                logger.trace("🗜️ Reversed GZIP compression", output_size=len(result))
-            elif op == FoundationOp.BZIP2:
-                bzip2_compressor = Bzip2Compressor(level=9)
-                result = bzip2_compressor.decompress_bytes(result)
-                logger.trace("🗜️ Reversed BZIP2 compression", output_size=len(result))
-            elif op == FoundationOp.XZ:
-                xz_compressor = XzCompressor()
-                result = xz_compressor.decompress_bytes(result)
-                logger.trace("🗜️ Reversed XZ compression", output_size=len(result))
-            elif op == FoundationOp.ZSTD:
-                try:
-                    zstd_compressor = ZstdCompressor()
-                    result = zstd_compressor.decompress_bytes(result)
-                    logger.trace("🗜️ Reversed ZSTD compression", output_size=len(result))
-                except ImportError as e:
-                    logger.error("❌ ZSTD library not available for decompression")
-                    raise ArchiveError(
-                        "ZSTD decompression required but zstandard library not installed. "
-                        "Install with: pip install provide-foundation[compression]"
-                    ) from e
-            else:
-                logger.warning(f"⚠️ Unsupported operation for reversal: {op}")
+            result = _reverse_single_operation(result, op)
 
         logger.debug(
             "✅ Operations reversed successfully",

--- a/src/flavor/psp/format_2025/launcher.py
+++ b/src/flavor/psp/format_2025/launcher.py
@@ -8,7 +8,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import contextlib
 from contextlib import contextmanager
+import gzip
+import hashlib
 import io
 from pathlib import Path
 import tarfile
@@ -160,8 +163,116 @@ class PSPFLauncher(PSPFReader):
             safe_rmtree(workenv_dir)
             raise  # Re-raise the exception
 
-    def extract_slot(self, slot_index: int, workenv_dir: Path, verify_checksum: bool = False) -> Path:  # noqa: C901  # ty: ignore[invalid-method-override]
+    def _read_slot_bytes(self, slot_entry: dict[str, Any], slot_index: int, verify_checksum: bool) -> bytes:
+        """Read one slot exactly as stored, and check it if asked.
+
+        The checksum covers the bytes in the file, compressed or not, and is the
+        first eight bytes of their SHA-256 read little-endian -- the same
+        derivation the Go and Rust readers use.
+        """
+        with Path(self.bundle_path).open("rb") as f:
+            f.seek(slot_entry["offset"])
+            slot_data: bytes = f.read(slot_entry["size"])
+
+        if not verify_checksum:
+            return slot_data
+
+        actual_checksum = int.from_bytes(hashlib.sha256(slot_data).digest()[:8], byteorder="little")
+        if actual_checksum != slot_entry["checksum"]:
+            logger.error(
+                f"❌ Checksum mismatch for slot {slot_index}: "
+                f"expected {slot_entry['checksum']:016x}, got {actual_checksum:016x}"
+            )
+            raise ValueError(f"Checksum mismatch for slot {slot_index}")
+
+        return slot_data
+
+    @staticmethod
+    def _decode_slot_bytes(slot_data: bytes, operations: int, slot_index: int) -> bytes:
+        """Undo the slot's stored encoding.
+
+        Anything ending in a tar is left alone: the archive is opened later,
+        during extraction, and decoding it here would only be undone again.
+        This mapping has to match the Go and Rust readers.
+        """
+        if operations in (_OP_NONE, _OP_TAR, _OP_TAR_GZ):
+            return slot_data
+        if operations == _OP_GZIP:
+            logger.debug(f"🗜️ Decompressing slot {slot_index} with gzip")
+            return gzip.decompress(slot_data)
+
+        logger.error(f"❌ Unsupported operations: {operations}")
+        raise ValueError(f"Unsupported operations: {operations}")
+
+    def _slot_target_name(self, slot_index: int) -> tuple[str, dict[str, Any]]:
+        """Where a slot's contents belong, and the metadata that said so."""
+        metadata = self.read_metadata()
+        slot_name = f"slot_{slot_index}"
+        slot_meta: dict[str, Any] = {}
+
+        if "slots" in metadata and slot_index < len(metadata["slots"]):
+            slot_meta = metadata["slots"][slot_index]
+            slot_name = slot_meta.get("target", slot_meta.get("id", slot_meta.get("name", slot_name)))
+
+        return self._normalize_slot_target(str(slot_name)), slot_meta
+
+    @staticmethod
+    def _looks_like_tarball(data: bytes) -> bool:
+        """Decide by content rather than by name, which a package chooses."""
+        with (
+            contextlib.suppress(tarfile.TarError, EOFError),
+            tarfile.open(fileobj=io.BytesIO(data), mode="r:*"),
+        ):
+            return True
+        return False
+
+    @staticmethod
+    def _safe_tar_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
+        """Reject anything that could write outside the extraction directory.
+
+        tarfile's "data" filter already refuses absolute paths and .., but it
+        still permits links, which can point anywhere once followed.
+        """
+        result = tarfile.data_filter(member, path)
+        if result is not None and (result.issym() or result.islnk()):
+            logger.warning(f"⚠️ Skipping symlink/hardlink in tarball: {result.name}")
+            return None
+        return result
+
+    def _extract_slot_tarball(self, data: bytes, slot_name: str, workenv_dir: Path, slot_index: int) -> Path:
+        """Unpack a tar slot into the work environment."""
+        logger.debug(f"📤 Extracting tarball {slot_name} to {workenv_dir}")
+        try:
+            with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
+                tar.extractall(path=workenv_dir, filter=self._safe_tar_filter)  # nosec B202
+        except (OSError, tarfile.ReadError) as e:
+            logger.error(f"❌ Disk or tarball error extracting slot {slot_index} to {workenv_dir}: {e}")
+            raise
+
+        if slot_name in {".", "{workenv}"}:
+            return workenv_dir
+        return workenv_dir / slot_name
+
+    def _write_slot_file(
+        self, data: bytes, slot_name: str, workenv_dir: Path, slot_meta: dict[str, Any], slot_index: int
+    ) -> Path:
+        """Write a single-file slot atomically, then apply its permissions."""
+        output_path = workenv_dir / slot_name
+        try:
+            ensure_parent_dir(output_path)
+            atomic_write(output_path, data)
+            self._apply_slot_permissions(output_path, slot_meta)
+        except OSError as e:
+            logger.error(f"❌ Disk error writing slot {slot_index} to {output_path}: {e}")
+            raise
+        return output_path
+
+    def extract_slot(self, slot_index: int, workenv_dir: Path, verify_checksum: bool = False) -> Path:  # ty: ignore[invalid-method-override]
         """Extract a single slot.
+
+        This is the Python launcher's own implementation; Go and Rust have
+        theirs, and the encoding and checksum rules above have to agree with
+        them.
 
         Args:
             slot_index: Index of the slot to extract
@@ -171,8 +282,6 @@ class PSPFLauncher(PSPFReader):
         Returns:
             Path: Path to the extracted slot content
         """
-
-        # NOTE: This logic is unique to Python launcher - Go/Rust have their own implementations
         slot_table = self.read_slot_table()
 
         if slot_index < 0 or slot_index >= len(slot_table):
@@ -181,101 +290,19 @@ class PSPFLauncher(PSPFReader):
 
         slot_entry = slot_table[slot_index]
         logger.debug(
-            f"📍 Slot {slot_index}: offset={slot_entry['offset']}, size={slot_entry['size']}, operations={slot_entry['operations']}"
+            f"📍 Slot {slot_index}: offset={slot_entry['offset']}, "
+            f"size={slot_entry['size']}, operations={slot_entry['operations']}"
         )
 
-        # Read slot data from bundle
-        with Path(self.bundle_path).open("rb") as f:
-            f.seek(slot_entry["offset"])
-            slot_data = f.read(slot_entry["size"])
+        slot_data = self._read_slot_bytes(slot_entry, slot_index, verify_checksum)
+        data = self._decode_slot_bytes(slot_data, slot_entry["operations"], slot_index)
 
-        # Verify checksum if requested (checksum is of the data AS STORED IN THE FILE)
-        if verify_checksum:
-            # NOTE: Use SHA-256 (first 8 bytes) to match Go/Rust implementations
-            # Checksum is of the slot data as it exists in the file (compressed or not)
-            import hashlib
-
-            hash_bytes = hashlib.sha256(slot_data).digest()[:8]
-            actual_checksum = int.from_bytes(hash_bytes, byteorder="little")
-            if actual_checksum != slot_entry["checksum"]:
-                logger.error(
-                    f"❌ Checksum mismatch for slot {slot_index}: expected {slot_entry['checksum']:016x}, got {actual_checksum:016x}"
-                )
-                raise ValueError(f"Checksum mismatch for slot {slot_index}")
-
-        # NOTE: Decoding logic must match Go/Rust implementations
-        # Decode if needed
-        if slot_entry["operations"] == _OP_NONE:
-            data = slot_data
-        elif slot_entry["operations"] == _OP_TAR:
-            data = slot_data  # Tar archives are extracted later
-        elif slot_entry["operations"] == _OP_GZIP:
-            logger.debug(f"🗜️ Decompressing slot {slot_index} with gzip")
-            import gzip
-
-            data = gzip.decompress(slot_data)
-        elif slot_entry["operations"] == _OP_TAR_GZ:
-            data = slot_data  # Will be decompressed and extracted later
-        else:
-            logger.error(f"❌ Unsupported operations: {slot_entry['operations']}")
-            raise ValueError(f"Unsupported operations: {slot_entry['operations']}")
-
-        # Get slot name from metadata - use target for extraction path
-        metadata = self.read_metadata()
-        slot_name = f"slot_{slot_index}"
-        slot_meta: dict[str, Any] = {}
-        if "slots" in metadata and slot_index < len(metadata["slots"]):
-            slot_meta = metadata["slots"][slot_index]
-            # Use "target" field for extraction path, fallback to "id" or "name"
-            slot_name = slot_meta.get("target", slot_meta.get("id", slot_meta.get("name", slot_name)))
-        slot_name = self._normalize_slot_target(str(slot_name))
+        slot_name, slot_meta = self._slot_target_name(slot_index)
         logger.debug(f"📝 Slot {slot_index} name: {slot_name}")
 
-        # NOTE: Tarball extraction logic matches Go's tar extraction
-        # Check if it's a tarball that needs extraction (by content, not just name)
-        import contextlib
-
-        is_tarball = False
-        with (
-            contextlib.suppress(tarfile.TarError, EOFError),
-            tarfile.open(fileobj=io.BytesIO(data), mode="r:*"),
-        ):
-            # If we can open it, it's a tarball
-            is_tarball = True
-
-        if is_tarball or slot_name.endswith(".tar.gz") or slot_name.endswith(".tgz"):
-            logger.debug(f"📤 Extracting tarball {slot_name} to {workenv_dir}")
-            try:
-                with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
-                    # "data" rejects absolute paths and .. but still allows symlinks;
-                    # we additionally strip symlinks to prevent link-based traversal.
-                    def _safe_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
-                        result = tarfile.data_filter(member, path)
-                        if result is not None and (result.issym() or result.islnk()):
-                            logger.warning(f"⚠️ Skipping symlink/hardlink in tarball: {result.name}")
-                            return None
-                        return result
-
-                    tar.extractall(path=workenv_dir, filter=_safe_filter)  # nosec B202
-
-                if slot_name in {".", "{workenv}"}:
-                    return workenv_dir
-
-                return workenv_dir / slot_name
-            except (OSError, tarfile.ReadError) as e:
-                logger.error(f"❌ Disk or tarball error extracting slot {slot_index} to {workenv_dir}: {e}")
-                raise  # Re-raise the exception
-        else:
-            # Write single file (atomic for safety)
-            output_path = workenv_dir / slot_name
-            try:
-                ensure_parent_dir(output_path)
-                atomic_write(output_path, data)
-                self._apply_slot_permissions(output_path, slot_meta)
-                return output_path
-            except OSError as e:
-                logger.error(f"❌ Disk error writing slot {slot_index} to {output_path}: {e}")
-                raise  # Re-raise the exception
+        if self._looks_like_tarball(data) or slot_name.endswith((".tar.gz", ".tgz")):
+            return self._extract_slot_tarball(data, slot_name, workenv_dir, slot_index)
+        return self._write_slot_file(data, slot_name, workenv_dir, slot_meta, slot_index)
 
     def _apply_slot_permissions(self, output_path: Path, slot_meta: dict[str, Any]) -> None:
         """Apply metadata-driven permissions after single-file extraction."""

--- a/src/flavor/psp/format_2025/validation.py
+++ b/src/flavor/psp/format_2025/validation.py
@@ -83,7 +83,123 @@ def validate_metadata(metadata: dict[str, Any]) -> list[str]:
     return errors
 
 
-def validate_slots(slots: list[SlotMetadata]) -> list[str]:  # noqa: C901
+# Rebuilt on every slot before; a slot's purpose and lifecycle are fixed
+# vocabularies, so they belong to the module rather than the loop.
+VALID_PURPOSES = (
+    "data",
+    "payload",
+    "code",
+    "runtime",
+    "config",
+    "tool",
+    "media",
+    "asset",
+    "library",
+    "binary",
+    "installer",
+)
+
+VALID_LIFECYCLES = (
+    "init",
+    "startup",
+    "runtime",
+    "shutdown",
+    "cache",
+    "temporary",
+    "lazy",
+    "eager",
+    "dev",
+    "config",
+    "platform",
+    "persistent",
+    "volatile",
+)
+
+
+def _validate_slot_source(slot: SlotMetadata) -> list[str]:
+    """Check that a declared source path exists and is something readable."""
+    if not slot.source:
+        return []
+
+    source_path = Path(slot.source)
+    if not source_path.exists():
+        return [f"🔍 Slot {slot.id}: Source path does not exist: {slot.source}"]
+    if not source_path.is_file() and not source_path.is_dir():
+        return [f"🔍 Slot {slot.id}: Source path is not a file or directory: {slot.source}"]
+    return []
+
+
+def _validate_slot_vocabulary(slot: SlotMetadata) -> list[str]:
+    """Check the fields drawn from a fixed set of values."""
+    errors: list[str] = []
+
+    if slot.purpose not in VALID_PURPOSES:
+        errors.append(
+            f"🎯 Slot '{slot.id}' has invalid purpose '{slot.purpose}'. "
+            f"Valid options: {', '.join(VALID_PURPOSES)}"
+        )
+
+    if slot.lifecycle not in VALID_LIFECYCLES:
+        errors.append(
+            f"♻️ Slot '{slot.id}' has invalid lifecycle '{slot.lifecycle}'. "
+            f"Valid options: {', '.join(VALID_LIFECYCLES)}"
+        )
+
+    return errors
+
+
+def _validate_slot_fields(slot: SlotMetadata) -> list[str]:
+    """Check one slot in isolation, ignoring how it relates to the others."""
+    errors: list[str] = []
+
+    if slot.size < 0:
+        errors.append(f"📏 Slot '{slot.id}' has negative size: {slot.size}")
+
+    # operations is a string like "tar.gz" or "TAR|GZIP".
+    if not isinstance(slot.operations, str):
+        errors.append(
+            f"🗜️ Slot '{slot.id}' has invalid operations type: "
+            f"expected string, got {type(slot.operations).__name__}"
+        )
+
+    errors.extend(_validate_slot_source(slot))
+
+    try:
+        normalize_workenv_target(slot.target)
+    except ValueError as exc:
+        errors.append(f"📁 Slot {slot.id}: invalid target path: {exc}")
+
+    errors.extend(_validate_slot_vocabulary(slot))
+
+    if slot.checksum and not isinstance(slot.checksum, str):  # pragma: no cover
+        errors.append(f"🔐 Slot '{slot.id}' checksum must be a string")
+
+    return errors
+
+
+def _validate_slot_identity(slot: SlotMetadata, seen_indices: set[int], seen_names: set[str]) -> list[str]:
+    """Check what a slot's index and name mean relative to the slots before it.
+
+    Both sets are updated here, including for a slot that was rejected: a third
+    slot repeating the same index should be reported against the first, not
+    silently accepted because the second was already an error.
+    """
+    errors: list[str] = []
+
+    if slot.index in seen_indices:
+        errors.append(f"🔢 Duplicate slot index {slot.index} for slot '{slot.id}'")
+    seen_indices.add(slot.index)
+
+    if not slot.id or not slot.id.strip():
+        errors.append(f"📝 Slot at index {slot.index} has empty name")
+    elif slot.id in seen_names:
+        errors.append(f"📝 Duplicate slot name '{slot.id}'")
+    seen_names.add(slot.id)
+
+    return errors
+
+
+def validate_slots(slots: list[SlotMetadata]) -> list[str]:
     """
     Validate slot configurations.
 
@@ -95,95 +211,12 @@ def validate_slots(slots: list[SlotMetadata]) -> list[str]:  # noqa: C901
     - Valid names
     """
     errors: list[str] = []
+    seen_indices: set[int] = set()
+    seen_names: set[str] = set()
 
-    if not slots:
-        return errors  # Empty slots is valid
-
-    seen_indices = set()
-    seen_names = set()
-
-    for _i, slot in enumerate(slots):
-        # Check index uniqueness
-        if slot.index in seen_indices:
-            errors.append(f"🔢 Duplicate slot index {slot.index} for slot '{slot.id}'")
-        seen_indices.add(slot.index)
-
-        # Check name validity
-        if not slot.id or not slot.id.strip():
-            errors.append(f"📝 Slot at index {slot.index} has empty name")
-        elif slot.id in seen_names:
-            errors.append(f"📝 Duplicate slot name '{slot.id}'")
-        seen_names.add(slot.id)
-
-        # Check size validity
-        if slot.size < 0:
-            errors.append(f"📏 Slot '{slot.id}' has negative size: {slot.size}")
-
-        # Check operations validity
-        # Operations field is a string like "tar.gz" or "TAR|GZIP"
-        if not isinstance(slot.operations, str):
-            errors.append(
-                f"🗜️ Slot '{slot.id}' has invalid operations type: expected string, got {type(slot.operations).__name__}"
-            )
-
-        # Check source path existence if provided
-        if slot.source:
-            source_path = Path(slot.source)
-            if not source_path.exists():
-                errors.append(f"🔍 Slot {slot.id}: Source path does not exist: {slot.source}")
-            elif not source_path.is_file() and not source_path.is_dir():
-                errors.append(f"🔍 Slot {slot.id}: Source path is not a file or directory: {slot.source}")
-
-        try:
-            normalize_workenv_target(slot.target)
-        except ValueError as exc:
-            errors.append(f"📁 Slot {slot.id}: invalid target path: {exc}")
-
-        # Check purpose validity
-        valid_purposes = [
-            "data",
-            "payload",
-            "code",
-            "runtime",
-            "config",
-            "tool",
-            "media",
-            "asset",
-            "library",
-            "binary",
-            "installer",
-        ]
-        if slot.purpose not in valid_purposes:
-            errors.append(
-                f"🎯 Slot '{slot.id}' has invalid purpose '{slot.purpose}'. "
-                f"Valid options: {', '.join(valid_purposes)}"
-            )
-
-        # Check lifecycle validity
-        valid_lifecycles = [
-            "init",
-            "startup",
-            "runtime",
-            "shutdown",
-            "cache",
-            "temporary",
-            "lazy",
-            "eager",
-            "dev",
-            "config",
-            "platform",
-            "persistent",
-            "volatile",
-        ]
-        if slot.lifecycle not in valid_lifecycles:
-            errors.append(
-                f"♻️ Slot '{slot.id}' has invalid lifecycle '{slot.lifecycle}'. "
-                f"Valid options: {', '.join(valid_lifecycles)}"
-            )
-
-        # Check checksum format if provided
-        if slot.checksum and not isinstance(slot.checksum, str):  # pragma: no cover
-            errors.append(f"🔐 Slot '{slot.id}' checksum must be a string")
+    for slot in slots:
+        errors.extend(_validate_slot_identity(slot, seen_indices, seen_names))
+        errors.extend(_validate_slot_fields(slot))
 
     return errors
 

--- a/src/flavor/psp/security.py
+++ b/src/flavor/psp/security.py
@@ -9,7 +9,9 @@ This module provides security-related functionality for PSP packages,
 including integrity verification, signature validation, and tamper detection."""
 
 from enum import IntEnum
+import gzip
 from pathlib import Path
+from typing import Any
 
 from provide.foundation import logger
 from provide.foundation.crypto import Ed25519Verifier
@@ -73,7 +75,150 @@ class PSPFIntegrityVerifier:
         """Initialize the verifier."""
         pass
 
-    def verify_integrity(self, bundle_path: Path) -> IntegrityResult:  # noqa: C901
+    def _verify_signature(self, reader: PSPFReader, index: Any, level: ValidationLevel) -> tuple[bool, bool]:
+        """Check the Ed25519 seal over the stored metadata.
+
+        Returns (signature_valid, tamper_detected).
+
+        Relaxed and minimal do not check the seal at all, so they report it
+        valid rather than unknown -- the level is a statement that the caller
+        does not want it checked.
+        """
+        if level in (ValidationLevel.RELAXED, ValidationLevel.MINIMAL):
+            logger.debug("🔐 Skipping signature verification due to validation level")
+            return True, False
+
+        if not (hasattr(index, "integrity_signature") and hasattr(index, "public_key")):
+            if level == ValidationLevel.STRICT:
+                logger.error("🔐 Index missing signature fields")
+            else:
+                logger.debug("🔐 Index missing signature fields")
+            return False, False
+
+        signed = (
+            index.integrity_signature
+            and index.public_key
+            and index.integrity_signature != b"\x00" * 512
+            and index.public_key != b"\x00" * 32
+        )
+        if not signed:
+            if level == ValidationLevel.STRICT:
+                logger.error("🔐 No valid signatures found - package unsigned")
+            else:
+                logger.debug("🔐 No valid signatures found")
+            return False, False
+
+        try:
+            # The seal covers the stored metadata bytes, so read them back
+            # rather than re-serialising what was parsed from them.
+            assert reader._backend is not None
+            metadata_compressed = reader._backend.read_at(index.metadata_offset, index.metadata_size)
+            if isinstance(metadata_compressed, memoryview):
+                metadata_compressed = bytes(metadata_compressed)
+            metadata_json = gzip.decompress(metadata_compressed)
+
+            verifier = Ed25519Verifier(index.public_key)
+            # Ed25519 occupies the first 64 bytes of the 512-byte field.
+            signature_valid = verifier.verify(metadata_json, index.integrity_signature[:64])
+            logger.debug(f"🔐 Signature validation result: {signature_valid}")
+            return signature_valid, False
+
+        except Exception as e:
+            if level == ValidationLevel.STRICT:
+                logger.error(f"❌ Signature verification error: {e}")
+                raise
+            if level == ValidationLevel.STANDARD:
+                logger.warning(f"⚠️ Signature verification error: {e}")
+                logger.warning("🚨 SECURITY WARNING: Package integrity verification failed")
+                logger.warning("🚨 Package may be corrupted or tampered with")
+                logger.warning(
+                    f"🚨 Continuing with standard validation (use {ENV_VALIDATION}=strict to enforce)"
+                )
+            else:
+                logger.warning(f"⚠️ Signature verification error: {e}")
+                logger.warning("⚠️ Continuing due to validation level")
+            return False, False
+
+    def _verify_one_slot(
+        self, reader: PSPFReader, index_of_slot: int, slot_id: str, level: ValidationLevel
+    ) -> tuple[bool, bool]:
+        """Check one slot's checksum. Returns (ok, tamper_detected)."""
+        try:
+            if reader.verify_slot_integrity(index_of_slot):
+                logger.debug(f"🔐 Slot {slot_id} integrity valid")
+                return True, False
+
+            if level == ValidationLevel.STRICT:
+                logger.error(f"❌ Slot {index_of_slot} integrity check failed - package corrupted")
+                return False, True
+            if level == ValidationLevel.STANDARD:
+                logger.warning(f"🚨 SECURITY WARNING: Slot {index_of_slot} integrity check failed")
+                logger.warning("🚨 Slot may be corrupted or tampered with")
+                logger.warning(
+                    f"🚨 Continuing with standard validation (use {ENV_VALIDATION}=strict to enforce)"
+                )
+            else:  # RELAXED
+                logger.warning(f"⚠️ Slot {index_of_slot} integrity check failed")
+                logger.warning("⚠️ Continuing due to relaxed validation")
+            return True, False
+
+        except Exception as e:
+            if level == ValidationLevel.STRICT:
+                logger.error(f"❌ Slot {slot_id} integrity check error: {e}")
+                return False, True
+            logger.warning(f"⚠️ Slot {slot_id} integrity check error: {e}")
+            logger.warning("⚠️ Continuing due to validation level")
+            return True, False
+
+    def _verify_slots(self, reader: PSPFReader, level: ValidationLevel) -> tuple[bool, bool]:
+        """Check every slot's checksum. Returns (ok, tamper_detected)."""
+        if level == ValidationLevel.MINIMAL:
+            logger.debug("🔐 Skipping slot verification due to minimal validation level")
+            return True, False
+
+        try:
+            slot_descriptors = reader.read_slot_descriptors()
+        except Exception as e:
+            if level == ValidationLevel.STRICT:
+                logger.error(f"❌ Slot verification error: {e}")
+                return False, True
+            logger.warning(f"⚠️ Slot verification error: {e}")
+            logger.warning("⚠️ Continuing due to validation level")
+            return True, False
+
+        ok = True
+        tamper_detected = False
+        for i, descriptor in enumerate(slot_descriptors):
+            slot_ok, slot_tampered = self._verify_one_slot(reader, i, descriptor.name or f"slot_{i}", level)
+            ok = ok and slot_ok
+            tamper_detected = tamper_detected or slot_tampered
+
+        return ok, tamper_detected
+
+    @staticmethod
+    def _overall_validity(
+        level: ValidationLevel, signature_valid: bool, tamper_detected: bool, readable: bool
+    ) -> bool:
+        """Decide whether the package passes, given what the level enforces.
+
+        Only strict turns a failed signature or detected tampering into a
+        failure. The other levels warn and require the metadata to be readable,
+        which is the tiering the warnings above tell the operator about.
+        """
+        if level == ValidationLevel.STRICT:
+            valid = signature_valid and not tamper_detected and readable
+            if not valid:
+                logger.error("❌ Package integrity verification failed under strict validation")
+            return valid
+
+        if level in (ValidationLevel.STANDARD, ValidationLevel.RELAXED):
+            if not signature_valid or tamper_detected:
+                logger.debug("🔐 Package has integrity issues but continuing due to validation level")
+            return readable
+
+        return readable  # MINIMAL
+
+    def verify_integrity(self, bundle_path: Path) -> IntegrityResult:
         """
         Verify the integrity of a PSPF package bundle.
 
@@ -85,10 +230,8 @@ class PSPFIntegrityVerifier:
         """
         logger.debug(f"🔐 Verifying package integrity: {bundle_path}")
 
-        # Get current validation level
         validation_level = get_validation_level()
 
-        # Skip all validation if level is NONE
         if validation_level == ValidationLevel.NONE:
             logger.warning("⚠️ VALIDATION DISABLED: Skipping integrity verification")
             return {
@@ -98,162 +241,20 @@ class PSPFIntegrityVerifier:
             }
 
         try:
-            # Open bundle for reading
             with PSPFReader(bundle_path) as reader:
-                # Read index and metadata
                 index = reader.read_index()
                 metadata = reader.read_metadata()
 
-                # Initialize verification state
-                signature_valid = True
-                tamper_detected = False
+                signature_valid, tamper_detected = self._verify_signature(reader, index, validation_level)
+                slots_ok, slots_tampered = self._verify_slots(reader, validation_level)
 
-                # Skip signature verification for relaxed/minimal levels
-                if validation_level in (
-                    ValidationLevel.RELAXED,
-                    ValidationLevel.MINIMAL,
-                ):
-                    logger.debug("🔐 Skipping signature verification due to validation level")
-                    signature_valid = True
-                else:
-                    # Verify signature if present
-                    if hasattr(index, "integrity_signature") and hasattr(index, "public_key"):
-                        if (
-                            index.integrity_signature
-                            and index.public_key
-                            and index.integrity_signature != b"\x00" * 512
-                            and index.public_key != b"\x00" * 32
-                        ):
-                            # Get the original metadata JSON that was signed during building
-                            # Read compressed metadata from file
-                            assert reader._backend is not None
-                            metadata_compressed = reader._backend.read_at(
-                                index.metadata_offset, index.metadata_size
-                            )
-
-                            # Convert to bytes if memoryview
-                            if isinstance(metadata_compressed, memoryview):
-                                metadata_compressed = bytes(metadata_compressed)
-
-                            # Decompress to get the original JSON that was signed
-                            import gzip
-
-                            metadata_json = gzip.decompress(metadata_compressed)
-
-                            # Verify Ed25519 signature
-                            try:
-                                # Extract first 64 bytes for Ed25519 signature
-                                ed25519_signature = index.integrity_signature[:64]
-
-                                verifier = Ed25519Verifier(index.public_key)
-                                signature_valid = verifier.verify(metadata_json, ed25519_signature)
-                                logger.debug(f"🔐 Signature validation result: {signature_valid}")
-
-                            except Exception as e:
-                                # Handle signature validation failure based on level
-                                signature_valid = False
-                                if validation_level == ValidationLevel.STRICT:
-                                    logger.error(f"❌ Signature verification error: {e}")
-                                    tamper_detected = True
-                                    raise
-                                elif validation_level == ValidationLevel.STANDARD:
-                                    logger.warning(f"⚠️ Signature verification error: {e}")
-                                    logger.warning(
-                                        "🚨 SECURITY WARNING: Package integrity verification failed"
-                                    )
-                                    logger.warning("🚨 Package may be corrupted or tampered with")
-                                    logger.warning(
-                                        f"🚨 Continuing with standard validation (use {ENV_VALIDATION}=strict to enforce)"
-                                    )
-                                else:
-                                    # Defensive: unreachable for current ValidationLevel values
-                                    # (RELAXED/MINIMAL skip this block at line 111)
-                                    logger.warning(f"⚠️ Signature verification error: {e}")
-                                    logger.warning("⚠️ Continuing due to validation level")
-                        else:
-                            # Missing or null signatures
-                            if validation_level == ValidationLevel.STRICT:
-                                logger.error("🔐 No valid signatures found - package unsigned")
-                                signature_valid = False
-                            else:
-                                logger.debug("🔐 No valid signatures found")
-                                signature_valid = False
-                    else:
-                        # No signature fields in index
-                        if validation_level == ValidationLevel.STRICT:
-                            logger.error("🔐 Index missing signature fields")
-                            signature_valid = False
-                        else:
-                            logger.debug("🔐 Index missing signature fields")
-                            signature_valid = False
-
-                # Verify slot checksums (skip for minimal level)
-                if validation_level != ValidationLevel.MINIMAL:
-                    try:
-                        slot_descriptors = reader.read_slot_descriptors()
-                        for i, descriptor in enumerate(slot_descriptors):
-                            slot_id = descriptor.name or f"slot_{i}"
-
-                            # Verify slot integrity using reader's built-in method
-                            try:
-                                is_valid = reader.verify_slot_integrity(i)
-                                if not is_valid:
-                                    if validation_level == ValidationLevel.STRICT:
-                                        logger.error(f"❌ Slot {i} integrity check failed - package corrupted")
-                                        tamper_detected = True
-                                        signature_valid = False
-                                    elif validation_level == ValidationLevel.STANDARD:
-                                        logger.warning(f"🚨 SECURITY WARNING: Slot {i} integrity check failed")
-                                        logger.warning("🚨 Slot may be corrupted or tampered with")
-                                        logger.warning(
-                                            f"🚨 Continuing with standard validation (use {ENV_VALIDATION}=strict to enforce)"
-                                        )
-                                        # Don't set tamper_detected for standard level
-                                    else:  # RELAXED
-                                        logger.warning(f"⚠️ Slot {i} integrity check failed")
-                                        logger.warning("⚠️ Continuing due to relaxed validation")
-                                else:
-                                    logger.debug(f"🔐 Slot {slot_id} integrity valid")
-                            except Exception as e:
-                                if validation_level == ValidationLevel.STRICT:
-                                    logger.error(f"❌ Slot {slot_id} integrity check error: {e}")
-                                    tamper_detected = True
-                                    signature_valid = False
-                                else:
-                                    logger.warning(f"⚠️ Slot {slot_id} integrity check error: {e}")
-                                    logger.warning("⚠️ Continuing due to validation level")
-
-                    except Exception as e:
-                        if validation_level == ValidationLevel.STRICT:
-                            logger.error(f"❌ Slot verification error: {e}")
-                            tamper_detected = True
-                            signature_valid = False
-                        else:
-                            logger.warning(f"⚠️ Slot verification error: {e}")
-                            logger.warning("⚠️ Continuing due to validation level")
-                else:
-                    logger.debug("🔐 Skipping slot verification due to minimal validation level")
-
-                # Overall validity depends on validation level
-                if validation_level == ValidationLevel.STRICT:
-                    # Strict: must have valid signature and no tampering
-                    valid = signature_valid and not tamper_detected and metadata is not None
-                    if not valid:
-                        logger.error("❌ Package integrity verification failed under strict validation")
-                elif validation_level in (
-                    ValidationLevel.STANDARD,
-                    ValidationLevel.RELAXED,
-                ):
-                    # Standard/Relaxed: metadata must be readable, warnings for other issues
-                    valid = metadata is not None
-                    if not signature_valid or tamper_detected:
-                        logger.debug("🔐 Package has integrity issues but continuing due to validation level")
-                else:  # MINIMAL
-                    # Minimal: only check if we can read metadata
-                    valid = metadata is not None
+                signature_valid = signature_valid and slots_ok
+                tamper_detected = tamper_detected or slots_tampered
 
                 result: IntegrityResult = {
-                    "valid": valid,
+                    "valid": self._overall_validity(
+                        validation_level, signature_valid, tamper_detected, metadata is not None
+                    ),
                     "signature_valid": signature_valid,
                     "tamper_detected": tamper_detected,
                 }
@@ -262,20 +263,17 @@ class PSPFIntegrityVerifier:
                 return result
 
         except Exception as e:
+            # A verification that could not complete is a failure at every
+            # level; only how loudly it is reported differs.
             if validation_level == ValidationLevel.STRICT:
                 logger.error(f"❌ Integrity verification failed: {e}")
-                return {
-                    "valid": False,
-                    "signature_valid": False,
-                    "tamper_detected": True,
-                }
             else:
                 logger.warning(f"⚠️ Integrity verification error: {e}")
-                return {
-                    "valid": False,
-                    "signature_valid": False,
-                    "tamper_detected": True,
-                }
+            return {
+                "valid": False,
+                "signature_valid": False,
+                "tamper_detected": True,
+            }
 
 
 # Create a module-level verifier instance for convenience


### PR DESCRIPTION
Stacked on #62 (merged). Clears the complexity backlog `gocyclo` and `xenon` were carrying, and promotes them from advisory to blocking.

## A real bug, found where it was hiding

`runBundleWithCwd` had a cyclomatic complexity of **103** across 590 lines. Inside it:

`ReleaseLock` removes the lock file unconditionally — it takes no owner and checks none. `runBundleWithCwd` registered `defer ReleaseLock(paths, logger)` **after the acquire attempt, on both paths**, so a launch that found the lock held, waited for the holder, and carried on would delete whichever process's lock file was there when it returned.

The window is real: `WaitForExtraction` returns the moment the lock file disappears, and another process can take the lock between that instant and this one returning. Two launches of the same package then extract into one work environment with nothing between them.

The same branch also called `extractAndMergeSlotsToWorkenv` **after waiting** — extracting a second time, concurrently, holding no lock. `TestLockIsNotReleasedByAProcessThatNeverAcquiredIt` fails on the previous commit.

## Complexity

**Go** — every function below is now under the 32 ceiling; those marked "off" no longer appear in the report at all.

| Function | Before | After |
|---|---:|---:|
| `runBundleWithCwd` | 103 | **32** |
| `doBuild` | 62 | **off** |
| `processRuntimeEnv` | 51 | **off** |
| `extractAndMergeSlotsToWorkenv` | 43 | **off** |
| `ExtractSlot` | 41 | **off** |
| `LaunchWithLogLevel` | 30 | **off** |

**Python** — 19 B / 28 C / **3 D** / **1 E** → 16 B / 22 C. No D or E remain, and **all seven `# noqa: C901` suppressions are gone** — each one complexity that had been noticed and silenced.

## The checks now block

| | | |
|---|---|---|
| Gocyclo | blocking | `-over 32` (worst today: `runBundleWithCwd`) |
| Gocyclo (target) | advisory | `-over 15` |
| Xenon | blocking | `max-absolute C, modules C, average B` |
| Xenon (target) | advisory | `max-absolute B, modules A, average A` |

A ratchet, set at what the tree holds rather than what it should reach. That's worth having because the failure being fixed is *a check that cannot fail* — advisory meant these reported into a summary nobody had to act on, which is how `cargo machete` spent months reporting "no such command".

**Verified the thresholds reject**: gocyclo at `-over 20` and xenon at `--max-absolute B` each exit 1 against the current tree, so the blocking status is real and not a number set loose enough to always pass.

## What decomposition kept surfacing

Each extraction named something that existed only as duplication:

- The validation-level reaction written out **three times** → `tolerateVerificationError`
- `{workenv}`/`{package_name}`/`{version}` substitution written out **four times** → `substituteSetupPlaceholders`
- The tar containment check written out **three times** → `escapesDir`. That's what keeps a tar entry from writing outside the work environment, so one copy matters beyond tidiness.
- The `slot_0_` and `slot_N_` merge branches were **45 identical lines**, and `slot_0_` is a prefix of `slot_` — the first branch was reachable only because it was tested first.
- The **order** of runtime env operations is load-bearing and was documented nowhere: the preserve list must be built before any removal, which is what makes `unset: "*"` mean "remove everything the pass patterns did not protect".
- `SOURCE_DATE_EPOCH` drops the hostname from the build host because a name that varies per machine defeats the reproducibility it asks for.
- The forward operation chain already had `_apply_single_operation`; the reverse never got the same treatment.

## Behaviour preserved deliberately

The validation tiering is unchanged, including the parts that read oddly until named: only `strict` turns a failed signature or detected tampering into a failure, and `standard` warns about a corrupted slot without failing — which is what its own warning tells the operator. The Go launcher tiers identically. I checked this was policy, not a bug, before preserving it.

## Two near-misses the tests caught

Both are the argument for the coverage this leaned on:

1. Unifying the slot-merge branches also unified their handling of an occupied destination — and that difference is load-bearing. Slot contents merge into a shared root and are expected to land on each other, so they clear the destination first; a top-level entry does not, because clearing first turns "a directory is in the way" into a silent success. `replaceExisting` is a parameter rather than an assumption because a test failed.
2. Twice, extracting helpers above a click command left the decorators attached to the *helper*, so `flavor helpers list` and `flavor workenv inspect` dispatched into the wrong function. Both caught by their command tests.

`staticcheck` also caught a dead initializer this refactor introduced — #62's promotion earning itself within the hour.

## Verification

- Go package coverage **95.7% → 96.2%**; every extracted function 87–100%. `runBundleWithCwd` was 98% covered before and after.
- Full Go suite, `-count=1`, 8 packages — pass
- Full Python suite — 2775 passed
- All three quality gates exit 0 with every blocking check green