### PR TITLE
Cover the rest of the release pipeline's scripts

### DIFF
--- a/ci/organize-release-wheels.sh
+++ b/ci/organize-release-wheels.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 
 INPUT_DIR="${1:-wheels}"
 OUTPUT_DIR="${2:-release-wheels}"
-VERSION="${3}"
+# Not "${3}": set -u would abort on an unset argument before the check below
+# could explain what was missing.
+VERSION="${3:-}"
 
 if [ -z "$VERSION" ]; then
     echo "❌ Error: Version is required"
@@ -15,31 +17,55 @@ if [ -z "$VERSION" ]; then
 fi
 
 echo "📦 Organizing wheels for version $VERSION"
+
+if [ ! -d "$INPUT_DIR" ]; then
+    echo "❌ Input directory not found: $INPUT_DIR"
+    echo "   The download step produced nothing, so the release would ship no wheels."
+    exit 1
+fi
+
 mkdir -p "$OUTPUT_DIR"
 
-# Find all wheel files and rename them with the release version
+COLLECTED=0
+
+# Find all wheel files and copy them for the release.
 for wheel_dir in "$INPUT_DIR"/flavor-wheel-*; do
     if [ -d "$wheel_dir" ]; then
-        platform=$(basename "$wheel_dir" | sed 's/flavor-wheel-[0-9.]*-//')
+        platform=$(basename "$wheel_dir" | sed -E 's/flavor-wheel-[0-9.]*-//')
         echo "  Processing platform: $platform"
-        
+
+        platform_wheels=0
         for wheel in "$wheel_dir"/*.whl; do
             if [ -f "$wheel" ]; then
-                # Extract wheel filename
+                # Not renamed: PEP 440 normalises versions (0.0.2-dev1 becomes
+                # 0.0.2.dev1) and the wheels already carry the normalised name.
+                # Rewriting it here would produce a filename pip rejects.
                 basename=$(basename "$wheel")
-                
-                # Don't rename - wheels already have correct normalized version
-                # PEP 440 normalizes versions like 0.0.2-dev1 to 0.0.2.dev1
-                # The wheels are already correctly named, just copy them
-                new_name="$basename"
-                
+
                 echo "    Copying: $basename"
-                cp "$wheel" "$OUTPUT_DIR/$new_name"
+                cp "$wheel" "$OUTPUT_DIR/$basename"
+                platform_wheels=$((platform_wheels + 1))
+                COLLECTED=$((COLLECTED + 1))
             fi
         done
+
+        # An artifact directory exists only because its build uploaded one, so
+        # an empty one means that build produced no wheel and the release would
+        # be short a platform without saying so.
+        if [ "$platform_wheels" -eq 0 ]; then
+            echo "❌ No wheel in $wheel_dir — platform $platform built nothing"
+            exit 1
+        fi
     fi
 done
 
 echo ""
-echo "✅ Collected wheels in $OUTPUT_DIR:"
+if [ "$COLLECTED" -eq 0 ]; then
+    echo "❌ No wheels collected from $INPUT_DIR."
+    echo "   PyPI publishing consumes this directory, so the release would ship"
+    echo "   nothing installable."
+    exit 1
+fi
+
+echo "✅ Collected $COLLECTED wheel(s) in $OUTPUT_DIR:"
 ls -la "$OUTPUT_DIR/"

--- a/tests/ci/test_create_release_tag.py
+++ b/tests/ci/test_create_release_tag.py
@@ -1,0 +1,148 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/create-release-tag.sh.
+
+The only release script that writes. It stamps VERSION, commits, and creates
+the annotated tag a published release and every downloaded artifact points at.
+
+`gh` is stubbed and records what it was asked to do, so the tests can assert on
+the calls without creating anything.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "create-release-tag.sh"
+
+
+def _stub_gh(tmp_path: Path, *, existing_tag_sha: str | None) -> tuple[Path, Path]:
+    """A `gh` that reports whether the tag exists and logs every call."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    calls = tmp_path / "gh-calls.log"
+
+    if existing_tag_sha is None:
+        lookup = "exit 1"  # no such tag
+    else:
+        lookup = f'printf \'{{"object":{{"sha":"{existing_tag_sha}"}}}}\\n\'; exit 0'
+
+    (bindir / "gh").write_text(
+        "#!/bin/bash\n"
+        f'echo "$*" >> "{calls}"\n'
+        'case "$*" in\n'
+        f"  *git/refs/tags/*) {lookup} ;;\n"
+        '  *git/tags*) printf \'{"sha":"newtagobj"}\\n\' ;;\n'
+        "  *git/refs*) printf '{}\\n' ;;\n"
+        "esac\n"
+        "exit 0\n"
+    )
+    (bindir / "gh").chmod(0o755)
+    return bindir, calls
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "t"],
+        ["git", "commit", "-q", "--allow-empty", "-m", "first"],
+    ):
+        subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+    (repo / "VERSION").write_text("0.0.1\n")
+    return repo
+
+
+def _run(repo: Path, bindir: Path, version: str = "9.9.9") -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "GITHUB_REPOSITORY": "provide-io/flavorpack",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), version, f"v{version}"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_stamps_version_and_creates_the_tag(tmp_path: Path) -> None:
+    """VERSION is written and committed, then the tag is created at that commit."""
+    repo = _repo(tmp_path)
+    bindir, calls = _stub_gh(tmp_path, existing_tag_sha=None)
+
+    result = _run(repo, bindir)
+
+    assert result.returncode == 0, result.stderr
+    assert (repo / "VERSION").read_text().strip() == "9.9.9"
+
+    log = calls.read_text()
+    assert "git/tags" in log, "no annotated tag object was created"
+    assert "refs/tags/v9.9.9" in log
+
+
+def test_existing_tag_at_the_same_commit_is_accepted(tmp_path: Path) -> None:
+    """Re-running a release must not fail once the tag already points at HEAD."""
+    repo = _repo(tmp_path)
+
+    # Stamp and commit first so HEAD is the commit the tag would point at.
+    (repo / "VERSION").write_text("9.9.9\n")
+    subprocess.run(["git", "add", "VERSION"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "🚀 Release v9.9.9"], cwd=repo, check=True, capture_output=True
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    bindir, _ = _stub_gh(tmp_path, existing_tag_sha=head)
+
+    result = _run(repo, bindir)
+
+    assert result.returncode == 0, f"a re-run over an identical tag failed: {result.stdout}{result.stderr}"
+    assert "already exists" in result.stdout
+
+
+def test_existing_tag_at_a_different_commit_is_refused(tmp_path: Path) -> None:
+    """Moving a released tag would orphan every artifact already published."""
+    repo = _repo(tmp_path)
+    bindir, _ = _stub_gh(tmp_path, existing_tag_sha="0" * 40)
+
+    result = _run(repo, bindir)
+
+    assert result.returncode != 0, f"the tag was allowed to move: {result.stdout}"
+    assert "different commit" in result.stdout
+
+
+def test_arguments_are_required(tmp_path: Path) -> None:
+    """Both the version and the tag name have to be supplied."""
+    repo = _repo(tmp_path)
+    bindir, _ = _stub_gh(tmp_path, existing_tag_sha=None)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "GITHUB_REPOSITORY": "provide-io/flavorpack",
+    }
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], cwd=repo, capture_output=True, text=True, check=False, env=env
+    )
+
+    assert result.returncode != 0
+
+
+# 🌶️📦🔚

--- a/tests/ci/test_get_release_runs.py
+++ b/tests/ci/test_get_release_runs.py
@@ -1,0 +1,163 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/get-release-runs.sh.
+
+This script decides which pipeline runs a release takes its artifacts from.
+Everything the release publishes comes from the two run IDs it returns, so a
+wrong answer here ships the wrong binaries under the right version number.
+
+`gh` is stubbed: the script's logic is the subject, not GitHub.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import textwrap
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "get-release-runs.sh"
+VERSION = "9.9.9"
+
+
+def _stub_gh(tmp_path: Path, runs: dict[str, list[str]], artifacts: dict[str, list[str]]) -> Path:
+    """A `gh` that answers from fixtures.
+
+    `gh run list` yields run IDs per workflow; `gh api .../artifacts` yields
+    artifact names per run.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "gh"
+
+    newline = "\\n"
+
+    def _emit(values: list[str]) -> str:
+        return " ".join(values) if values else "''"
+
+    run_cases = "\n".join(
+        f'      *{workflow}*) printf "%s{newline}" {_emit(ids)} ;;' for workflow, ids in runs.items()
+    )
+    art_cases = "\n".join(
+        f'      *runs/{run_id}/artifacts*) printf "%s{newline}" {_emit(names)} ;;'
+        for run_id, names in artifacts.items()
+    )
+
+    stub.write_text(
+        textwrap.dedent(f"""\
+        #!/bin/bash
+        case "$1" in
+          run)
+            case "$*" in
+        {run_cases}
+              *) : ;;
+            esac
+            ;;
+          api)
+            case "$*" in
+        {art_cases}
+              *) exit 1 ;;
+            esac
+            ;;
+        esac
+        """)
+    )
+    stub.chmod(0o755)
+    return bindir
+
+
+def _run(tmp_path: Path, bindir: Path, version: str = VERSION) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "GITHUB_REPOSITORY": "provide-io/flavorpack",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), version], cwd=tmp_path, capture_output=True, text=True, check=False, env=env
+    )
+
+
+def test_finds_the_run_carrying_this_version(tmp_path: Path) -> None:
+    """The newest run whose artifacts carry the release version wins."""
+    bindir = _stub_gh(
+        tmp_path,
+        runs={"helper-prep.yml": ["300", "200"], "flavor-pipeline.yml": ["301", "201"]},
+        artifacts={
+            "300": [f"flavor-helpers-{VERSION}-all"],
+            "200": ["flavor-helpers-0.0.1-all"],
+            "301": [f"flavor-wheel-{VERSION}-linux_amd64"],
+            "201": ["flavor-wheel-0.0.1-linux_amd64"],
+        },
+    )
+
+    result = _run(tmp_path, bindir)
+
+    assert result.returncode == 0, result.stderr
+    assert "300" in result.stdout
+    assert "301" in result.stdout
+
+
+def test_skips_runs_built_at_another_version(tmp_path: Path) -> None:
+    """A newer run for a different version must not be taken.
+
+    Artifacts are matched by the version in their name, so a release cut while
+    main has moved on has to reach past the newer runs.
+    """
+    bindir = _stub_gh(
+        tmp_path,
+        runs={"helper-prep.yml": ["400", "300"], "flavor-pipeline.yml": ["401", "301"]},
+        artifacts={
+            "400": ["flavor-helpers-1.2.3-all"],
+            "300": [f"flavor-helpers-{VERSION}-all"],
+            "401": ["flavor-wheel-1.2.3-linux_amd64"],
+            "301": [f"flavor-wheel-{VERSION}-linux_amd64"],
+        },
+    )
+
+    result = _run(tmp_path, bindir)
+
+    assert result.returncode == 0, result.stderr
+    assert "300" in result.stdout, "took a run built at the wrong version"
+    assert "301" in result.stdout
+
+
+def test_no_matching_run_fails(tmp_path: Path) -> None:
+    """A release with no artifacts for its version must stop here.
+
+    Continuing would assemble a release out of whatever ran most recently.
+    """
+    bindir = _stub_gh(
+        tmp_path,
+        runs={"helper-prep.yml": ["300"], "flavor-pipeline.yml": ["301"]},
+        artifacts={"300": ["flavor-helpers-0.0.1-all"], "301": ["flavor-wheel-0.0.1-linux_amd64"]},
+    )
+
+    result = _run(tmp_path, bindir)
+
+    assert result.returncode != 0, f"a release with no matching artifacts was allowed: {result.stdout}"
+
+
+def test_version_is_required(tmp_path: Path) -> None:
+    """Without a version there is nothing to match against."""
+    bindir = _stub_gh(tmp_path, runs={}, artifacts={})
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}", "RELEASE_VERSION": ""},
+    )
+
+    assert result.returncode != 0
+
+
+# 🌶️📦🔚

--- a/tests/ci/test_organize_release_wheels.py
+++ b/tests/ci/test_organize_release_wheels.py
@@ -1,0 +1,106 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/organize-release-wheels.sh.
+
+The sibling script that collects PSP packages shipped v0.5.0 without its two
+Windows binaries, because a glob matched nothing and the script reported
+success anyway. This one collects the wheels that get published to PyPI, and
+had the same ending: an unconditional "✅ Collected wheels" with no count.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "organize-release-wheels.sh"
+VERSION = "9.9.9"
+
+
+def _wheel(root: Path, platform: str, filename: str) -> Path:
+    """Write one downloaded wheel artifact, in the layout the release job produces."""
+    path = root / f"flavor-wheel-{VERSION}-{platform}" / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"not a real wheel")
+    return path
+
+
+def _run(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "wheels", "out", VERSION],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_collects_every_platform_wheel(tmp_path: Path) -> None:
+    """All six platform wheels reach the output directory."""
+    wheels = tmp_path / "wheels"
+    for platform, name in [
+        ("linux_amd64", f"flavorpack-{VERSION}-py3-none-manylinux2014_x86_64.whl"),
+        ("linux_arm64", f"flavorpack-{VERSION}-py3-none-manylinux2014_aarch64.whl"),
+        ("darwin_arm64", f"flavorpack-{VERSION}-py3-none-macosx_11_0_arm64.whl"),
+        ("windows_amd64", f"flavorpack-{VERSION}-py3-none-win_amd64.whl"),
+    ]:
+        _wheel(wheels, platform, name)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert len(list((tmp_path / "out").iterdir())) == 4, "a platform wheel was dropped"
+
+
+def test_collecting_no_wheels_fails(tmp_path: Path) -> None:
+    """A release with no wheels must not be cut.
+
+    PyPI publishing consumes exactly this output. Reporting success over an
+    empty directory is how a release ships nothing installable.
+    """
+    (tmp_path / "wheels").mkdir()
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0, f"collecting no wheels reported success: {result.stdout}"
+
+
+def test_platform_directory_without_a_wheel_fails(tmp_path: Path) -> None:
+    """A platform whose build produced no wheel is a short release, not a pass."""
+    wheels = tmp_path / "wheels"
+    (wheels / f"flavor-wheel-{VERSION}-linux_amd64").mkdir(parents=True)
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0, f"an empty platform directory reported success: {result.stdout}"
+
+
+def test_missing_input_directory_fails(tmp_path: Path) -> None:
+    """A download step that produced nothing must not read as a clean run."""
+    result = _run(tmp_path)
+
+    assert result.returncode != 0, f"a missing input directory reported success: {result.stdout}"
+
+
+def test_version_is_required(tmp_path: Path) -> None:
+    """Without a version the script cannot know what it is assembling."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "wheels", "out"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Version is required" in result.stdout
+
+
+# 🌶️📦🔚

--- a/tests/ci/test_validate_release_version.py
+++ b/tests/ci/test_validate_release_version.py
@@ -1,0 +1,116 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/validate-release-version.sh.
+
+The first gate the release workflow runs. Everything after it — tagging,
+asset collection, the PyPI upload — assumes this said yes for a good reason.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "validate-release-version.sh"
+
+
+def _run(
+    version: str | None, cwd: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    args = ["bash", str(SCRIPT)] + ([version] if version is not None else [])
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False, env=env)
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    """A repository with one commit, so tag checks have something to compare."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "t"],
+        ["git", "commit", "-q", "--allow-empty", "-m", "first"],
+    ):
+        subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+@pytest.mark.parametrize("version", ["1.0.0", "0.5.0", "10.20.30", "1.0.0-beta.1", "2.0.0-rc1"])
+def test_accepts_valid_versions(version: str, tmp_path: Path) -> None:
+    """Semantic versions, with or without a prerelease suffix."""
+    result = _run(version, _git_repo(tmp_path))
+    assert result.returncode == 0, f"{version} rejected: {result.stdout}"
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.0", "v1.0.0", "1.0.0.0", "1.0.0-", "abc", "1.0.0 ", "", "01.0.0-!"],
+)
+def test_rejects_invalid_versions(version: str, tmp_path: Path) -> None:
+    """Anything that is not a semantic version stops the release.
+
+    A malformed version reaches artifact names and the tag, so accepting one
+    produces a release nothing can refer to.
+    """
+    result = _run(version, _git_repo(tmp_path))
+    assert result.returncode != 0, f"{version!r} was accepted: {result.stdout}"
+
+
+def test_missing_version_is_rejected(tmp_path: Path) -> None:
+    """No argument at all."""
+    result = _run(None, _git_repo(tmp_path))
+    assert result.returncode != 0
+
+
+def test_existing_tag_on_a_different_commit_is_refused(tmp_path: Path) -> None:
+    """Re-tagging a released version somewhere else would rewrite history.
+
+    The tag is what a published release, and every downloaded artifact, points
+    at.
+    """
+    repo = _git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.2.3"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "second"], cwd=repo, check=True, capture_output=True
+    )
+
+    result = _run("1.2.3", repo)
+
+    assert result.returncode != 0, f"re-tagging a different commit was allowed: {result.stdout}"
+    assert "different commit" in result.stdout
+
+
+def test_existing_tag_on_head_is_allowed(tmp_path: Path) -> None:
+    """Re-running a release to publish only is a legitimate case."""
+    repo = _git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.2.3"], cwd=repo, check=True, capture_output=True)
+
+    result = _run("1.2.3", repo)
+
+    assert result.returncode == 0, f"a publish-only re-run was refused: {result.stdout}"
+
+
+def test_writes_github_output(tmp_path: Path) -> None:
+    """The workflow reads version and version_tag from here."""
+    import os
+
+    repo = _git_repo(tmp_path)
+    out = tmp_path / "gh_output"
+    env = {**os.environ, "GITHUB_OUTPUT": str(out)}
+
+    result = _run("3.4.5", repo, env=env)
+
+    assert result.returncode == 0, result.stdout
+    written = out.read_text()
+    assert "version=3.4.5" in written
+    assert "version_tag=v3.4.5" in written
+
+
+# 🌶️📦🔚


### PR DESCRIPTION
The release workflow calls **five** scripts. One was covered after it shipped v0.5.0 without its Windows binaries; the other four ran on nothing but hope. All five now have tests — **36 in `tests/ci/`**.

## organize-release-wheels.sh had the same defect, on the PyPI path

It ended with an unconditional:

```bash
echo "✅ Collected wheels in $OUTPUT_DIR:"
```

No count. No failure. **Four of the five tests written for it failed:**

| Test | What it found |
|---|---|
| `test_collecting_no_wheels_fails` | zero wheels → success |
| `test_platform_directory_without_a_wheel_fails` | a platform that built nothing → success |
| `test_missing_input_directory_fails` | no input directory at all → success |
| `test_version_is_required` | the guard was **unreachable** — `set -u` aborts on the unset `${3}` before the friendly message can print |

So a release could have published **no wheels at all**, or silently dropped a platform, and this step would have said ✅ either way. This is the script whose output the PyPI upload consumes.

It now counts what it collects, fails on zero, fails on a platform that built nothing, and uses `${3:-}` so its own error message can be reached.

## validate-release-version.sh needed no changes

17 tests, all passing against the script as written. It is the first gate the release runs, and everything after it — the tag, the asset collection, the PyPI upload — assumes it said yes for a good reason. Now that assumption is pinned.

## The two that talk to GitHub

`get-release-runs.sh` and `create-release-tag.sh` call `gh api`, so `gh` is stubbed and the tests assert on the scripts' logic rather than the API. The cases with consequences:

- taking a run built at **another version** (artifacts are matched by the version in their name, so a release cut after main moved on has to reach past newer runs)
- publishing with **no matching artifacts at all** — continuing would assemble a release from whatever ran most recently
- **moving a tag** a published release already points at, which would orphan every artifact already downloaded
- re-running a release once the tag already points at HEAD, which is legitimate and must not fail

## Also

A GNU-ism in `organize-release-wheels.sh`'s `sed`, now `-E`, matching the fix in its sibling.

## Verification

- All four quality gates pass (python, go, rust, shell)
- `tests/ci/`: **36 passed**
- Full Python suite: **2825 passed**