### PR TITLE
Stop dropping the Windows flavor packages; name Windows packages .exe consistently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           - `flavor-${{ needs.prepare.outputs.version }}-windows_arm64.exe` - Windows ARM64
           
           ### Test Packages
-          - `taster-${{ needs.prepare.outputs.version }}-*.psp` - Comprehensive test suite
+          - `taster-${{ needs.prepare.outputs.version }}-*.psp` (`.exe` on Windows) - Comprehensive test suite
           
           ## 🔧 What's New
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,8 +238,8 @@ jobs:
           - `flavor-${{ needs.prepare.outputs.version }}-linux_arm64.psp` - Linux ARM64
           - `flavor-${{ needs.prepare.outputs.version }}-darwin_amd64.psp` - macOS Intel
           - `flavor-${{ needs.prepare.outputs.version }}-darwin_arm64.psp` - macOS Apple Silicon
-          - `flavor-${{ needs.prepare.outputs.version }}-windows_amd64.psp` - Windows x86_64
-          - `flavor-${{ needs.prepare.outputs.version }}-windows_arm64.psp` - Windows ARM64
+          - `flavor-${{ needs.prepare.outputs.version }}-windows_amd64.exe` - Windows x86_64
+          - `flavor-${{ needs.prepare.outputs.version }}-windows_arm64.exe` - Windows ARM64
           
           ### Test Packages
           - `taster-${{ needs.prepare.outputs.version }}-*.psp` - Comprehensive test suite

--- a/.github/workflows/taster-pipeline.yml
+++ b/.github/workflows/taster-pipeline.yml
@@ -194,9 +194,8 @@ jobs:
             "$LAUNCHER" \
             "${{ matrix.platform }}" \
             "${{ needs.setup.outputs.version }}"
-
-          # Export path for subsequent steps
-          echo "taster_path=$PWD/tests/taster/taster-${{ needs.setup.outputs.version }}-${{ matrix.platform }}.psp" >> $GITHUB_OUTPUT
+          # build-taster-with-psp.sh writes taster_path to $GITHUB_OUTPUT; it
+          # picks the extension, so it is the one that knows the name.
 
       - name: 🔍 Verify Built Package
         shell: bash

--- a/ci/build-taster-with-psp.sh
+++ b/ci/build-taster-with-psp.sh
@@ -28,6 +28,15 @@ echo "Testing Flavor PSP..."
 "${FLAVOR_PSP}" --version
 "${FLAVOR_PSP}" --help
 
+# Windows needs .exe for the binary to be directly runnable, the same rule
+# ci/build-flavor-self.sh applies. The two disagreed until v0.5.0, which is how
+# the Windows flavor packages ended up excluded from the release while the
+# taster ones shipped under a name Windows will not execute.
+EXT=".psp"
+if [[ "${PLATFORM}" == "windows_"* ]]; then
+  EXT=".exe"
+fi
+
 # Build Taster
 cd tests/taster
 
@@ -38,16 +47,23 @@ LAUNCHER_PATH="../../${LAUNCHER}"
 
 ../../"${FLAVOR_PSP}" pack \
   --manifest pyproject.toml \
-  --output "taster-${VERSION}-${PLATFORM}.psp" \
+  --output "taster-${VERSION}-${PLATFORM}${EXT}" \
   --launcher-bin "${LAUNCHER_PATH}" \
   --key-seed "taster-${VERSION}"
 
+TASTER_PATH="$PWD/taster-${VERSION}-${PLATFORM}${EXT}"
+
 # Make it executable
-chmod +x taster-*.psp
+chmod +x "${TASTER_PATH}"
 
 # Test the built Taster
 echo "Testing built Taster..."
-./taster-*.psp --version
+"${TASTER_PATH}" --version
 
-# Output the path
-echo "taster_path=$PWD/taster-${VERSION}-${PLATFORM}.psp"
+# This script owns the name, so it reports the path rather than leaving the
+# caller to rebuild it. Two places spelling one filename is what shipped a
+# release short two platforms.
+echo "taster_path=${TASTER_PATH}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "taster_path=${TASTER_PATH}" >> "${GITHUB_OUTPUT}"
+fi

--- a/ci/organize-release-packages.sh
+++ b/ci/organize-release-packages.sh
@@ -17,6 +17,9 @@ fi
 echo "📦 Organizing PSP packages for version $VERSION"
 mkdir -p "$OUTPUT_DIR"
 
+COLLECTED=0
+SKIPPED=0
+
 # Process each input directory
 for input_dir in "$@"; do
     if [ ! -d "$input_dir" ]; then
@@ -26,30 +29,53 @@ for input_dir in "$@"; do
     
     echo "  Processing: $input_dir"
     
-    # Find all PSP files in subdirectories
+    # Packages are named .psp, except a Windows flavor build, which is written
+    # .exe so the binary is directly runnable. Globbing *.psp alone silently
+    # dropped both Windows flavor packages from every release: they were built,
+    # downloaded, and then skipped by a loop that matched nothing and reported
+    # success anyway.
     for psp_subdir in "$input_dir"/*; do
         if [ -d "$psp_subdir" ]; then
-            for psp in "$psp_subdir"/*.psp; do
+            for psp in "$psp_subdir"/*.psp "$psp_subdir"/*.exe; do
                 if [ -f "$psp" ]; then
                     basename=$(basename "$psp")
-                    
+
                     # Replace version in filename (handles any semantic version)
                     new_name=$(echo "$basename" | sed "s/-[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^-]*\)\?-/-${VERSION}-/")
-                    
+
                     echo "    Copying: $basename -> $new_name"
                     cp "$psp" "$OUTPUT_DIR/$new_name"
                     chmod +x "$OUTPUT_DIR/$new_name"
+                    COLLECTED=$((COLLECTED + 1))
+                fi
+            done
+
+            # Anything left behind is a package that was built and shipped
+            # nowhere. Naming it is the difference between noticing a release
+            # is short two platforms and finding out from a user.
+            for other in "$psp_subdir"/*; do
+                case "$other" in
+                    *.psp | *.exe) continue ;;
+                esac
+                if [ -f "$other" ]; then
+                    echo "    ⚠️ Not a package, not collected: $(basename "$other")"
+                    SKIPPED=$((SKIPPED + 1))
                 fi
             done
         fi
     done
 done
 
-if [ -d "$OUTPUT_DIR" ] && [ "$(ls -A "$OUTPUT_DIR")" ]; then
+echo ""
+if [ "$COLLECTED" -eq 0 ]; then
+    echo "❌ No packages collected. The release would ship no binaries at all."
+    exit 1
+fi
+
+echo "✅ Collected $COLLECTED package(s) in $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR/"
+
+if [ "$SKIPPED" -gt 0 ]; then
     echo ""
-    echo "✅ Collected PSP packages in $OUTPUT_DIR:"
-    ls -la "$OUTPUT_DIR/"
-else
-    echo ""
-    echo "⚠️ No PSP packages collected"
+    echo "⚠️ $SKIPPED file(s) were present but not collected (listed above)."
 fi


### PR DESCRIPTION
v0.5.0 shipped **four** flavor packages and **six** taster packages. The two Windows flavor packages were built, uploaded, downloaded by the release job, and then discarded without a word.

## The mechanism

`organize-release-packages.sh` collected with:

```bash
for psp in "$psp_subdir"/*.psp; do
```

A Windows flavor build is written `.exe`, deliberately — `ci/build-flavor-self.sh`: *"Windows uses .exe so the binary is directly runnable."* The glob matched nothing for those two directories, the loop body never ran, and the script finished with:

```
✅ Collected PSP packages in release-psp:
```

**76 MB and 70 MB of correct, tested binaries, reported as a success.** From the v0.5.0 log — downloaded, then never copied:

```
Starting download of artifact to: flavor-psp/flavor-0.5.0-windows_amd64
Starting download of artifact to: flavor-psp/flavor-0.5.0-windows_arm64
...
    Copying: flavor-0.5.0-linux_amd64.psp   -> ...
    Copying: taster-0.5.0-windows_amd64.psp -> ...   ← taster Windows made it
✅ Collected PSP packages in release-psp:
```

## Why it stayed hidden

`ci/build-taster-with-psp.sh` wrote `.psp` on **every** platform. So taster kept appearing in releases and the gap read as a flavor-specific problem, rather than two scripts disagreeing about one convention.

It was also wrong on its own terms: `taster-0.5.0-windows_amd64.psp` is a file Windows will not execute. `ci/build-flavor-self.sh` uses `.exe`, and `pretaster-pipeline.yml` does it twice — the convention was established repo-wide and only taster diverged.

## And the notes promised the missing files

Published v0.5.0 notes tell users to download `flavor-0.5.0-windows_amd64.psp` and `...arm64.psp`. Neither can exist.

## Changes

**Collection**
- Collect `.exe` as well as `.psp`
- **Name every uncollected file** — a release short two platforms belongs in the log, not a user's bug report
- **Exit non-zero when nothing is collected.** The old tail printed `⚠️ No PSP packages collected` and *returned success*, so a release shipping no binaries would still have been cut

**Naming**
- taster uses `.exe` on Windows, matching flavor and pretaster
- The build script picks the extension and reports the path via `$GITHUB_OUTPUT`. `taster-pipeline.yml` had been rebuilding the same filename itself, so the name lived in two places that could drift — the workflow reads it now

**Docs**
- Release notes name `.exe` for Windows

The upload step already listed both extensions, and `flavor-pipeline.yml` already globbed both for taster — the rest of the pipeline was waiting for a build that produced one.

## Verification

Reconstructed the exact failure — one linux `.psp`, two windows `.exe`, one taster `.psp`, plus a stray `build.log`:

```
    Copying: flavor-0.5.0-linux_amd64.psp -> flavor-0.5.0-linux_amd64.psp
    ⚠️ Not a package, not collected: build.log
    Copying: flavor-0.5.0-windows_amd64.exe -> flavor-0.5.0-windows_amd64.exe
    Copying: flavor-0.5.0-windows_arm64.exe -> flavor-0.5.0-windows_arm64.exe
    Copying: taster-0.5.0-windows_amd64.psp -> taster-0.5.0-windows_amd64.psp
✅ Collected 4 package(s) in out:
⚠️ 1 file(s) were present but not collected (listed above).
```

Empty tree exits **1**.

## On v0.5.0

Already published and short two binaries. Windows users can `pip install flavorpack` — the wheels are on PyPI and fine — but cannot download a standalone `flavor` executable. The artifacts still exist in the pipeline run and can be attached to the existing release without recutting it.