### PR TITLE
Lint and test the release pipeline's shell scripts

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,6 +29,11 @@ on:
       - 'src/flavor-rs/Cargo.toml'
       - 'src/flavor-rs/fuzz/Cargo.toml'
       - '.github/workflows/code-quality.yml'
+      # The release pipeline is shell. Editing it used to trigger no check at
+      # all: every workflow listed only its own YAML, so a PR touching ci/ and
+      # another workflow ran zero jobs.
+      - 'ci/**'
+      - '.github/workflows/**'
   
   schedule:
     # Run daily at 2 AM UTC
@@ -154,9 +159,35 @@ jobs:
           if-no-files-found: ignore
 
   # Aggregate Quality Report
+  # ShellCheck over the release pipeline. ci/ is ~50 scripts that nothing
+  # linted until v0.5.0 shipped without its Windows binaries.
+  shell-quality:
+    name: 🐚 Shell Quality
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # ubuntu-24.04 ships shellcheck; install only if that changes.
+      - name: 📦 Ensure ShellCheck
+        run: command -v shellcheck || sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: 🔍 Shell Quality Checks
+        run: ci/quality-checks.sh shell
+
+      - name: 📤 Upload Shell Reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shell-quality-reports
+          path: quality-logs/
+          if-no-files-found: ignore
+
   quality-report:
     name: 📊 Quality Report
-    needs: [python-quality, go-quality, rust-quality]
+    needs: [python-quality, go-quality, rust-quality, shell-quality]
     if: always()
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,6 +41,10 @@ on:
       - 'src/flavor-rs/Cargo.toml'
       - 'src/flavor-rs/Cargo.lock'
       - 'src/flavor-rs/Makefile'
+      # tests/ci/ covers the release pipeline's shell scripts; without this the
+      # tests exist and never run on a PR that changes what they cover.
+      - 'ci/**'
+      - 'tests/ci/**'
       # Fixtures are inputs to the suites, so a change to one has to re-run them.
       - 'tests/**'
       - 'ci/pr-tests.sh'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,6 +125,17 @@ repos:
         files: ^src/flavor-rs/
         stages: [pre-push]
 
+      # ── Shell ──────────────────────────────────────────────────────────
+      # ci/ is ~50 scripts that are the release pipeline. Nothing linted them
+      # until v0.5.0 shipped short two platforms, and the bug that did it was
+      # valid shell -- so this is a floor, not a substitute for tests/ci/.
+      - id: shellcheck
+        name: shellcheck
+        entry: shellcheck --severity=warning
+        language: system
+        files: \.sh$
+        stages: [pre-commit, pre-push]
+
       # ── Cross-language ─────────────────────────────────────────────────
       - id: version-sync
         name: version sync check

--- a/ci/freebsd-build-rust.sh
+++ b/ci/freebsd-build-rust.sh
@@ -17,8 +17,9 @@ esac
 
 HOST_ARCH=$(uname -m)
 if [ "$HOST_ARCH" = "amd64" ]; then
-  export RUSTUP_HOME="$(pwd)/vm-rust-home/rustup"
-  export CARGO_HOME="$(pwd)/vm-rust-home/cargo"
+  VM_RUST_HOME="$(pwd)/vm-rust-home"
+  export RUSTUP_HOME="${VM_RUST_HOME}/rustup"
+  export CARGO_HOME="${VM_RUST_HOME}/cargo"
   export PATH="$CARGO_HOME/bin:$PATH"
 fi
 

--- a/ci/freebsd-prep-rust.sh
+++ b/ci/freebsd-prep-rust.sh
@@ -9,8 +9,9 @@ HOST_ARCH=$(uname -m)
 
 if [ "$HOST_ARCH" = "amd64" ]; then
   # x86_64 FreeBSD: rustup has a host binary — install into working dir so it can be cached.
-  export RUSTUP_HOME="$(pwd)/vm-rust-home/rustup"
-  export CARGO_HOME="$(pwd)/vm-rust-home/cargo"
+  VM_RUST_HOME="$(pwd)/vm-rust-home"
+  export RUSTUP_HOME="${VM_RUST_HOME}/rustup"
+  export CARGO_HOME="${VM_RUST_HOME}/cargo"
 
   if [ -x "$CARGO_HOME/bin/rustc" ]; then
     echo "📦 Rust toolchain already cached — skipping install"

--- a/ci/organize-release-packages.sh
+++ b/ci/organize-release-packages.sh
@@ -40,8 +40,12 @@ for input_dir in "$@"; do
                 if [ -f "$psp" ]; then
                     basename=$(basename "$psp")
 
-                    # Replace version in filename (handles any semantic version)
-                    new_name=$(echo "$basename" | sed "s/-[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^-]*\)\?-/-${VERSION}-/")
+                    # Replace version in filename (handles any semantic version).
+                    # -E because \+ and \? are GNU extensions to basic regex: on
+                    # BSD sed the expression matched nothing and the rename was
+                    # silently skipped. The release job runs on Linux, so this
+                    # only ever failed for someone running the script locally.
+                    new_name=$(echo "$basename" | sed -E "s/-[0-9]+\.[0-9]+\.[0-9]+(-[^-]*)?-/-${VERSION}-/")
 
                     echo "    Copying: $basename -> $new_name"
                     cp "$psp" "$OUTPUT_DIR/$new_name"

--- a/ci/pr-tests.sh
+++ b/ci/pr-tests.sh
@@ -20,7 +20,10 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 FAILED=0
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$REPO_ROOT"
+# set -e is deliberately not enabled here (checks are meant to run to
+# completion), so a failed cd would otherwise run every suite from whatever
+# directory the runner happened to be in.
+cd "$REPO_ROOT" || exit 1
 
 LOG_DIR="${PR_TESTS_LOG_DIR:-$REPO_ROOT/test-logs}"
 mkdir -p "$LOG_DIR"

--- a/ci/quality-checks.sh
+++ b/ci/quality-checks.sh
@@ -121,6 +121,14 @@ case "$LANGUAGE" in
     check blocking "Rustfmt"      cargo fmt -- --check
     check blocking "Cargo machete" cargo machete
     ;;
+  shell)
+    say "## 🐚 Shell Code Quality"
+    say ""
+    # The release pipeline is ~50 shell scripts. Nothing linted them until
+    # v0.5.0 shipped short two platforms. warning is what the tree holds today;
+    # info and style still report 22 findings between them.
+    check blocking "ShellCheck" shellcheck --severity=warning ci/*.sh
+    ;;
   *)
     echo "❌ Unknown language: $LANGUAGE" >&2
     exit 2

--- a/ci/run-pretaster-tests.sh
+++ b/ci/run-pretaster-tests.sh
@@ -17,6 +17,7 @@ if [[ "$(uname -s)" == "FreeBSD" ]]; then
     exit 1
   fi
 else
+  # shellcheck disable=SC2209  # the command name, not its output
   MAKE_CMD=make
   MAKE_SHELL=""
 fi
@@ -97,7 +98,8 @@ fi
 cd tests/pretaster
 
 # Set workenv base for builders to resolve {workenv} placeholders
-export FLAVOR_WORKENV_BASE="$(pwd)"
+FLAVOR_WORKENV_BASE="$(pwd)"
+export FLAVOR_WORKENV_BASE
 echo "📁 Setting FLAVOR_WORKENV_BASE=$FLAVOR_WORKENV_BASE"
 echo "📂 Current directory: $(pwd)"
 echo "📂 Contents of scripts directory:"

--- a/ci/test-binaries.sh
+++ b/ci/test-binaries.sh
@@ -57,7 +57,8 @@ determine_test_mode() {
 test_binary() {
     local binary="$1"
     local mode="$2"
-    local binary_name=$(basename "$binary")
+    local binary_name
+    binary_name=$(basename "$binary")
 
     local passed=true
     local size version help_check cli_mode format_info
@@ -118,7 +119,8 @@ PYJSON
         format-only|*)
             # Check binary format
             if command -v file >/dev/null 2>&1; then
-                local file_info=$(file "$binary" 2>&1)
+                local file_info
+                file_info=$(file "$binary" 2>&1)
                 if echo "$file_info" | grep -qE "executable|ELF|Mach-O|PE32"; then
                     format_info="valid"
 

--- a/tests/ci/test_organize_release_packages.py
+++ b/tests/ci/test_organize_release_packages.py
@@ -1,0 +1,139 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/organize-release-packages.sh.
+
+v0.5.0 shipped without its two Windows flavor packages. They were built,
+uploaded as artifacts, downloaded by the release job, and then dropped by a
+loop that globbed ``*.psp`` while a Windows flavor build is written ``.exe``.
+The loop body never ran, and the script reported success.
+
+Nothing tested this script, and nothing still would: no PR check matches
+``ci/**``. These tests are what stands between that shape and another release
+that is quietly short a platform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "organize-release-packages.sh"
+VERSION = "9.9.9"
+
+
+def _artifact(root: Path, subdir: str, filename: str) -> Path:
+    """Write one downloaded artifact, in the layout the release job produces."""
+    path = root / subdir / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"not a real package")
+    return path
+
+
+def _run(tmp_path: Path, *input_dirs: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "out", VERSION, *input_dirs],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_collects_windows_exe_packages(tmp_path: Path) -> None:
+    """A Windows flavor package is named .exe and still belongs in the release.
+
+    This is the v0.5.0 failure exactly: with the old ``*.psp`` glob both files
+    are skipped and the script still exits 0.
+    """
+    _artifact(tmp_path / "flavor-psp", f"flavor-{VERSION}-linux_amd64", f"flavor-{VERSION}-linux_amd64.psp")
+    _artifact(
+        tmp_path / "flavor-psp", f"flavor-{VERSION}-windows_amd64", f"flavor-{VERSION}-windows_amd64.exe"
+    )
+    _artifact(
+        tmp_path / "flavor-psp", f"flavor-{VERSION}-windows_arm64", f"flavor-{VERSION}-windows_arm64.exe"
+    )
+
+    result = _run(tmp_path, "flavor-psp")
+
+    assert result.returncode == 0, result.stderr
+    collected = sorted(p.name for p in (tmp_path / "out").iterdir())
+    assert collected == [
+        f"flavor-{VERSION}-linux_amd64.psp",
+        f"flavor-{VERSION}-windows_amd64.exe",
+        f"flavor-{VERSION}-windows_arm64.exe",
+    ], f"a platform was dropped: {collected}"
+
+
+def test_collects_from_several_input_directories(tmp_path: Path) -> None:
+    """flavor and taster arrive as separate downloads and merge into one set."""
+    _artifact(tmp_path / "flavor-psp", f"flavor-{VERSION}-linux_amd64", f"flavor-{VERSION}-linux_amd64.psp")
+    _artifact(
+        tmp_path / "taster-psp", f"taster-{VERSION}-windows_amd64", f"taster-{VERSION}-windows_amd64.exe"
+    )
+
+    result = _run(tmp_path, "flavor-psp", "taster-psp")
+
+    assert result.returncode == 0, result.stderr
+    assert sorted(p.name for p in (tmp_path / "out").iterdir()) == [
+        f"flavor-{VERSION}-linux_amd64.psp",
+        f"taster-{VERSION}-windows_amd64.exe",
+    ]
+
+
+def test_uncollected_files_are_named(tmp_path: Path) -> None:
+    """Anything left behind is reported, so a shortfall is visible in the log.
+
+    The v0.5.0 run printed only what it copied, so two missing platforms looked
+    exactly like a complete release.
+    """
+    _artifact(tmp_path / "flavor-psp", f"flavor-{VERSION}-linux_amd64", f"flavor-{VERSION}-linux_amd64.psp")
+    _artifact(tmp_path / "flavor-psp", f"flavor-{VERSION}-linux_amd64", "build.log")
+
+    result = _run(tmp_path, "flavor-psp")
+
+    assert result.returncode == 0, result.stderr
+    assert "build.log" in result.stdout, f"an uncollected file was not named: {result.stdout}"
+
+
+def test_collecting_nothing_fails(tmp_path: Path) -> None:
+    """A release that would ship no binaries must not be cut.
+
+    The previous version printed "⚠️ No PSP packages collected" and returned
+    success, so this case would have produced an empty release.
+    """
+    (tmp_path / "flavor-psp" / "empty").mkdir(parents=True)
+
+    result = _run(tmp_path, "flavor-psp")
+
+    assert result.returncode != 0, f"collecting nothing reported success: {result.stdout}"
+    assert "No packages collected" in result.stdout
+
+
+def test_version_in_filename_is_rewritten(tmp_path: Path) -> None:
+    """Artifacts built at the pipeline's version are renamed to the release's."""
+    _artifact(tmp_path / "flavor-psp", "flavor-0.0.1-linux_amd64", "flavor-0.0.1-linux_amd64.psp")
+
+    result = _run(tmp_path, "flavor-psp")
+
+    assert result.returncode == 0, result.stderr
+    assert [p.name for p in (tmp_path / "out").iterdir()] == [f"flavor-{VERSION}-linux_amd64.psp"]
+
+
+def test_missing_input_directory_is_skipped_not_fatal(tmp_path: Path) -> None:
+    """A pipeline that produced no taster packages should not stop the release."""
+    _artifact(tmp_path / "flavor-psp", f"flavor-{VERSION}-linux_amd64", f"flavor-{VERSION}-linux_amd64.psp")
+
+    result = _run(tmp_path, "flavor-psp", "taster-psp")
+
+    assert result.returncode == 0, result.stderr
+    assert "taster-psp" in result.stdout
+
+
+# 🌶️📦🔚


### PR DESCRIPTION
`ci/` is ~50 shell scripts, invoked 50 times across the workflows. **They are the release pipeline.** Nothing linted them, no test asserted anything about them, and editing them triggered no PR check.

PR #65 demonstrated the last part: it changed two workflows and two `ci/` scripts and ran **zero jobs**. Every workflow's `paths` filter listed its own YAML and source files only.

That is the shape that shipped v0.5.0 without its Windows binaries.

## Tests for the script that dropped them

`tests/ci/test_organize_release_packages.py` — six tests. Reverting the fix to the old `*.psp` glob **fails two of them**, so they cover the actual defect rather than its neighbourhood:

```
FAILED test_collects_windows_exe_packages - AssertionError: a platform was dropped: ['flavor-9.9.9-linux_amd64.psp']
FAILED test_collects_from_several_input_directories
```

They also pin the parts that made it invisible: uncollected files must be **named**, and collecting nothing must **exit non-zero** rather than print a warning and return success.

## Writing them found a second bug

The version rewrite used `\+` and `\?` — GNU extensions to basic regex. On BSD sed the expression matches nothing and the rename is **silently skipped**:

```
$ echo "flavor-0.0.1-linux_amd64.psp" | sed "s/-[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^-]*\)\?-/-9.9.9-/"
flavor-0.0.1-linux_amd64.psp     ← unchanged
$ echo "flavor-0.0.1-linux_amd64.psp" | sed -E "s/-[0-9]+\.[0-9]+\.[0-9]+(-[^-]*)?-/-9.9.9-/"
flavor-9.9.9-linux_amd64.psp
```

The release job runs on Linux, so this only ever failed for someone running the script locally — which is why it survived.

## ShellCheck, in pre-commit and as a blocking check

At `--severity=warning`, which is what the tree holds today; info and style still report 22 findings between them.

Nine warnings had to be fixed first, and **one was real**: `ci/pr-tests.sh` runs `set -uo pipefail` with **no `-e`**, so a failed `cd "$REPO_ROOT"` would have run every suite from whatever directory the runner happened to be in. The rest were SC2155 assignments masking exit status, plus one genuine false positive (`MAKE_CMD=make` assigns a command *name*, not its output) which carries a directive.

## Both guards checked against a failure

Not assumed:

- Tests fail on the old glob (above)
- Shell gate exits **1** on a script with a warning-level finding, **0** once removed

## Path filters

- `code-quality` now runs on `ci/**` and `.github/workflows/**`
- `pr-tests` now runs on `ci/**` and `tests/ci/**`

Without the second, the new tests would exist and never run on a PR that changes what they cover — the same failure in a new place.

## What this does not do

ShellCheck would **not** have caught the `*.psp` glob. That was valid shell doing the wrong thing, and only a test finds those. It is a floor, not a substitute.

## Verification

- All four quality gates pass (python, go, rust, **shell**)
- Full Python suite: **2795 passed**