### PR TITLE
Upgrade provide-telemetry to v0.9.0

### DIFF
--- a/src/flavor-go/go.mod
+++ b/src/flavor-go/go.mod
@@ -9,9 +9,14 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/provide-io/provide-telemetry/go v0.7.0
+	github.com/provide-io/provide-telemetry/go v0.9.0
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/image v0.45.0 // indirect
 )

--- a/src/flavor-go/go.sum
+++ b/src/flavor-go/go.sum
@@ -1,10 +1,16 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/provide-io/provide-telemetry/go v0.7.0 h1:6ZvCxib/6+EjfR6WNTq2+rgAuXam4RS1Gh8S5CEMhyE=
 github.com/provide-io/provide-telemetry/go v0.7.0/go.mod h1:oswZtj04QnU7STnGyF2iNLxODzpzTa8yKFZAVwXNlfI=
+github.com/provide-io/provide-telemetry/go v0.9.0 h1:jS8FFNnB1XSUIJPoftHgyBGX1K3mnzIw+qWWm4pr81s=
+github.com/provide-io/provide-telemetry/go v0.9.0/go.mod h1:oswZtj04QnU7STnGyF2iNLxODzpzTa8yKFZAVwXNlfI=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/src/flavor-go/pkg/logging/logger.go
+++ b/src/flavor-go/pkg/logging/logger.go
@@ -8,51 +8,86 @@ import (
 	"strings"
 
 	"github.com/provide-io/flavor/go/flavor/pkg/envvars"
-	provlog "github.com/provide-io/provide-telemetry/go/logger"
+	telemetry "github.com/provide-io/provide-telemetry/go"
 )
+
+// LevelTrace is re-exported for callers that need trace-level logging.
+const LevelTrace = telemetry.LevelTrace
 
 // Setup initialises the logger from flavorpack env vars.
 // Must be called once at process startup before any logging.
 // If output is non-nil, log records are written there instead of os.Stderr.
+//
+// The writer is what keeps launcher output legible when several language
+// runtimes share one stream: the caller wraps it to prefix every line, and the
+// Go and Rust launchers are told apart by 🐹 and 🦀.
 func Setup(logLevel string, output io.Writer) {
-	format := provlog.LogFormatConsole
+	format := "console"
 	if IsJSONFormat(logLevel) {
-		format = provlog.LogFormatJSON
+		format = "json"
 	}
-	// Strip the "json:" prefix from the level string if present.
-	actualLevel := logLevel
-	if strings.HasPrefix(logLevel, "json:") {
-		actualLevel = logLevel[len("json:"):]
-	} else if logLevel == "json" {
-		actualLevel = "info"
+
+	cfg := telemetry.DefaultTelemetryConfig()
+	cfg.ServiceName = "flavor-go"
+	cfg.Logging.Level = strings.ToUpper(stripJSONPrefix(logLevel))
+	cfg.Logging.Format = format
+
+	opts := []telemetry.SetupOption{telemetry.WithConfig(cfg)}
+	if output != nil {
+		opts = append(opts, telemetry.WithLogOutput(output))
 	}
-	provlog.Configure(provlog.LogConfig{
-		ServiceName: "flavor-go",
-		Level:       strings.ToUpper(actualLevel),
-		Format:      format,
-		Output:      output,
-	})
+
+	// SetupTelemetry runs once per process: a second call returns the first
+	// config unchanged, so a later Setup would silently keep the first level and
+	// the first writer. ReconfigureTelemetry does not help -- it applies the
+	// config but ignores WithLogOutput. Shutting down first is what makes a
+	// repeat Setup mean what it says; it no-ops when nothing is set up yet.
+	_ = telemetry.ShutdownTelemetry(context.Background())
+
+	// A telemetry setup that fails should not stop a package from running: the
+	// launcher's job is to run the payload, and losing logs is not a reason to
+	// refuse. The error is reported through the logger that setup leaves behind.
+	if _, err := telemetry.SetupTelemetry(opts...); err != nil {
+		telemetry.GetLogger(context.Background(), "flavor-go.logging").
+			Warn("⚠️ Telemetry setup failed; continuing with defaults", "error", err)
+	}
 }
 
-// NewLogger returns a named *slog.Logger via provide-telemetry/go/logger.
+// stripJSONPrefix removes the transport prefix from a level string, leaving the
+// severity. Bare "json" names no severity and means info.
+func stripJSONPrefix(logLevel string) string {
+	if after, found := strings.CutPrefix(logLevel, "json:"); found {
+		return after
+	}
+	if logLevel == "json" {
+		return "info"
+	}
+	return logLevel
+}
+
+// NewLogger returns a named *slog.Logger via provide-telemetry.
 func NewLogger(ctx context.Context, name string) *slog.Logger {
-	return provlog.GetLogger(ctx, name)
+	return telemetry.GetLogger(ctx, name)
 }
 
 // NewDefaultLogger returns a named *slog.Logger using the current active configuration,
 // evaluated at call time. Use for package-level loggers where no context is available.
 func NewDefaultLogger(name string) *slog.Logger {
-	return provlog.GetDefaultLogger(name)
+	return telemetry.GetLogger(context.Background(), name)
 }
 
 // NewNullLogger returns a *slog.Logger that discards all output (for tests).
+//
+// provide-telemetry removed its own null and buffer loggers in 0.8.0 with no
+// replacement. Both are a handler over a writer, so flavorpack keeps its own
+// rather than holding the dependency back for two test helpers.
 func NewNullLogger() *slog.Logger {
-	return provlog.NewNullLogger()
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: LevelTrace}))
 }
 
 // NewBufferLogger returns a *slog.Logger that writes to w at the given level (for tests).
 func NewBufferLogger(w io.Writer, level slog.Level) *slog.Logger {
-	return provlog.NewBufferLogger(w, level)
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
 }
 
 // IsJSONFormat reports whether the given logLevel string (or the FLAVOR_JSON_LOG
@@ -71,15 +106,15 @@ func GetLogLevel() string {
 	return level
 }
 
-// LevelTrace is re-exported for callers that need trace-level logging.
-const LevelTrace = provlog.LevelTrace
-
 // Trace emits a TRACE-level record on logger.
+//
+// provide-telemetry's own Trace is a tracing-span helper in 0.9.0 and does not
+// emit a log record, so this writes one directly at LevelTrace.
 func Trace(logger *slog.Logger, msg string, args ...any) {
-	provlog.Trace(logger, msg, args...)
+	logger.Log(context.Background(), LevelTrace, msg, args...)
 }
 
 // IsEnabled reports whether logger would emit records at level.
 func IsEnabled(logger *slog.Logger, level slog.Level) bool {
-	return provlog.IsEnabled(logger, level)
+	return logger.Enabled(context.Background(), level)
 }

--- a/src/flavor-go/pkg/logging/telemetry_writer_test.go
+++ b/src/flavor-go/pkg/logging/telemetry_writer_test.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// The launcher prefix is why provide-telemetry 0.8.x was backed out: with no
+// writer hook the launcher cannot mark its own lines, and Go and Rust output
+// becomes indistinguishable when both share one stream. 0.9.0 restored
+// WithLogOutput, so this pins that the prefix reaches the records.
+func TestPrefixSurvivesTelemetrySetup(t *testing.T) {
+	var buf bytes.Buffer
+	Setup("debug", NewPrefixWriter("🐹 ", &buf))
+
+	NewLogger(context.Background(), "smoke").Info("hello from the launcher")
+
+	out := buf.String()
+	if !strings.Contains(out, "🐹 ") {
+		t.Fatalf("prefix missing from telemetry output: %q", out)
+	}
+	if !strings.Contains(out, "hello from the launcher") {
+		t.Fatalf("message missing from telemetry output: %q", out)
+	}
+	t.Logf("output: %s", strings.TrimSpace(out))
+}


### PR DESCRIPTION
flavorpack was held at `provide-telemetry/go v0.7.0`. The v0.8.1 upgrade was backed out because the root package wrote only to `os.Stderr`, and the launcher needs a writer: Go and Rust output share one stream in the pretaster matrix, and the `🐹` / `🦀` prefixes are what tell them apart. Filed upstream as provide-telemetry#53, now closed.

## The blocker is gone

v0.9.0 adds `WithLogOutput(w io.Writer)`, and its release notes name this exact case:

> This is the surface a host needs to wrap the SDK's log stream: **to prefix it when several language runtimes share one stream**, to tee it, or to drop it with `io.Discard`.

`telemetry_writer_test.go` pins it, because losing the prefix is the failure that held this upgrade back for two versions:

```
🐹 time=... level=INFO message="hello from the launcher" logger_name=smoke service.name=flavor-go
```

## Migration

The `go/logger` subpackage is gone, so `pkg/logging` moves to the root package. Everything outside `pkg/logging` already went through that wrapper, so this is **one 85-line file**.

Six names #53 also flagged were **not** restored, and are now local:

| Was | Now |
|---|---|
| `NewNullLogger`, `NewBufferLogger` | local — a handler over a writer |
| `IsEnabled` | `logger.Enabled` |
| `Configure` / `LogConfig` | `SetupTelemetry(WithConfig(...))` |
| `GetDefaultLogger` | `GetLogger` with a background context |

Keeping the dependency two versions behind for two test helpers is the worse trade.

**`Trace` needed care rather than translation.** v0.9.0 exports `Trace` as a *tracing-span helper* with an entirely different signature, and it emits no log record:

```go
func Trace(ctx context.Context, name string, fn func(context.Context) error) error   // v0.9.0
provlog.Trace(logger, msg, args...)                                                  // what this called
```

`logging.Trace` now writes a record directly at `LevelTrace`.

## One behaviour change worth naming

`SetupTelemetry` runs **once per process** and returns the first config on every later call, where `provlog.Configure` reconfigured each time. A second `Setup` would therefore have silently kept the first level *and* the first writer.

`TestBuilderBuildWithLogLevelWritesExpectedLogs` caught it — its later subtests read empty log files. `ReconfigureTelemetry` does not close the gap: it applies the config and **ignores `WithLogOutput`**. `Setup` now shuts down first, which no-ops when nothing is configured yet and makes a repeat `Setup` mean what it says.

## Does not unblock #26

The Rust crate at 0.9.0 has no writer equivalent. `logger/emit.rs` emits with bare `eprintln!` at lines 121, 164 and 179, and `setup_telemetry(config: Option<TelemetryConfig>)` takes a config and nothing else. Adopting it in `flavor-rs` today drops the `🦀 ` prefix — the precise failure #26 said to check for before starting. Recorded on that issue.

## Verification

- Full Go suite, `-count=1`, 8 packages — all pass
- `go vet`, `golangci-lint`, `staticcheck` — clean
- The prefix test fails if the writer is ever ignored again