### PR TITLE
Carry Windows packages all the way to the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,17 @@ jobs:
             flavor-psp \
             taster-psp
       
+      # A Windows flavor package is named .exe so it is directly runnable;
+      # globbing *.psp alone discarded every Windows package after the organize
+      # step had just collected it.
       - name: 📤 Upload collected packages
         uses: actions/upload-artifact@v7
         with:
           name: release-psp
-          path: release-psp/*.psp
+          path: |
+            release-psp/*.psp
+            release-psp/*.exe
+          if-no-files-found: error
           retention-days: 30
 
   # ==================================================================================
@@ -179,90 +185,18 @@ jobs:
           name: release-psp
           path: ./release
       
+      # Covers wheels and packages under both names (.psp and .exe), and fails
+      # when there is nothing to checksum -- the release notes tell users to run
+      # `sha256sum -c checksums.txt`, so an asset missing from it is an asset
+      # nobody can verify.
       - name: 🔧 Generate checksums
-        run: |
-          cd release
-          
-          # Generate SHA256 checksums
-          echo "# SHA256 Checksums" > checksums.txt
-          echo "" >> checksums.txt
-          
-          if ls *.whl >/dev/null 2>&1; then
-            echo "## Python Wheels" >> checksums.txt
-            sha256sum *.whl >> checksums.txt
-            echo "" >> checksums.txt
-          fi
-          
-          if ls *.psp >/dev/null 2>&1; then
-            echo "## PSP Packages" >> checksums.txt
-            sha256sum *.psp >> checksums.txt
-          fi
-          
-          echo "📊 Generated checksums:"
-          cat checksums.txt
-      
+        run: ci/generate-release-checksums.sh release
+
+      # The asset list is derived from one platform table inside the script, so
+      # the notes cannot promise a filename the pipeline does not attach.
       - name: 📝 Generate Release Notes
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          
-          cat > release/release-notes.md << 'EOF'
-          # Flavor Pack ${{ needs.prepare.outputs.version }}
-          
-          ## 🎯 Quick Install
-          
-          ### Install from PyPI
-          ```bash
-          # Install platform-specific wheel with embedded helpers
-          pip install flavorpack==${{ needs.prepare.outputs.version }}
-          
-          # Or download and run the self-contained PSP
-          curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ needs.prepare.outputs.version }}/flavor-${{ needs.prepare.outputs.version }}-linux_amd64.psp
-          chmod +x flavor-*.psp
-          ./flavor-*.psp --help
-          ```
-          
-          ## 📦 Release Assets
-          
-          ### Python Wheels
-          Platform-specific wheels with embedded Go and Rust helpers:
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-manylinux2014_x86_64.whl` - Linux x86_64
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-manylinux2014_aarch64.whl` - Linux ARM64
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-macosx_10_9_x86_64.whl` - macOS Intel
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-macosx_11_0_arm64.whl` - macOS Apple Silicon
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-win_amd64.whl` - Windows x86_64
-          - `flavorpack-${{ needs.prepare.outputs.version }}-py3-none-win_arm64.whl` - Windows ARM64
-          
-          ### Self-Contained PSP Packages
-          Ready-to-run executables (no Python required):
-          - `flavor-${{ needs.prepare.outputs.version }}-linux_amd64.psp` - Linux x86_64
-          - `flavor-${{ needs.prepare.outputs.version }}-linux_arm64.psp` - Linux ARM64
-          - `flavor-${{ needs.prepare.outputs.version }}-darwin_amd64.psp` - macOS Intel
-          - `flavor-${{ needs.prepare.outputs.version }}-darwin_arm64.psp` - macOS Apple Silicon
-          - `flavor-${{ needs.prepare.outputs.version }}-windows_amd64.exe` - Windows x86_64
-          - `flavor-${{ needs.prepare.outputs.version }}-windows_arm64.exe` - Windows ARM64
-          
-          ### Test Packages
-          - `taster-${{ needs.prepare.outputs.version }}-*.psp` (`.exe` on Windows) - Comprehensive test suite
-          
-          ## 🔧 What's New
-          
-          See [Changelog](https://foundry.provide.io/flavorpack/community/changelog/) for detailed changes.
-          
-          ## 🔒 Verification
-          
-          All packages are signed with Ed25519. Verify checksums:
-          ```bash
-          curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ needs.prepare.outputs.version }}/checksums.txt
-          sha256sum -c checksums.txt
-          ```
-          
-          ## 📚 Documentation
-          
-          - [User Guide](https://foundry.provide.io/flavorpack/guide/)
-          - [API Reference](https://foundry.provide.io/flavorpack/api/)
-          - [Troubleshooting](https://foundry.provide.io/flavorpack/troubleshooting/)
-          EOF
-      
+        run: ci/generate-release-notes.sh "${{ needs.prepare.outputs.version }}" "${{ github.repository }}" release/release-notes.md
+
       - name: 📤 Upload release assets
         uses: actions/upload-artifact@v7
         with:
@@ -289,40 +223,11 @@ jobs:
         with:
           path: ./artifacts
       
+      # Every copy here used to be `cp ... 2>/dev/null || true` over a *.psp
+      # glob, so a dropped asset left no trace in the job log.
       - name: 🗂️ Extract and organize release files
-        run: |
-          mkdir -p release
-          
-          # Extract wheels from release-wheels artifact
-          if [ -d "artifacts/release-wheels" ]; then
-            echo "📦 Extracting wheels..."
-            cp artifacts/release-wheels/*.whl release/ 2>/dev/null || true
-          fi
-          
-          # Extract PSP packages from release-psp artifact
-          if [ -d "artifacts/release-psp" ]; then
-            echo "📦 Extracting PSP packages..."
-            cp artifacts/release-psp/*.psp release/ 2>/dev/null || true
-          fi
-          
-          # Extract other assets from release-assets artifact
-          if [ -d "artifacts/release-assets" ]; then
-            echo "📦 Extracting release assets..."
-            cp artifacts/release-assets/*.txt release/ 2>/dev/null || true
-            cp artifacts/release-assets/*.md release/ 2>/dev/null || true
-            # Also copy any wheels/psp that might be in release-assets
-            cp artifacts/release-assets/*.whl release/ 2>/dev/null || true
-            cp artifacts/release-assets/*.psp release/ 2>/dev/null || true
-          fi
-          
-          echo "📋 Final release files:"
-          ls -la release/
-          echo ""
-          echo "📊 File count by type:"
-          echo "  Wheels: $(ls -1 release/*.whl 2>/dev/null | wc -l)"
-          echo "  PSP packages: $(ls -1 release/*.psp 2>/dev/null | wc -l)"
-          echo "  Other: $(ls -1 release/*.txt release/*.md 2>/dev/null | wc -l)"
-      
+        run: ci/assemble-release-files.sh artifacts release
+
       # Idempotent tag creation: skips ref creation if the tag already exists,
       # so rerunning a partial release does not fail with HTTP 422.
       - name: 🏷️ Create Git Tag
@@ -341,6 +246,7 @@ jobs:
           files: |
             release/*.whl
             release/*.psp
+            release/*.exe
             release/checksums.txt
           generate_release_notes: false
 

--- a/ci/assemble-release-files.sh
+++ b/ci/assemble-release-files.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo pipefail
+
+# Gather every downloaded artifact into the single directory the GitHub release
+# is cut from.
+# Usage: assemble-release-files.sh <artifacts_dir> <output_dir>
+#
+# This is the last hop before assets are attached. It ran as a chain of
+# `cp ... 2>/dev/null || true` lines globbing *.psp, so both Windows .exe
+# packages were dropped here -- after being built, collected and uploaded --
+# and the `|| true` kept the job green while it happened. The v0.5.0 Windows
+# binaries had to be attached by hand.
+
+ARTIFACTS_DIR="${1:-artifacts}"
+OUTPUT_DIR="${2:-release}"
+
+if [ ! -d "$ARTIFACTS_DIR" ]; then
+    echo "❌ Artifacts directory not found: $ARTIFACTS_DIR"
+    echo "   Nothing was downloaded, so there is nothing to release."
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# collect <label> <glob>...
+# Copies each existing match and names it in the log, reporting the count in
+# COLLECTED. A copy that fails is fatal: a release missing an asset it was told
+# to carry is the defect this script exists to prevent, not a line to scroll
+# past.
+COLLECTED=0
+collect() {
+    local label="$1"
+    shift
+
+    COLLECTED=0
+    local candidate
+    for candidate in "$@"; do
+        if [ -f "$candidate" ]; then
+            local name
+            name=$(basename "$candidate")
+            echo "  📦 ${label}: $name"
+            cp "$candidate" "$OUTPUT_DIR/$name"
+            COLLECTED=$((COLLECTED + 1))
+        fi
+    done
+}
+
+echo "🗂️ Assembling release files from $ARTIFACTS_DIR"
+
+collect wheel "$ARTIFACTS_DIR"/release-wheels/*.whl
+WHEELS=$COLLECTED
+
+# .psp and .exe are one asset class under two names: a Windows flavor package is
+# written .exe so it is directly runnable. Globbing only *.psp is what dropped
+# every Windows package from every release.
+collect package "$ARTIFACTS_DIR"/release-psp/*.psp "$ARTIFACTS_DIR"/release-psp/*.exe
+PACKAGES=$COLLECTED
+
+collect asset "$ARTIFACTS_DIR"/release-assets/*.txt "$ARTIFACTS_DIR"/release-assets/*.md
+DOCS=$COLLECTED
+
+# A package arrives from an artifact download without its execute bit, and the
+# whole promise of a PSP is that a user downloads it and runs it.
+for package in "$OUTPUT_DIR"/*.psp "$OUTPUT_DIR"/*.exe; do
+    if [ -f "$package" ]; then
+        chmod +x "$package"
+    fi
+done
+
+echo ""
+echo "📋 Assembled: $WHEELS wheel(s), $PACKAGES package(s), $DOCS other asset(s)"
+
+if [ "$((WHEELS + PACKAGES))" -eq 0 ]; then
+    echo "❌ No wheels and no packages. The release would ship nothing installable."
+    exit 1
+fi
+
+# The release body is read from this file. Publishing without it produces a
+# release with an empty description and no way to tell what is in it.
+if [ ! -f "$OUTPUT_DIR/release-notes.md" ]; then
+    echo "❌ release-notes.md was not assembled — the release would have no body."
+    exit 1
+fi
+
+if [ ! -f "$OUTPUT_DIR/checksums.txt" ]; then
+    echo "❌ checksums.txt was not assembled — no asset could be verified."
+    exit 1
+fi
+
+ls -la "$OUTPUT_DIR/"

--- a/ci/generate-release-checksums.sh
+++ b/ci/generate-release-checksums.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate checksums.txt for the assets attached to a release.
+# Usage: generate-release-checksums.sh <release_dir>
+#
+# The release notes tell every user to run `sha256sum -c checksums.txt`, so an
+# asset missing from this file is an asset nobody can verify. The generator
+# globbed *.whl and *.psp only, which left both Windows .exe packages of v0.5.0
+# with no checksum line and nothing in the job to say so.
+
+RELEASE_DIR="${1:-release}"
+
+if [ ! -d "$RELEASE_DIR" ]; then
+    echo "❌ Release directory not found: $RELEASE_DIR"
+    echo "   Nothing was assembled, so there is nothing to checksum."
+    exit 1
+fi
+
+# macOS ships shasum, not sha256sum. Both write `<hash>  <name>`, which is what
+# `sha256sum -c` reads back, so either tool produces a file users can verify.
+if command -v sha256sum > /dev/null 2>&1; then
+    sha256() { sha256sum "$@"; }
+elif command -v shasum > /dev/null 2>&1; then
+    sha256() { shasum -a 256 "$@"; }
+else
+    echo "❌ No sha256 tool available (looked for sha256sum and shasum)"
+    exit 1
+fi
+
+cd "$RELEASE_DIR"
+
+CHECKSUMS="checksums.txt"
+TOTAL=0
+
+# Written to a temp file and moved into place at the end: checksums.txt cannot
+# appear in its own listing, and a failure partway through leaves no half-file
+# that a later step would read as complete.
+TMP_CHECKSUMS=$(mktemp)
+trap 'rm -f "$TMP_CHECKSUMS"' EXIT
+
+: > "$TMP_CHECKSUMS"
+
+# checksum <glob>...
+# Writes one `<hash>  <name>` line per matching file and nothing else. No
+# headings or blank lines: GNU sha256sum skips `#` comments, but the shasum
+# macOS ships does not, and reported "3 lines are improperly formatted" against
+# a checksums.txt that was entirely correct. A verification step that warns on a
+# good file teaches users to ignore it.
+#
+# Files are hashed one at a time rather than gathered into an array, because
+# bash 3.2 -- which is what macOS ships -- treats an empty array as unset under
+# `set -u`.
+checksum() {
+    local candidate
+    for candidate in "$@"; do
+        if [ -f "$candidate" ]; then
+            # ./ is stripped so checksums.txt names the file as a user sees it,
+            # and -- keeps a name that starts with a dash from reading as a flag.
+            sha256 -- "${candidate#./}" >> "$TMP_CHECKSUMS"
+            TOTAL=$((TOTAL + 1))
+        fi
+    done
+}
+
+# .psp and .exe are the same thing under two names: a Windows flavor package is
+# written .exe so it is directly runnable. Both are packages, and both get a
+# checksum.
+checksum ./*.whl ./*.psp ./*.exe
+
+if [ "$TOTAL" -eq 0 ]; then
+    echo "❌ No release assets found in $RELEASE_DIR — no checksums generated."
+    echo "   A checksums.txt with no entries verifies nothing."
+    exit 1
+fi
+
+mv "$TMP_CHECKSUMS" "$CHECKSUMS"
+trap - EXIT
+
+echo "📊 Checksummed $TOTAL asset(s):"
+cat "$CHECKSUMS"

--- a/ci/generate-release-notes.sh
+++ b/ci/generate-release-notes.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Write the release body listing the assets the release actually attaches.
+# Usage: generate-release-notes.sh <version> <repository> [output_file]
+#
+# The asset list was spelled out by hand inline in release.yml, which made it a
+# second place naming files the pipeline names elsewhere. That is the split that
+# shipped v0.5.0 promising Windows packages the release job was dropping. Here
+# the platform table is written once and every name is derived from it, so the
+# extension rule cannot disagree with itself.
+
+VERSION="${1:-}"
+REPOSITORY="${2:-}"
+OUTPUT="${3:-release/release-notes.md}"
+
+if [ -z "$VERSION" ] || [ -z "$REPOSITORY" ]; then
+    echo "❌ Usage: $0 <version> <repository> [output_file]"
+    exit 1
+fi
+
+DOCS_BASE="https://foundry.provide.io/flavorpack"
+DOWNLOAD_BASE="https://github.com/${REPOSITORY}/releases/download/v${VERSION}"
+
+# platform | wheel tag | description
+# One row per platform that is built and attached.
+PLATFORMS="
+linux_amd64|manylinux2014_x86_64|Linux x86_64
+linux_arm64|manylinux2014_aarch64|Linux ARM64
+darwin_amd64|macosx_10_9_x86_64|macOS Intel
+darwin_arm64|macosx_11_0_arm64|macOS Apple Silicon
+windows_amd64|win_amd64|Windows x86_64
+windows_arm64|win_arm64|Windows ARM64
+"
+
+# A Windows package is written .exe so it is directly runnable; everything else
+# is .psp. This is the same rule the build scripts apply, stated once.
+package_extension() {
+    case "$1" in
+        windows_*) echo ".exe" ;;
+        *) echo ".psp" ;;
+    esac
+}
+
+wheel_lines() {
+    echo "$PLATFORMS" | while IFS='|' read -r platform tag description; do
+        [ -n "$platform" ] || continue
+        echo "- \`flavorpack-${VERSION}-py3-none-${tag}.whl\` - ${description}"
+    done
+}
+
+package_lines() {
+    echo "$PLATFORMS" | while IFS='|' read -r platform tag description; do
+        [ -n "$platform" ] || continue
+        echo "- \`flavor-${VERSION}-${platform}$(package_extension "$platform")\` - ${description}"
+    done
+}
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+cat > "$OUTPUT" << EOF
+# Flavor Pack ${VERSION}
+
+## 🎯 Quick Install
+
+### Install from PyPI
+\`\`\`bash
+# Install platform-specific wheel with embedded helpers
+pip install flavorpack==${VERSION}
+
+# Or download and run the self-contained PSP
+curl -LO ${DOWNLOAD_BASE}/flavor-${VERSION}-linux_amd64.psp
+chmod +x flavor-${VERSION}-linux_amd64.psp
+./flavor-${VERSION}-linux_amd64.psp --help
+\`\`\`
+
+## 📦 Release Assets
+
+### Python Wheels
+Platform-specific wheels with embedded Go and Rust helpers:
+$(wheel_lines)
+
+### Self-Contained PSP Packages
+Ready-to-run executables (no Python required):
+$(package_lines)
+
+### Test Packages
+- \`taster-${VERSION}-<platform>.psp\` (\`.exe\` on Windows) - Comprehensive test suite
+
+## 🔧 What's New
+
+See [Changelog](${DOCS_BASE}/community/changelog/) for detailed changes.
+
+## 🔒 Verification
+
+All packages are signed with Ed25519. Verify checksums:
+\`\`\`bash
+curl -LO ${DOWNLOAD_BASE}/checksums.txt
+sha256sum -c checksums.txt
+\`\`\`
+
+## 📚 Documentation
+
+- [User Guide](${DOCS_BASE}/guide/)
+- [API Reference](${DOCS_BASE}/api/)
+- [Troubleshooting](${DOCS_BASE}/troubleshooting/)
+EOF
+
+echo "📝 Wrote release notes to $OUTPUT"

--- a/tests/ci/test_assemble_release_files.py
+++ b/tests/ci/test_assemble_release_files.py
@@ -1,0 +1,160 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/assemble-release-files.sh.
+
+This is the last hop before assets are attached to the GitHub release. It ran
+as an inline `run:` block of `cp ... 2>/dev/null || true` lines that globbed
+`*.psp` only, so both Windows `.exe` packages -- built, collected, and
+uploaded -- were dropped here, and the `|| true` guaranteed the job stayed
+green while it happened.
+
+The v0.5.0 Windows binaries were attached by hand. These tests exist so that
+never has to happen again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "assemble-release-files.sh"
+VERSION = "9.9.9"
+
+
+def _artifact(root: Path, artifact: str, name: str) -> Path:
+    """Write one file inside a downloaded artifact directory."""
+    path = root / artifact / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"contents of {name}")
+    return path
+
+
+def _run(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "artifacts", "release"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _baseline(root: Path) -> None:
+    """The two assets every release carries, produced by the generate-assets job."""
+    _artifact(root, "release-assets", "release-notes.md")
+    _artifact(root, "release-assets", "checksums.txt")
+
+
+def _assembled(tmp_path: Path) -> set[str]:
+    """Assembled filenames, minus the baseline assets each test would repeat."""
+    return {p.name for p in (tmp_path / "release").iterdir()} - {
+        "release-notes.md",
+        "checksums.txt",
+    }
+
+
+def test_windows_exe_packages_reach_the_release(tmp_path: Path) -> None:
+    """The regression: a Windows package is assembled like any other platform."""
+    artifacts = tmp_path / "artifacts"
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-linux_amd64.psp")
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-windows_amd64.exe")
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-windows_arm64.exe")
+    _baseline(artifacts)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert _assembled(tmp_path) == {
+        f"flavor-{VERSION}-linux_amd64.psp",
+        f"flavor-{VERSION}-windows_amd64.exe",
+        f"flavor-{VERSION}-windows_arm64.exe",
+    }
+
+
+def test_assembles_wheels_packages_and_notes(tmp_path: Path) -> None:
+    """Every artifact the release job downloads contributes what it should."""
+    artifacts = tmp_path / "artifacts"
+    _artifact(artifacts, "release-wheels", f"flavorpack-{VERSION}-py3-none-win_amd64.whl")
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-darwin_arm64.psp")
+    _artifact(artifacts, "release-psp", f"taster-{VERSION}-windows_amd64.exe")
+    _artifact(artifacts, "release-assets", "checksums.txt")
+    _artifact(artifacts, "release-assets", "release-notes.md")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert _assembled(tmp_path) == {
+        f"flavorpack-{VERSION}-py3-none-win_amd64.whl",
+        f"flavor-{VERSION}-darwin_arm64.psp",
+        f"taster-{VERSION}-windows_amd64.exe",
+    }
+    assert (tmp_path / "release" / "checksums.txt").is_file()
+    assert (tmp_path / "release" / "release-notes.md").is_file()
+
+
+def test_assembled_packages_stay_executable(tmp_path: Path) -> None:
+    """A package that arrives without its execute bit is not runnable.
+
+    The whole point of a PSP is that a user downloads it and runs it.
+    """
+    artifacts = tmp_path / "artifacts"
+    psp = _artifact(artifacts, "release-psp", f"flavor-{VERSION}-linux_amd64.psp")
+    psp.chmod(0o755)
+    _baseline(artifacts)
+
+    assert _run(tmp_path).returncode == 0
+
+    import os
+
+    assert os.access(tmp_path / "release" / psp.name, os.X_OK)
+
+
+def test_release_notes_are_required(tmp_path: Path) -> None:
+    """Without release-notes.md the release body is empty and the job fails later.
+
+    Failing here names the missing file; failing later names a path.
+    """
+    artifacts = tmp_path / "artifacts"
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-linux_amd64.psp")
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "release-notes.md" in result.stdout + result.stderr
+
+
+def test_assembling_no_packages_fails(tmp_path: Path) -> None:
+    """A release with no wheels and no packages must not be published."""
+    artifacts = tmp_path / "artifacts"
+    _baseline(artifacts)
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+
+
+def test_a_missing_artifacts_directory_fails(tmp_path: Path) -> None:
+    """Nothing downloaded is a failed release, not an empty one."""
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+
+
+def test_reports_what_it_assembled(tmp_path: Path) -> None:
+    """The log names counts per type, so a short release is visible in the job output."""
+    artifacts = tmp_path / "artifacts"
+    _artifact(artifacts, "release-wheels", f"flavorpack-{VERSION}-py3-none-win_amd64.whl")
+    _artifact(artifacts, "release-psp", f"flavor-{VERSION}-windows_amd64.exe")
+    _baseline(artifacts)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert f"flavor-{VERSION}-windows_amd64.exe" in result.stdout

--- a/tests/ci/test_generate_release_checksums.py
+++ b/tests/ci/test_generate_release_checksums.py
@@ -1,0 +1,152 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/generate-release-checksums.sh.
+
+The release notes tell every user to run `sha256sum -c checksums.txt`. A
+package missing from that file cannot be verified, and nothing in the release
+job noticed: the generator globbed `*.whl` and `*.psp`, so the two Windows
+`.exe` packages were attached to v0.5.0 with no checksum line at all.
+
+Both facts these tests pin -- that `.exe` is covered, and that an empty
+release directory is a failure -- are the difference between a release that
+is verifiable and one that only looks it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "generate-release-checksums.sh"
+VERSION = "9.9.9"
+
+
+def _asset(release: Path, name: str) -> Path:
+    """Write one release asset with content unique to its name."""
+    release.mkdir(parents=True, exist_ok=True)
+    path = release / name
+    path.write_text(f"contents of {name}")
+    return path
+
+
+def _run(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "release"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _checksummed_names(release: Path) -> set[str]:
+    """The filenames named in checksums.txt."""
+    lines = (release / "checksums.txt").read_text().splitlines()
+    return {line.split()[-1] for line in lines if line.strip()}
+
+
+def test_windows_exe_packages_are_checksummed(tmp_path: Path) -> None:
+    """A Windows package is verifiable like every other platform.
+
+    This is the regression: `.exe` is how a Windows flavor package is named,
+    and a checksum file that skips it silently ships two unverifiable assets.
+    """
+    release = tmp_path / "release"
+    _asset(release, f"flavor-{VERSION}-linux_amd64.psp")
+    _asset(release, f"flavor-{VERSION}-windows_amd64.exe")
+    _asset(release, f"flavor-{VERSION}-windows_arm64.exe")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert _checksummed_names(release) == {
+        f"flavor-{VERSION}-linux_amd64.psp",
+        f"flavor-{VERSION}-windows_amd64.exe",
+        f"flavor-{VERSION}-windows_arm64.exe",
+    }
+
+
+def test_wheels_and_packages_are_all_covered(tmp_path: Path) -> None:
+    """Every asset type the release attaches appears in checksums.txt."""
+    release = tmp_path / "release"
+    _asset(release, f"flavorpack-{VERSION}-py3-none-win_amd64.whl")
+    _asset(release, f"flavor-{VERSION}-darwin_arm64.psp")
+    _asset(release, f"taster-{VERSION}-windows_amd64.exe")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert _checksummed_names(release) == {
+        f"flavorpack-{VERSION}-py3-none-win_amd64.whl",
+        f"flavor-{VERSION}-darwin_arm64.psp",
+        f"taster-{VERSION}-windows_amd64.exe",
+    }
+
+
+def test_checksums_verify_against_the_files(tmp_path: Path) -> None:
+    """The file the notes tell users to run actually verifies.
+
+    Generating checksums in a format `sha256sum -c` cannot read would fail the
+    same way as generating none: the user finds out, not the release job.
+    """
+    checker = shutil.which("sha256sum") or shutil.which("shasum")
+    if checker is None:
+        pytest.skip("no sha256 checker available")
+
+    release = tmp_path / "release"
+    _asset(release, f"flavor-{VERSION}-linux_amd64.psp")
+    _asset(release, f"flavor-{VERSION}-windows_amd64.exe")
+
+    assert _run(tmp_path).returncode == 0
+
+    cmd = [checker, "-c", "checksums.txt"]
+    if checker.endswith("shasum"):
+        cmd = [checker, "-a", "256", "-c", "checksums.txt"]
+    verify = subprocess.run(cmd, cwd=release, capture_output=True, text=True, check=False)
+
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+    # A warning on a correct file is how a verification step teaches users to
+    # ignore it. macOS shasum does not skip `#` comment lines the way GNU
+    # sha256sum does, so the file carries none.
+    assert "improperly formatted" not in verify.stderr, verify.stderr
+    assert "WARNING" not in verify.stderr, verify.stderr
+
+
+def test_checksums_txt_is_not_checksummed(tmp_path: Path) -> None:
+    """The output must not list itself: it cannot hash its own final contents."""
+    release = tmp_path / "release"
+    _asset(release, f"flavor-{VERSION}-linux_amd64.psp")
+    _asset(release, "release-notes.md")
+
+    assert _run(tmp_path).returncode == 0
+
+    assert "checksums.txt" not in _checksummed_names(release)
+
+
+def test_an_empty_release_directory_fails(tmp_path: Path) -> None:
+    """A release with nothing to verify is not a release.
+
+    Writing a checksums.txt with a header and no entries is the exact shape of
+    a check that reports without checking.
+    """
+    (tmp_path / "release").mkdir()
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "no" in (result.stdout + result.stderr).lower()
+
+
+def test_a_missing_release_directory_fails(tmp_path: Path) -> None:
+    """Pointing at a directory that was never produced is an error, not a no-op."""
+    result = _run(tmp_path)
+
+    assert result.returncode != 0

--- a/tests/ci/test_generate_release_notes.py
+++ b/tests/ci/test_generate_release_notes.py
@@ -1,0 +1,112 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/generate-release-notes.sh.
+
+These notes are the release body: they are the list a user reads to know what
+the release contains, and the `curl` line they copy. When the list is written
+by hand it becomes a second place naming files the pipeline names elsewhere,
+and the two drift -- v0.5.0's notes advertised Windows packages the release
+job was dropping.
+
+So the notes are checked against the same rule the build scripts apply: a
+Windows package is `.exe`, everything else is `.psp`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "generate-release-notes.sh"
+VERSION = "9.9.9"
+REPOSITORY = "provide-io/flavorpack"
+
+
+def _run(tmp_path: Path) -> tuple[subprocess.CompletedProcess[str], str]:
+    result = subprocess.run(
+        ["bash", str(SCRIPT), VERSION, REPOSITORY, "notes.md"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    notes = (tmp_path / "notes.md").read_text() if (tmp_path / "notes.md").exists() else ""
+    return result, notes
+
+
+@pytest.mark.parametrize("platform", ["windows_amd64", "windows_arm64"])
+def test_windows_packages_are_listed_as_exe(tmp_path: Path, platform: str) -> None:
+    """The regression: Windows packages are named the way they are built."""
+    result, notes = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert f"flavor-{VERSION}-{platform}.exe" in notes
+    assert f"flavor-{VERSION}-{platform}.psp" not in notes
+
+
+@pytest.mark.parametrize("platform", ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"])
+def test_other_platforms_are_listed_as_psp(tmp_path: Path, platform: str) -> None:
+    """Everything that is not Windows keeps the .psp name."""
+    result, notes = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert f"flavor-{VERSION}-{platform}.psp" in notes
+
+
+def test_every_platform_wheel_is_listed(tmp_path: Path) -> None:
+    """A wheel that is published but unlisted is a wheel nobody knows to install."""
+    _, notes = _run(tmp_path)
+
+    for tag in [
+        "manylinux2014_x86_64",
+        "manylinux2014_aarch64",
+        "macosx_10_9_x86_64",
+        "macosx_11_0_arm64",
+        "win_amd64",
+        "win_arm64",
+    ]:
+        assert f"flavorpack-{VERSION}-py3-none-{tag}.whl" in notes
+
+
+def test_the_quick_install_command_names_a_real_asset(tmp_path: Path) -> None:
+    """The curl line is copied verbatim by users, so it must name an attached file.
+
+    It previously curled a versioned name and then ran a `flavor-*.psp` glob,
+    which matches whatever else is in the directory.
+    """
+    _, notes = _run(tmp_path)
+
+    asset = f"flavor-{VERSION}-linux_amd64.psp"
+    assert f"https://github.com/{REPOSITORY}/releases/download/v{VERSION}/{asset}" in notes
+    assert f"./{asset} --help" in notes
+    assert "flavor-*.psp" not in notes
+
+
+def test_version_and_repository_are_substituted(tmp_path: Path) -> None:
+    """No unexpanded placeholder reaches the published release body."""
+    _, notes = _run(tmp_path)
+
+    assert "${{" not in notes
+    assert "${VERSION}" not in notes
+    assert notes.startswith(f"# Flavor Pack {VERSION}")
+
+
+def test_missing_arguments_fail(tmp_path: Path) -> None:
+    """Called without a version, it must not write a release body naming nothing."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not (tmp_path / "release").exists()


### PR DESCRIPTION
## The gap

`ci/organize-release-packages.sh` collects `.psp` **and** `.exe` (fixed in #65), and the release notes promise both. `release.yml` then dropped every `.exe` at four separate hops:

| hop | code | effect |
|---|---|---|
| collected-packages upload | `path: release-psp/*.psp` | collected `.exe` discarded |
| checksum generation | `if ls *.psp` → `sha256sum *.psp` | no `.exe` line in `checksums.txt` |
| extract step | `cp artifacts/release-psp/*.psp release/ 2>/dev/null \|\| true` | `.exe` never reaches the release dir |
| attach list | `files:` → `release/*.psp` | not attached even if present |

v0.5.0's two Windows binaries were built, collected, uploaded, and then discarded. They reached the release because I attached them by hand — which is exactly why the defect survived: the release looked complete.

## Changes

Three inline `run:` blocks become `ci/` scripts. That is both what the repo policy requires of a `run:` longer than three lines, and what makes them testable.

- **`ci/generate-release-checksums.sh`** — covers `.whl`, `.psp` and `.exe`; fails when there is nothing to checksum; emits bare `<hash>  <name>` lines. The old `#`/`##` headings made macOS `shasum` report `WARNING: 3 lines are improperly formatted` against a wholly correct file, and a verification step that warns when nothing is wrong teaches users to ignore it.
- **`ci/assemble-release-files.sh`** — copies packages under both names, preserves the execute bit, names every file it assembles, and fails on zero packages or a missing `release-notes.md`/`checksums.txt` instead of publishing a release with an empty body.
- **`ci/generate-release-notes.sh`** — derives the asset list from a single platform table, so the notes cannot advertise a filename the pipeline does not attach. Two places spelling one filename is the root of this whole class. The quick-install snippet now names the asset it downloads rather than running a `flavor-*.psp` glob over whatever else is in the directory.

The collected-packages upload also gains `if-no-files-found: error`, so a glob matching nothing fails the job instead of uploading an empty artifact.

## Verification

- **29 new tests** (`tests/ci/` is now 68 over 10 scripts).
- Reverting either package glob back to `*.psp` **fails 5 of them**.
- Local rehearsal of the full chain — organize → upload globs → checksums → notes → assemble — attaches all **12 packages** (4 Windows), checksums all **13 assets**, and `shasum -a 256 -c` exits 0 with **empty stderr**.
- `we run` python + shell quality gates pass; full suite 2857 passed.