### PR TITLE
build: setuptools 83.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "provide-foundation[cli,compression,crypto,transport,platform]>=0.4.1; sys_platform == 'win32' and platform_machine == 'ARM64'",
     "pip>=25.2",
     "uv>=0.9.6",
-    "setuptools==82.0.1",  # Pinned to match build-backends group; checked by _ensure_no_isolation_build_backend
+    "setuptools==83.0.0",  # Pinned to match build-backends group; checked by _ensure_no_isolation_build_backend
     "wheel==0.46.3",       # Required for building wheels; pinned to match build-backends group
 ]
 keywords = ["packaging", "pspf", "flavor", "executable", "bundle"]
@@ -79,7 +79,7 @@ docs = [
     "mkdocs-mermaid2-plugin>=1.1.0",
 ]
 build-backends = [
-    "setuptools==82.0.1",
+    "setuptools==83.0.0",
     "wheel==0.46.3",
 ]
 

--- a/src/flavor/packaging/python/wheel_builder.py
+++ b/src/flavor/packaging/python/wheel_builder.py
@@ -27,7 +27,7 @@ from flavor.packaging.python.uv_manager import UVManager
 # These must match [dependency-groups.build-backends] in pyproject.toml.
 # To update: change the version in pyproject.toml, run `uv lock`, update here.
 _PINNED_BUILD_BACKENDS: dict[str, str] = {
-    "setuptools": "82.0.1",
+    "setuptools": "83.0.0",
     "wheel": "0.46.3",
 }
 

--- a/tests/packaging/python/test_slot_builder_build_backends.py
+++ b/tests/packaging/python/test_slot_builder_build_backends.py
@@ -46,7 +46,7 @@ class TestBundleBuildBackends:
             (manifest_dir / "pyproject.toml").write_text(
                 '[project]\nname = "foo"\n'
                 "[dependency-groups]\n"
-                'build-backends = ["setuptools==82.0.1", "wheel==0.46.3"]\n'
+                'build-backends = ["setuptools==83.0.0", "wheel==0.46.3"]\n'
             )
             (manifest_dir / "uv.lock").write_text("# mock lock file\n")
             wheels_dir = manifest_dir / "wheels"
@@ -82,7 +82,7 @@ class TestBundleBuildBackends:
         with tempfile.TemporaryDirectory() as tmp:
             manifest_dir = Path(tmp)
             (manifest_dir / "pyproject.toml").write_text(
-                '[project]\nname = "foo"\n[dependency-groups]\nbuild-backends = ["setuptools==82.0.1"]\n'
+                '[project]\nname = "foo"\n[dependency-groups]\nbuild-backends = ["setuptools==83.0.0"]\n'
             )
             # No uv.lock created
             wheels_dir = manifest_dir / "wheels"
@@ -99,7 +99,7 @@ class TestBundleBuildBackends:
             (manifest_dir / "pyproject.toml").write_text(
                 '[project]\nname = "foo"\n'
                 "[dependency-groups]\n"
-                'build-backends = ["setuptools==82.0.1", "wheel==0.46.3"]\n'
+                'build-backends = ["setuptools==83.0.0", "wheel==0.46.3"]\n'
             )
             (manifest_dir / "uv.lock").write_text("# mock lock file\n")
             wheels_dir = manifest_dir / "wheels"

--- a/tests/taster/pyproject.toml
+++ b/tests/taster/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "provide-foundation[cli,compression,crypto,transport,platform]>=0.4.0; sys_platform == 'win32' and platform_machine == 'ARM64'",
     # exec-test calls build_package_from_manifest() which requires these pinned build
     # backends in the workenv via importlib_metadata (must match flavorpack>=0.4.0's pins)
-    "setuptools==82.0.1",
+    "setuptools==83.0.0",
     "wheel==0.46.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -901,14 +901,14 @@ requires-dist = [
     { name = "pip", specifier = ">=25.2" },
     { name = "provide-foundation", extras = ["all"], marker = "platform_machine != 'ARM64' or sys_platform != 'win32'", specifier = ">=0.4.1" },
     { name = "provide-foundation", extras = ["cli", "compression", "crypto", "platform", "transport"], marker = "platform_machine == 'ARM64' and sys_platform == 'win32'", specifier = ">=0.4.1" },
-    { name = "setuptools", specifier = "==82.0.1" },
+    { name = "setuptools", specifier = "==83.0.0" },
     { name = "uv", specifier = ">=0.9.6" },
     { name = "wheel", specifier = "==0.46.3" },
 ]
 
 [package.metadata.requires-dev]
 build-backends = [
-    { name = "setuptools", specifier = "==82.0.1" },
+    { name = "setuptools", specifier = "==83.0.0" },
     { name = "wheel", specifier = "==0.46.3" },
 ]
 dev = [
@@ -3748,11 +3748,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears **PYSEC-2026-3447**, fixed in setuptools 83.0.0.

Unlike the other finding in this lock, nothing platform-shaped is in the way: setuptools publishes `py3-none-any` at every version, so this pin has never had anything to do with wheel availability. It is pinned exactly because `_ensure_no_isolation_build_backend` refuses a no-isolation build unless the installed backend matches, byte for byte, what the `build-backends` group declares.

## Six places, moved together

That runtime equality check exists because the version lives in six:

| | |
|---|---|
| `pyproject.toml:42` | project dependencies |
| `pyproject.toml:82` | `build-backends` group |
| `wheel_builder.py:30` | `_PINNED_BUILD_BACKENDS` |
| `test_slot_builder_build_backends.py` | three fixtures |
| `tests/taster/pyproject.toml` | fixture project |

All six moved. A partial bump fails the assertion rather than drifting quietly, which is the point of having it — but six copies of one constant is worth a follow-up on its own terms.

## Result

| | advisories |
|---|---|
| before | 13 |
| after | **11** |

What remains is `cryptography` 46.0.3, held by `[tool.uv] constraint-dependencies`. **Upstream has not restored the win_arm64 wheel** — checked against PyPI, no release from 46.0.4 through 50.0.1 publishes one:

| version | win_arm64 |
|---|---|
| 46.0.3 | yes |
| 46.0.4 – 46.0.7 | no |
| 47.0.0 – 50.0.1 | no |

`flavor-pipeline.yml` builds `windows_arm64` on a `windows-11-arm` runner, so the cap is load-bearing rather than vestigial. Raising it is a decision about that platform, not a version bump — see the earlier discussion for the marker-split option that would keep 46.0.3 only where the wheel is missing.

## Verification

Suite: `2864 passed, 5 deselected`, single process, with setuptools 83.0.0 actually installed (checked, not assumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhi1SLuFiEseRhH9iLMv8Q