### PR TITLE
Pin and lock every cargo tool install

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -382,9 +382,7 @@ jobs:
 
       - name: 🧰 Install Rust quality tools
         run: |
-          cargo install cargo-llvm-cov --locked || true
-          cargo install cargo-mutants --locked || true
-          cargo install cargo-fuzz --locked || true
+          ci/install-rust-cargo-tools.sh cargo-llvm-cov cargo-mutants cargo-fuzz
           rustup toolchain install nightly --profile minimal
 
       - name: 📊 Run Rust fast quality

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -400,13 +400,10 @@ jobs:
       
       - name: 📦 Install Cargo Tools
         run: |
-          cargo install cargo-audit
-          cargo install cargo-outdated
-          cargo install cargo-tree
-          cargo install cargo-license
-          cargo install cargo-deny
-          cargo install cargo-machete
-          cargo install cargo-udeps
+          # cargo-tree is built into cargo (1.44+) and cargo-udeps was installed
+          # here but never invoked, so neither is installed any more.
+          ci/install-rust-cargo-tools.sh cargo-audit cargo-outdated cargo-license cargo-deny
+          ci/install-rust-quality-tools.sh
       
       - name: 🔍 Dependency Tree
         run: |

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -452,8 +452,7 @@ jobs:
       
       - name: 📦 Install cargo-license
         run: |
-          cargo install cargo-license
-          cargo install cargo-deny
+          ci/install-rust-cargo-tools.sh cargo-license cargo-deny
       
       # Reports every crate's licence, then enforces src/flavor-rs/deny.toml.
       # Script policy: this used to be 74 lines of inline YAML that wrote its

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -409,7 +409,7 @@ jobs:
           echo "## 🦀 Rust Security Analysis" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          cargo install cargo-audit
+          ci/install-rust-cargo-tools.sh cargo-audit
           
           echo "### Cargo Audit" >> $GITHUB_STEP_SUMMARY
           
@@ -433,7 +433,7 @@ jobs:
         run: |
           echo "### Cargo Deny Security Check" >> $GITHUB_STEP_SUMMARY
           
-          cargo install cargo-deny
+          ci/install-rust-cargo-tools.sh cargo-deny
           
           cd src/flavor-rs
           
@@ -478,7 +478,7 @@ jobs:
           echo "### Unsafe Code Analysis" >> $GITHUB_STEP_SUMMARY
 
           # Install cargo-geiger
-          cargo install cargo-geiger
+          ci/install-rust-cargo-tools.sh cargo-geiger
 
           cd src/flavor-rs
 

--- a/ci/install-rust-cargo-tools.sh
+++ b/ci/install-rust-cargo-tools.sh
@@ -76,9 +76,11 @@ for tool in "$@"; do
         exit 1
     fi
 
-    subcommand="${tool#cargo-}"
-
-    if cargo "$subcommand" --version 2> /dev/null | grep -q "$version"; then
+    # `cargo install --list` is what cargo itself recorded, which is the only
+    # uniform way to ask: not every subcommand answers --version. cargo-license
+    # 0.7.0 exits 2 on it, so asking the tool would reinstall it every run and
+    # then declare the fresh install broken.
+    if cargo install --list 2> /dev/null | grep -qE "^${tool} v${version}:"; then
         echo "✅ ${tool} ${version} already installed"
     else
         echo "📦 Installing ${tool} ${version}"
@@ -88,10 +90,17 @@ for tool in "$@"; do
     # A tool that is absent has to fail here, where the message names the tool,
     # rather than inside the check that needs it, where a missing subcommand
     # reads as a check that found nothing wrong.
-    if ! cargo "$subcommand" --version > /dev/null 2>&1; then
-        echo "❌ ${tool} is not runnable after installation" >&2
+    if ! command -v "$tool" > /dev/null 2>&1; then
+        echo "❌ ${tool} is not on PATH after installation" >&2
         exit 1
     fi
 
-    echo "✅ Installed: $(cargo "$subcommand" --version | head -1)"
+    # Executing it is the difference between present and working. --version or
+    # --help, because which one a tool answers to is its own business.
+    if ! "$tool" --version > /dev/null 2>&1 && ! "$tool" --help > /dev/null 2>&1; then
+        echo "❌ ${tool} is installed but does not run" >&2
+        exit 1
+    fi
+
+    echo "✅ Installed: ${tool} ${version}"
 done

--- a/ci/install-rust-cargo-tools.sh
+++ b/ci/install-rust-cargo-tools.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# install-rust-cargo-tools.sh - Install pinned cargo subcommands for a CI job.
+#
+# Usage: install-rust-cargo-tools.sh <tool> [tool...]
+#   e.g. install-rust-cargo-tools.sh cargo-license cargo-deny
+#
+# Every install is pinned and --locked. Without both, `cargo install` resolves
+# each tool's dependency tree afresh on every run, so an upstream break in any
+# transitive dependency of any tool turns a job red for reasons that have
+# nothing to do with this repository. That is not hypothetical: tinyvec 1.13.0
+# was published broken at 21:13 on 2026-09-03 and fixed at 01:26 the next
+# morning, and in that window `cargo install cargo-deny` could not build, so
+# License Compliance failed on a pull request whose own dependencies were fine.
+#
+# The same reasoning as ci/install-rust-quality-tools.sh, which pins the one
+# tool the code-quality workflow runs. This covers the audit, licence and
+# security workflows, which were installing theirs unpinned.
+
+set -euo pipefail
+
+# Bump deliberately: a version change alters what CI enforces.
+CARGO_AUDIT_VERSION="${CARGO_AUDIT_VERSION:-0.22.2}"
+CARGO_OUTDATED_VERSION="${CARGO_OUTDATED_VERSION:-0.19.0}"
+CARGO_LICENSE_VERSION="${CARGO_LICENSE_VERSION:-0.7.0}"
+CARGO_DENY_VERSION="${CARGO_DENY_VERSION:-0.20.2}"
+CARGO_GEIGER_VERSION="${CARGO_GEIGER_VERSION:-0.13.0}"
+CARGO_LLVM_COV_VERSION="${CARGO_LLVM_COV_VERSION:-0.9.0}"
+CARGO_MUTANTS_VERSION="${CARGO_MUTANTS_VERSION:-27.1.0}"
+CARGO_FUZZ_VERSION="${CARGO_FUZZ_VERSION:-0.13.2}"
+
+if [ "$#" -eq 0 ]; then
+    echo "❌ Usage: $0 <tool> [tool...]"
+    echo "   Known tools: cargo-audit cargo-outdated cargo-license cargo-deny"
+    echo "                cargo-geiger cargo-llvm-cov cargo-mutants cargo-fuzz"
+    exit 1
+fi
+
+# version_for <tool> — the pin for a tool, or empty when the tool is unknown.
+version_for() {
+    case "$1" in
+        cargo-audit) echo "$CARGO_AUDIT_VERSION" ;;
+        cargo-outdated) echo "$CARGO_OUTDATED_VERSION" ;;
+        cargo-license) echo "$CARGO_LICENSE_VERSION" ;;
+        cargo-deny) echo "$CARGO_DENY_VERSION" ;;
+        cargo-geiger) echo "$CARGO_GEIGER_VERSION" ;;
+        cargo-llvm-cov) echo "$CARGO_LLVM_COV_VERSION" ;;
+        cargo-mutants) echo "$CARGO_MUTANTS_VERSION" ;;
+        cargo-fuzz) echo "$CARGO_FUZZ_VERSION" ;;
+        *) echo "" ;;
+    esac
+}
+
+# install_tool <tool> <version>
+# binstall pulls a prebuilt binary; building from source is the fallback.
+install_tool() {
+    local tool="$1"
+    local version="$2"
+
+    if command -v cargo-binstall > /dev/null 2>&1; then
+        cargo binstall --no-confirm "${tool}@${version}" \
+            || cargo install "${tool}@${version}" --locked
+    else
+        cargo install "${tool}@${version}" --locked
+    fi
+}
+
+for tool in "$@"; do
+    version="$(version_for "$tool")"
+
+    # An unknown tool is a typo in a workflow, and installing whatever that name
+    # happens to resolve to on crates.io is the wrong recovery.
+    if [ -z "$version" ]; then
+        echo "❌ No pinned version for '$tool'."
+        echo "   Add one to $(basename "$0") rather than installing it unpinned."
+        exit 1
+    fi
+
+    subcommand="${tool#cargo-}"
+
+    if cargo "$subcommand" --version 2> /dev/null | grep -q "$version"; then
+        echo "✅ ${tool} ${version} already installed"
+    else
+        echo "📦 Installing ${tool} ${version}"
+        install_tool "$tool" "$version"
+    fi
+
+    # A tool that is absent has to fail here, where the message names the tool,
+    # rather than inside the check that needs it, where a missing subcommand
+    # reads as a check that found nothing wrong.
+    if ! cargo "$subcommand" --version > /dev/null 2>&1; then
+        echo "❌ ${tool} is not runnable after installation" >&2
+        exit 1
+    fi
+
+    echo "✅ Installed: $(cargo "$subcommand" --version | head -1)"
+done

--- a/tests/ci/test_install_rust_cargo_tools.py
+++ b/tests/ci/test_install_rust_cargo_tools.py
@@ -26,37 +26,56 @@ pytestmark = [pytest.mark.ci, pytest.mark.packaging]
 
 SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "install-rust-cargo-tools.sh"
 
-# A cargo stub that records its arguments and reports the pinned version back,
-# so the script's "already installed" path is what runs.
+# A cargo stub that answers `cargo install --list` with the tools the test says
+# are present, which is the record the script reads to decide whether to install.
 CARGO_STUB = """#!/bin/bash
 echo "$@" >> "$CALLS"
-if [ "$2" = "--version" ]; then
-    echo "$1 {version}"
+if [ "$1" = "install" ] && [ "$2" = "--list" ]; then
+    cat "$INSTALLED" 2>/dev/null
 fi
 exit 0
 """
 
+# A tool that refuses --version and answers --help, which is what cargo-license
+# 0.7.0 does. Asking it for a version is what broke the first attempt at this
+# script: the install succeeded and the check then called it broken.
+TOOL_STUB = """#!/bin/bash
+if [ "$1" = "--help" ]; then
+    exit 0
+fi
+exit 2
+"""
 
-def _stub_cargo(tmp_path: Path, version: str = "9.9.9") -> tuple[Path, Path]:
-    """A PATH containing only a cargo stub, plus the file it logs calls to."""
+
+def _stub_env(tmp_path: Path, tools: tuple[str, ...], version: str) -> tuple[Path, Path]:
+    """A PATH holding a cargo stub and a stub for each tool cargo reports installed."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
-    calls = tmp_path / "calls.txt"
+    installed = tmp_path / "installed.txt"
 
     cargo = bin_dir / "cargo"
-    cargo.write_text(CARGO_STUB.format(version=version))
+    cargo.write_text(CARGO_STUB)
     cargo.chmod(0o755)
 
-    return bin_dir, calls
+    installed.write_text("".join(f"{tool} v{version}:\n    {tool}\n" for tool in tools))
+
+    for tool in tools:
+        binary = bin_dir / tool
+        binary.write_text(TOOL_STUB)
+        binary.chmod(0o755)
+
+    return bin_dir, installed
 
 
 def _run(tmp_path: Path, *tools: str, version: str = "9.9.9") -> subprocess.CompletedProcess[str]:
-    bin_dir, calls = _stub_cargo(tmp_path, version)
+    known = tuple(tool for tool in tools if tool.startswith("cargo-") and "nonexistent" not in tool)
+    bin_dir, installed = _stub_env(tmp_path, known, version)
     env = {
         "PATH": f"{bin_dir}:/usr/bin:/bin",
-        "CALLS": str(calls),
-        # Pin every tool to what the stub reports, so the script takes its
-        # already-installed path and never shells out to a real install.
+        "CALLS": str(tmp_path / "calls.txt"),
+        "INSTALLED": str(installed),
+        # Pin every tool to what the stub reports installed, so the script takes
+        # its already-installed path and never shells out to a real install.
         "CARGO_LICENSE_VERSION": version,
         "CARGO_DENY_VERSION": version,
         "CARGO_AUDIT_VERSION": version,
@@ -72,7 +91,11 @@ def _run(tmp_path: Path, *tools: str, version: str = "9.9.9") -> subprocess.Comp
 
 
 def test_installs_each_tool_it_is_given(tmp_path: Path) -> None:
-    """Every named tool is checked, and the script reports each one."""
+    """Every named tool is checked, and the script reports each one.
+
+    The stubs refuse `--version` the way cargo-license does, so this also pins
+    that a tool without that flag is not mistaken for a broken install.
+    """
     result = _run(tmp_path, "cargo-license", "cargo-deny")
 
     assert result.returncode == 0, result.stderr
@@ -127,7 +150,8 @@ def test_the_source_fallback_is_locked(tmp_path: Path) -> None:
     installs = [
         line.strip()
         for line in body.splitlines()
-        if "cargo install" in line and not line.strip().startswith("#")
+        # `cargo install --list` reads what is installed; it installs nothing.
+        if "cargo install" in line and "--list" not in line and not line.strip().startswith("#")
     ]
 
     assert installs, "no cargo install lines found"

--- a/tests/ci/test_install_rust_cargo_tools.py
+++ b/tests/ci/test_install_rust_cargo_tools.py
@@ -1,0 +1,135 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 provide.io llc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Tests for ci/install-rust-cargo-tools.sh.
+
+Four workflows installed their cargo subcommands with bare `cargo install`, so
+each run resolved every tool's dependency tree afresh. When tinyvec 1.13.0 was
+published broken, `cargo install cargo-deny` could not build for four hours and
+License Compliance failed on a pull request whose own dependencies were fine.
+
+What these pin is that the install is reproducible -- a pinned version and
+`--locked` every time -- and that a tool which does not end up runnable fails
+here, naming the tool, rather than inside the check that needs it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.packaging]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "install-rust-cargo-tools.sh"
+
+# A cargo stub that records its arguments and reports the pinned version back,
+# so the script's "already installed" path is what runs.
+CARGO_STUB = """#!/bin/bash
+echo "$@" >> "$CALLS"
+if [ "$2" = "--version" ]; then
+    echo "$1 {version}"
+fi
+exit 0
+"""
+
+
+def _stub_cargo(tmp_path: Path, version: str = "9.9.9") -> tuple[Path, Path]:
+    """A PATH containing only a cargo stub, plus the file it logs calls to."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    calls = tmp_path / "calls.txt"
+
+    cargo = bin_dir / "cargo"
+    cargo.write_text(CARGO_STUB.format(version=version))
+    cargo.chmod(0o755)
+
+    return bin_dir, calls
+
+
+def _run(tmp_path: Path, *tools: str, version: str = "9.9.9") -> subprocess.CompletedProcess[str]:
+    bin_dir, calls = _stub_cargo(tmp_path, version)
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "CALLS": str(calls),
+        # Pin every tool to what the stub reports, so the script takes its
+        # already-installed path and never shells out to a real install.
+        "CARGO_LICENSE_VERSION": version,
+        "CARGO_DENY_VERSION": version,
+        "CARGO_AUDIT_VERSION": version,
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), *tools],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_installs_each_tool_it_is_given(tmp_path: Path) -> None:
+    """Every named tool is checked, and the script reports each one."""
+    result = _run(tmp_path, "cargo-license", "cargo-deny")
+
+    assert result.returncode == 0, result.stderr
+    assert "cargo-license" in result.stdout
+    assert "cargo-deny" in result.stdout
+
+
+def test_an_unknown_tool_fails_rather_than_installing_unpinned(tmp_path: Path) -> None:
+    """A typo in a workflow must not become an unpinned install.
+
+    Installing whatever that name resolves to on crates.io is the wrong
+    recovery: it is how an unreviewed dependency enters CI.
+    """
+    result = _run(tmp_path, "cargo-nonexistent")
+
+    assert result.returncode != 0
+    output = result.stdout + result.stderr
+    assert "cargo-nonexistent" in output
+    assert "unpinned" in output
+
+
+def test_calling_it_with_no_tools_fails(tmp_path: Path) -> None:
+    """An install step that installs nothing must not report success."""
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "Usage" in result.stdout + result.stderr
+
+
+def test_every_pinned_version_is_exact(tmp_path: Path) -> None:
+    """No pin is a range: `cargo install` must resolve one version, not the newest.
+
+    A caret or wildcard would put the tool's own release schedule back in the
+    build, which is the failure this script exists to prevent.
+    """
+    body = SCRIPT.read_text()
+    pins = [line.split(":-")[1].split("}")[0] for line in body.splitlines() if "_VERSION:-" in line]
+
+    assert pins, "no version pins found"
+    for pin in pins:
+        assert pin[0].isdigit(), f"pin is not an exact version: {pin}"
+        assert not any(char in pin for char in "^~*<>= "), f"pin is a range: {pin}"
+
+
+def test_the_source_fallback_is_locked(tmp_path: Path) -> None:
+    """Every `cargo install` in the script carries --locked.
+
+    Without it the tool's own lockfile is ignored and its dependencies resolve
+    afresh, which is exactly what let a broken upstream release fail CI.
+    """
+    body = SCRIPT.read_text()
+    installs = [
+        line.strip()
+        for line in body.splitlines()
+        if "cargo install" in line and not line.strip().startswith("#")
+    ]
+
+    assert installs, "no cargo install lines found"
+    for line in installs:
+        assert "--locked" in line, f"install is not locked: {line}"


### PR DESCRIPTION
## The failure this prevents

Four workflows installed their cargo subcommands with bare `cargo install`, so every run resolved each tool's full dependency tree afresh. Any upstream break anywhere in those trees turns a job red for reasons unrelated to this repository.

It already happened, on the 0.5.1 release PR:

| | |
|---|---|
| `tinyvec 1.13.0` published, broken | 2026-09-03 **21:13** |
| `🦀 Rust Licenses` failed installing `cargo-deny` | 2026-09-04 **01:24** |
| `tinyvec 1.13.1` published, fixed | 2026-09-04 **01:26** |

A two-hour window in someone else's crate failed a PR whose own dependencies were fine.

## The fix

`ci/install-rust-cargo-tools.sh` takes the tools a job needs and installs each at a **pinned version with `--locked`**, preferring a prebuilt binary via `cargo-binstall` and falling back to source.

Then it verifies each one is actually runnable, and fails **there** — where the message names the tool — rather than letting the job continue to a check whose missing subcommand reads as a check that found nothing wrong. That's the same reasoning as `ci/install-rust-quality-tools.sh`, which already did this for the one tool the quality gate runs; this extends it to the other four workflows.

An unknown tool name is refused rather than installed unpinned. Installing whatever a typo resolves to on crates.io is how an unreviewed dependency gets into CI.

## Two removals

- **`cargo-tree`** — `cargo tree` has been built into cargo since 1.44. The install was doing nothing the toolchain didn't already provide.
- **`cargo-udeps`** — installed by `dependency-audit.yml` and **never invoked** by it. Pure build time, and one more tree that could break the job.

## The other side of the same defect

`code-quality.yml` had `--locked` already, but wrote `|| true` after it:

```yaml
cargo install cargo-llvm-cov --locked || true
```

Reproducible, and then the failure swallowed — a failed install left the tools absent and the checks that need them silently doing nothing. Same defect as an unpinned install, reached from the other direction.

## Verification

Five tests (`tests/ci/` is now **73** over 11 scripts), driven by a `cargo` stub so nothing is really installed. They pin that an unknown tool fails, that installing nothing fails, that **every version pin is exact** (no caret, tilde or wildcard — a range would put the tool's release schedule back in the build), and that **every `cargo install` line carries `--locked`**.

Zero `cargo install` lines remain in any workflow. ShellCheck and the shell quality gate pass.

## Not covered

`dependency-audit.yml:523` runs `cargo machete ... || true`, which swallows that check's own result. Different defect from the install, left alone here.