### PR TITLE
Report the launcher read-back where the build's output goes

### DIFF
--- a/src/flavor/packaging/orchestrator_helpers.py
+++ b/src/flavor/packaging/orchestrator_helpers.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import tarfile
 from typing import Any
 
-from provide.foundation import logger
+from provide.foundation import logger, pout
 from provide.foundation.errors import ProcessError
 from provide.foundation.file.formats import write_json
 from provide.foundation.platform import is_windows
@@ -450,6 +450,8 @@ def verify_built_package(package_path: Path, *, launcher_name: str, host_platfor
     # when that launcher is native. A foreign one is a deliberate --launcher-bin
     # choice, already warned about when the launcher is resolved.
     if host_platform not in launcher_name and "any" not in launcher_name:
+        pout(f"  ⚠️  Skipping launcher read-back: {launcher_name} is not native to {host_platform}")
+        pout("     A launcher that cannot read this package will not be caught here.")
         logger.warning(
             "⚠️🚀 Skipping launcher read-back: embedded launcher is not native",
             launcher=launcher_name,
@@ -459,7 +461,10 @@ def verify_built_package(package_path: Path, *, launcher_name: str, host_platfor
         )
         return
 
-    logger.info("🔍🚀 Asking the embedded launcher to read the package back...")
+    # pout, not logger: the orchestrator's info logging is suppressed in CI, so
+    # a check that only logged would leave no evidence it ran. A check whose
+    # success is invisible cannot be told apart from one that did not happen.
+    pout("🔍 Asking the embedded launcher to read the package back...")
     try:
         result = _run_launcher_verify(package_path)
     except ProcessError as exc:
@@ -479,7 +484,7 @@ def verify_built_package(package_path: Path, *, launcher_name: str, host_platfor
         ) from exc
 
     if result.returncode == 0:
-        logger.info("✅🚀 Embedded launcher reads the package it ships in")
+        pout("  ✅ Embedded launcher reads the package it ships in")
         return
 
     said = _last_lines(result.stderr) or _last_lines(result.stdout)

--- a/tests/packaging/test_orchestrator_self_check.py
+++ b/tests/packaging/test_orchestrator_self_check.py
@@ -75,6 +75,38 @@ class TestVerifyBuiltPackage:
                 package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
             )
 
+    def test_result_is_visible_in_build_output(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The check reports on stdout, not only through the logger.
+
+        The orchestrator's info logging is suppressed in CI, so a check that
+        only logged left no evidence it ran -- indistinguishable from one that
+        did not happen. That is the failure this whole function exists to
+        remove, so its own result has to be visible.
+        """
+        package = _stub_package(tmp_path / "good.psp", "exit 0")
+
+        verify_built_package(
+            package, launcher_name="flavor-rs-launcher-linux_amd64", host_platform="linux_amd64"
+        )
+
+        out = capsys.readouterr().out
+        assert "read the package back" in out, f"the check left no trace on stdout: {out!r}"
+        assert "reads the package it ships in" in out, f"the result was not reported: {out!r}"
+
+    def test_skip_is_visible_in_build_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """A skipped check says so where the build's other output goes."""
+        package = _stub_package(tmp_path / "foreign.psp", "exit 1")
+
+        verify_built_package(
+            package, launcher_name="flavor-rs-launcher-linux_arm64", host_platform="darwin_arm64"
+        )
+
+        out = capsys.readouterr().out
+        assert "Skipping launcher read-back" in out, f"the skip was silent: {out!r}"
+        assert "will not be caught here" in out, f"the skip did not say what it costs: {out!r}"
+
     def test_diagnosis_survives_leading_log_noise(self, tmp_path: Path) -> None:
         """The reason is the last thing printed, not the first.
 


### PR DESCRIPTION
Found while verifying that the read-back added in #61 actually fires in the release pipeline. It fires. It also leaves no trace.

## What the 0.5.0 build logs show

```
✍️  Writing PSPF package file...
🔍 Processing and verifying artifacts...
```

Every build phase appears except this one. The two lines were `logger.info`, and the orchestrator's info logging is suppressed in the pipeline — `FLAVOR_LOG_LEVEL=trace` is set, but that governs the **Rust and Go launchers**, not the Python side.

## Why "it clearly ran" is not good enough

It did run: the skip path logs a warning, no warning appears in the logs, and a failure would have stopped the build. But that is inference from absence.

A check whose success is invisible cannot be told apart from one that did not happen. That is the defect this function was added to remove — and it had the defect itself.

## After

```
✍️  Writing PSPF package file...
🔍 Asking the embedded launcher to read the package back...
  ✅ Embedded launcher reads the package it ships in
🔍 Processing and verifying artifacts...
  ✅ Package integrity verified
✅ Successfully built 1 package(s)
```

The skip is louder too. It keeps its structured warning and now also says on stdout which launcher was not native and what that costs — a silently skipped check is the worse half of the same problem.

## Verification

- Real `flavor pack` of this repo, output above
- Two tests pin the messages, because a message nothing asserts on is the next thing to quietly disappear
- `tests/packaging/`: **463 passed**
- ruff, mypy clean

## Note on the release in flight

The 0.5.0 artifacts already built are unaffected — this changes reporting, not behaviour. But it means the pipeline evidence for the read-back is inference rather than a log line, so this is worth landing before cutting the real release, so the release build shows the check ran.