### PR TITLE
Keep a git-sourced dependency in the payload, and relaunch a rebuilt package

### DIFF
--- a/src/flavor-rs/src/psp/format_2025/execution/validation.rs
+++ b/src/flavor-rs/src/psp/format_2025/execution/validation.rs
@@ -4,8 +4,8 @@ use super::super::index::Index;
 use super::super::metadata::{CacheValidationInfo, Metadata};
 use super::super::paths::WorkenvPaths;
 use super::placeholders::substitute_placeholders;
-use crate::exceptions::{FlavorError, Result};
-use log::{debug, warn};
+use crate::exceptions::Result;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::fs;
 
@@ -48,66 +48,29 @@ pub(super) fn validate_package_checksum(
     }
 }
 
+/// Reports a workenv built by a different package as unusable, at every
+/// validation level.
+///
+/// The stored value identifies the package that produced this workenv, so a
+/// mismatch means the cache belongs to another build and its contents are
+/// stale. Extraction runs again and replaces them.
+///
+/// This is a cache-validity question, not an authenticity one. Authenticity is
+/// settled earlier by signature verification, which runs on every launch and
+/// aborts under `Strict`. Neither checksum covers the extracted tree, so a
+/// mismatch says nothing about whether that tree was modified; re-extraction
+/// overwrites it either way.
 fn validate_package_checksum_mismatch(
     stored_checksum: &str,
     current_checksum: &str,
     validation_level: crate::psp::format_2025::defaults::ValidationLevel,
 ) -> Result<bool> {
-    use crate::psp::format_2025::defaults::ValidationLevel;
-
-    match validation_level {
-        ValidationLevel::None | ValidationLevel::Minimal => {
-            warn!(
-                "⚠️ SECURITY WARNING: Package checksum mismatch! cached: {}, current: {}",
-                stored_checksum, current_checksum
-            );
-            warn!("⚠️ Cache may be compromised or package has changed");
-            warn!(
-                "⚠️ Continuing due to validation level: {:?}",
-                validation_level
-            );
-            Ok(false)
-        }
-        ValidationLevel::Relaxed => {
-            warn!(
-                "⚠️ SECURITY WARNING: Package checksum mismatch! cached: {}, current: {}",
-                stored_checksum, current_checksum
-            );
-            warn!("⚠️ Cache may be compromised or package has changed");
-            warn!("⚠️ Continuing due to relaxed validation");
-            Ok(false)
-        }
-        ValidationLevel::Standard => {
-            eprintln!(
-                "🚨 SECURITY WARNING: Package checksum mismatch! cached: {}, current: {}",
-                stored_checksum, current_checksum
-            );
-            eprintln!("🚨 Cache may be compromised or package has changed");
-            eprintln!(
-                "🚨 Continuing with standard validation (use FLAVOR_VALIDATION=strict to enforce)"
-            );
-            warn!(
-                "⚠️ Package checksum mismatch, continuing with standard validation: cached: {}, current: {}",
-                stored_checksum, current_checksum
-            );
-            Ok(false)
-        }
-        ValidationLevel::Strict => {
-            log::error!(
-                "🚨 CRITICAL: Package checksum mismatch! cached: {}, current: {}",
-                stored_checksum,
-                current_checksum
-            );
-            log::error!("🚨 Cache may be compromised or package has changed");
-            log::error!(
-                "🚨 Refusing to continue. Set FLAVOR_VALIDATION=relaxed to bypass (NOT RECOMMENDED)"
-            );
-            Err(FlavorError::Generic(format!(
-                "package checksum mismatch: cached={}, current={}",
-                stored_checksum, current_checksum
-            )))
-        }
-    }
+    debug!(
+        "🔍 Work environment belongs to package {}, this one is {}; extracting again \
+         (validation level: {:?})",
+        stored_checksum, current_checksum, validation_level
+    );
+    Ok(false)
 }
 
 /// Save package checksum to cache
@@ -318,35 +281,23 @@ mod tests {
     }
 
     #[test]
-    fn validate_package_checksum_mismatch_varies_by_validation_level() {
-        assert!(
-            !validate_package_checksum_mismatch("deadbeef", "cafebabe", ValidationLevel::Relaxed)
-                .expect("relaxed mismatch should be non-fatal")
-        );
-        assert!(
-            !validate_package_checksum_mismatch("deadbeef", "cafebabe", ValidationLevel::Standard)
-                .expect("standard mismatch should be non-fatal")
-        );
-        assert!(
-            validate_package_checksum_mismatch("deadbeef", "cafebabe", ValidationLevel::Strict)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn validate_package_checksum_mismatch_none_level_is_non_fatal() {
-        assert!(
-            !validate_package_checksum_mismatch("deadbeef", "cafebabe", ValidationLevel::None)
-                .expect("none mismatch should be non-fatal")
-        );
-    }
-
-    #[test]
-    fn validate_package_checksum_mismatch_minimal_level_is_non_fatal() {
-        assert!(
-            !validate_package_checksum_mismatch("deadbeef", "cafebabe", ValidationLevel::Minimal)
-                .expect("minimal mismatch should be non-fatal")
-        );
+    fn a_rebuilt_package_invalidates_the_cache_rather_than_refusing() {
+        // A rebuilt package must stay launchable. The checksum identifies the
+        // package that filled the cache, so a mismatch means the cache is
+        // stale and extraction should run again -- the answer the missing-file
+        // branch already gives. Failing instead strands the package behind a
+        // hidden metadata directory only a hand-written `rm` can clear.
+        for level in [
+            ValidationLevel::None,
+            ValidationLevel::Minimal,
+            ValidationLevel::Relaxed,
+            ValidationLevel::Standard,
+            ValidationLevel::Strict,
+        ] {
+            let reusable = validate_package_checksum_mismatch("deadbeef", "cafebabe", level)
+                .unwrap_or_else(|err| panic!("{level:?} refused a rebuilt package: {err}"));
+            assert!(!reusable, "{level:?} reused a workenv from another package");
+        }
     }
 
     #[test]

--- a/src/flavor/packaging/python/pypapip_manager.py
+++ b/src/flavor/packaging/python/pypapip_manager.py
@@ -44,6 +44,9 @@ _WIN_PIP_NOTRUST_WRAPPER = (
     "sys.exit(main(sys.argv[1:]))"
 )
 
+#: Suffixes pip gives a downloaded source archive when no wheel is available.
+_SOURCE_ARCHIVE_SUFFIXES = (".zip", ".tar.gz", ".tar.bz2", ".tgz")
+
 
 def _pip_base_cmd(python_exe: Path) -> list[str]:
     """Return the base pip invocation.
@@ -285,8 +288,47 @@ class PyPaPipManager:
             error_msg += self._platform_failure_hint(result.stderr)
             logger.error(error_msg)
             raise RuntimeError(error_msg)
-        else:
-            logger.info("✅ Successfully downloaded all wheels")
+
+        self._build_downloaded_source_archives(python_exe, dest_dir)
+        logger.info("✅ Successfully downloaded all wheels")
+
+    def _build_downloaded_source_archives(self, python_exe: Path, dest_dir: Path) -> None:
+        """Turn any source archive in ``dest_dir`` into a wheel beside it.
+
+        ``--only-binary :all:`` governs what pip resolves from an index; a
+        direct reference such as ``name @ git+https://...`` is exempt and
+        arrives as a source archive. Every consumer of this directory
+        enumerates ``*.whl`` (``orchestrator_helpers.py:109`` and ``:672``), so
+        an archive left here is packed by nothing, installed by nothing, and
+        reported by nothing: the payload ships without that dependency while
+        the build reports success. Branch pins produce exactly this shape.
+        """
+        archives = [
+            path
+            for path in sorted(dest_dir.iterdir())
+            if path.is_file() and path.name.endswith(_SOURCE_ARCHIVE_SUFFIXES)
+        ]
+        if not archives:
+            return
+
+        logger.info(
+            "🌐🛠️ Building wheels for source archives",
+            archives=[path.name for path in archives],
+        )
+        for archive in archives:
+            wheel_cmd = self._get_pypapip_wheel_cmd(
+                python_exe=python_exe,
+                wheel_dir=dest_dir,
+                source=archive,
+                no_deps=True,
+            )
+            logger.debug("💻 Building wheel from source archive", command=" ".join(wheel_cmd))
+            built = run(wheel_cmd, check=False, capture_output=True, env=_windows_system_env() or None)
+            if built.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to build a wheel from {archive.name}, which the payload needs: {built.stderr}"
+                )
+            archive.unlink()
 
     @retry(
         ConnectionError,

--- a/tests/packaging/python/test_pypapip_manager.py
+++ b/tests/packaging/python/test_pypapip_manager.py
@@ -288,6 +288,54 @@ class TestPyPaPipManager:
             assert "--python-version" in cmd_312 and "3.12" in cmd_312
 
     @patch("flavor.packaging.python.pypapip_manager.run")
+    def test_a_source_archive_is_turned_into_a_wheel(self, mock_run: Mock) -> None:
+        """Everything downstream enumerates `*.whl`, so an sdist must be built.
+
+        `--only-binary :all:` constrains what pip resolves from an index, not a
+        direct reference: `name @ git+https://...` is fetched as a source
+        archive. The packer globs `*.whl` (orchestrator_helpers.py:109, :672),
+        so an archive left beside the wheels is packed by nothing and reported
+        by nothing -- the payload ships without that dependency.
+        """
+        mock_run.return_value = Mock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = Path(tmp)
+            (dest_dir / "attrs-25.1.0-py3-none-any.whl").write_bytes(b"wheel")
+            (dest_dir / "pyvider-0.6.2.zip").write_bytes(b"sdist")
+
+            requirements_file = dest_dir / "requirements.txt"
+            requirements_file.write_text("pyvider @ git+https://example.invalid/pyvider@main\n")
+
+            self.pip_manager.download_wheels_from_requirements(
+                Path("/usr/bin/python3"), requirements_file, dest_dir
+            )
+
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        built = [cmd for cmd in commands if "wheel" in cmd]
+        assert built, f"the source archive was never built into a wheel; ran: {commands}"
+        assert any("pyvider-0.6.2.zip" in " ".join(cmd) for cmd in built), (
+            "a command built a wheel, but not from the archive that needs one"
+        )
+
+    @patch("flavor.packaging.python.pypapip_manager.run")
+    def test_wheels_alone_need_no_building(self, mock_run: Mock) -> None:
+        """The common case stays a single download."""
+        mock_run.return_value = Mock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = Path(tmp)
+            (dest_dir / "attrs-25.1.0-py3-none-any.whl").write_bytes(b"wheel")
+            requirements_file = dest_dir / "requirements.txt"
+            requirements_file.write_text("attrs\n")
+
+            self.pip_manager.download_wheels_from_requirements(
+                Path("/usr/bin/python3"), requirements_file, dest_dir
+            )
+
+        assert mock_run.call_count == 1, "a build ran with nothing to build"
+
+    @patch("flavor.packaging.python.pypapip_manager.run")
     def test_download_wheels_from_requirements(self, mock_run: Mock) -> None:
         """Test downloading wheels from requirements file."""
         mock_result = Mock()
@@ -301,7 +349,8 @@ class TestPyPaPipManager:
 
         try:
             python_exe = Path("/usr/bin/python3")
-            dest_dir = Path("/tmp/wheels")
+            dest_stack = tempfile.TemporaryDirectory()
+            dest_dir = Path(dest_stack.name)
 
             self.pip_manager.download_wheels_from_requirements(python_exe, requirements_file, dest_dir)
 
@@ -314,7 +363,7 @@ class TestPyPaPipManager:
             assert cmd[0] == "/usr/bin/python3"
             assert "download" in cmd
             assert "--dest" in cmd
-            assert "/tmp/wheels" in cmd
+            assert dest_dir.as_posix() in cmd
             assert "-r" in cmd
             # Normalize path separators for cross-platform comparison
             assert any(str(requirements_file).replace("\\", "/") == c.replace("\\", "/") for c in cmd)


### PR DESCRIPTION
Two faults met in the same workflow — pinning a dependency to a branch, then rebuilding the package. Together they produced a package that installed without its main dependency and then refused to start. Found while putting a `pyvider` branch through the Terraform example corpus.

## A git-sourced dependency was dropped from the payload

`--only-binary :all:` governs what pip resolves from an index; a direct reference such as `name @ git+https://…` is exempt and arrives as a **source archive**. Every consumer of the download directory enumerates `*.whl` (`orchestrator_helpers.py:109`, `:672`), so the archive was packed by nothing, installed by nothing, and reported by nothing.

`flavor pack` exited 0. The payload's `site-packages/pyvider/` held only the subpackages contributed by sibling distributions, with no `pyvider-*.dist-info` at all, and the entry point died with `ModuleNotFoundError: No module named 'pyvider.cli'`.

`download_wheels_from_requirements` now builds a wheel from any source archive it finds, and raises if it cannot.

Verified against the real requirement: `pyvider-0.6.2.zip` is built to `pyvider-0.6.2-py3-none-any.whl`, leaving zero non-wheel files.

## A rebuilt package could not launch

The stored checksum identifies the package that filled a workenv, so a mismatch means the cache is stale — what the missing-file branch already reports as `Ok(false)`. Under `Strict` it returned an error instead, leaving the package unlaunchable until `~/.cache/flavor/workenv/.{name}.pspf` was deleted by hand. That directory is hidden, and clearing the visible `workenv/{name}` does not touch it, so the failure reads as a corrupt package:

```
🚨 CRITICAL: Package checksum mismatch! cached: b39e67df, current: 7782681f
❌ Package integrity check failed
```

A mismatch now invalidates the cache at every validation level, as the Go launcher does (`internal/workenv/validation.go:41`).

### This changes no security property

Package authenticity is settled by signature verification, which runs on every launch and aborts under `Strict` (`launcher/mod.rs:149-175`). The checksum comparison runs afterwards, on an already-verified package. Neither checksum covers the extracted tree, so a mismatch never said anything about whether that tree had been modified — and re-extraction overwrites it, where refusing left it in place. The warnings claiming a compromised cache went with it, having fired on every legitimate rebuild.

## Verification

| gate | result |
|---|---|
| `pytest` (single process) | 2864 passed |
| `cargo test --lib` | 306 passed |
| ruff check / format | clean |
| mypy | 91 source files, no issues |
| clippy `-D warnings` | clean |

Tests written before the fixes, both watched fail first. One pre-existing test passed a `/tmp/wheels` path that never existed — nothing looked at the directory before — and now uses a real temporary one, with its assertions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhi1SLuFiEseRhH9iLMv8Q