### PR TITLE
fix(launcher): treat an unset cache variable and an empty one alike

### DIFF
--- a/src/flavor-rs/src/utils/mod.rs
+++ b/src/flavor-rs/src/utils/mod.rs
@@ -38,31 +38,59 @@ pub fn get_platform_string() -> String {
 /// Get the appropriate cache directory for the current platform
 /// Uses XDG Base Directory Specification for consistency across all platforms
 pub fn get_cache_dir() -> std::path::PathBuf {
+    resolve_cache_dir(
+        env::var_os(crate::env_vars::CACHE_DIR),
+        env::var_os("XDG_CACHE_HOME"),
+        env::var_os("HOME"),
+        env::var_os("LOCALAPPDATA"),
+        env::temp_dir(),
+    )
+}
+
+/// Treat a variable that is set to nothing as one that is not set.
+///
+/// `var_os` reports an empty value as `Some("")`, and joining that onto a
+/// relative suffix yields a relative cache directory -- one that lands wherever
+/// the process happens to be running rather than under a home. A caller that
+/// builds a child environment from `os.environ.get("HOME", "")` produces
+/// exactly that value on a platform with no HOME.
+fn non_empty(value: Option<std::ffi::OsString>) -> Option<std::ffi::OsString> {
+    value.filter(|v| !v.is_empty())
+}
+
+/// Resolve the cache directory from already-read environment values.
+///
+/// Split from `get_cache_dir` so the ordering is reachable from a test. The
+/// LOCALAPPDATA fallback is not compiled out on other platforms: nothing sets
+/// it there, so it costs a `None` check and stays exercised by the suite.
+fn resolve_cache_dir(
+    cache_dir: Option<std::ffi::OsString>,
+    xdg_cache: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+    local_app_data: Option<std::ffi::OsString>,
+    temp_dir: std::path::PathBuf,
+) -> std::path::PathBuf {
     use std::path::PathBuf;
 
-    if let Ok(cache_dir) = env::var(crate::env_vars::CACHE_DIR) {
+    if let Some(cache_dir) = non_empty(cache_dir) {
         return PathBuf::from(cache_dir);
     }
 
-    // Use XDG_CACHE_HOME if set, otherwise ~/.cache
-    // This provides consistency across all Unix-like platforms (Linux, macOS, BSDs)
-    if let Ok(xdg_cache) = env::var("XDG_CACHE_HOME") {
+    // XDG_CACHE_HOME if set, otherwise ~/.cache. This provides consistency
+    // across all Unix-like platforms (Linux, macOS, BSDs).
+    if let Some(xdg_cache) = non_empty(xdg_cache) {
         return PathBuf::from(xdg_cache).join("flavor");
     }
 
-    if let Some(home) = env::var_os("HOME") {
+    if let Some(home) = non_empty(home) {
         return PathBuf::from(home).join(".cache/flavor");
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        if let Ok(local_app_data) = env::var("LOCALAPPDATA") {
-            return PathBuf::from(local_app_data).join("flavor/cache");
-        }
+    if let Some(local_app_data) = non_empty(local_app_data) {
+        return PathBuf::from(local_app_data).join("flavor/cache");
     }
 
-    // Fallback to temp directory
-    env::temp_dir().join("flavor")
+    temp_dir.join("flavor")
 }
 
 #[cfg(test)]
@@ -83,26 +111,65 @@ mod tests {
         assert!(platform.contains('_'));
     }
 
-    #[test]
-    fn get_cache_dir_prefers_explicit_override() {
-        let dir = env::temp_dir().join("flavor-cache-test");
-        let value = dir.to_string_lossy().into_owned();
-        let resolved = get_cache_dir_from_env(Some(&value), None, None);
-        assert_eq!(resolved, dir);
+    fn os(value: &str) -> Option<std::ffi::OsString> {
+        Some(std::ffi::OsString::from(value))
+    }
+
+    fn temp() -> std::path::PathBuf {
+        std::path::PathBuf::from("/var/tmp")
     }
 
     #[test]
-    fn get_cache_dir_prefers_xdg_then_home_then_temp() {
-        let xdg = get_cache_dir_from_env(None, Some("/tmp/xdg-cache"), Some("/tmp/home"));
-        assert_eq!(
-            xdg,
-            std::path::PathBuf::from("/tmp/xdg-cache").join("flavor")
-        );
+    fn cache_dir_prefers_explicit_override() {
+        let resolved = resolve_cache_dir(os("/cache"), os("/xdg"), os("/home"), None, temp());
+        assert_eq!(resolved, std::path::PathBuf::from("/cache"));
+    }
 
-        let home = get_cache_dir_from_env(None, None, Some("/tmp/home"));
+    #[test]
+    fn cache_dir_prefers_xdg_then_home_then_temp() {
+        let xdg = resolve_cache_dir(None, os("/xdg-cache"), os("/home"), None, temp());
+        assert_eq!(xdg, std::path::PathBuf::from("/xdg-cache").join("flavor"));
+
+        let home = resolve_cache_dir(None, None, os("/home"), None, temp());
         assert_eq!(
             home,
-            std::path::PathBuf::from("/tmp/home").join(".cache/flavor")
+            std::path::PathBuf::from("/home").join(".cache/flavor")
+        );
+
+        let fallback = resolve_cache_dir(None, None, None, None, temp());
+        assert_eq!(fallback, temp().join("flavor"));
+    }
+
+    #[test]
+    fn cache_dir_is_absolute_when_home_is_set_to_nothing() {
+        // A caller building a child environment from `os.environ.get("HOME", "")`
+        // passes an empty value on a platform with no HOME. Joining onto it
+        // yields `.cache/flavor`, which resolves against the child's working
+        // directory instead of a home.
+        let resolved = resolve_cache_dir(None, None, os(""), None, temp());
+        assert!(
+            resolved.is_absolute(),
+            "empty HOME produced a relative cache directory: {resolved:?}"
+        );
+        assert_eq!(resolved, temp().join("flavor"));
+    }
+
+    #[test]
+    fn cache_dir_falls_back_to_local_app_data_when_home_is_empty() {
+        let resolved =
+            resolve_cache_dir(None, None, os(""), os("C:/Users/r/AppData/Local"), temp());
+        assert_eq!(
+            resolved,
+            std::path::PathBuf::from("C:/Users/r/AppData/Local").join("flavor/cache")
+        );
+    }
+
+    #[test]
+    fn cache_dir_ignores_an_empty_override() {
+        let resolved = resolve_cache_dir(os(""), os(""), os("/home"), None, temp());
+        assert_eq!(
+            resolved,
+            std::path::PathBuf::from("/home").join(".cache/flavor")
         );
     }
 
@@ -114,24 +181,5 @@ mod tests {
             }
             None => false,
         }
-    }
-
-    fn get_cache_dir_from_env(
-        cache_dir: Option<&str>,
-        xdg_cache: Option<&str>,
-        home: Option<&str>,
-    ) -> std::path::PathBuf {
-        use std::path::PathBuf;
-
-        if let Some(cache_dir) = cache_dir {
-            return PathBuf::from(cache_dir);
-        }
-        if let Some(xdg_cache) = xdg_cache {
-            return PathBuf::from(xdg_cache).join("flavor");
-        }
-        if let Some(home) = home {
-            return PathBuf::from(home).join(".cache/flavor");
-        }
-        env::temp_dir().join("flavor")
     }
 }


### PR DESCRIPTION
## Problem

`get_cache_dir()` reads `HOME` with `env::var_os`, which reports a variable *set to nothing* as `Some("")`. Joining that onto a relative suffix yields:

```
PathBuf::from("").join(".cache/flavor")  ->  ".cache/flavor"   // relative
```

The launcher then resolves its work environment against whatever working directory it inherited, instead of against a home.

A caller that builds a child environment with `os.environ.get("HOME", "")` passes exactly that empty value on a platform with no `HOME`. tofusoup's conformance driver did this on Windows (fixed separately in provide-io/tofusoup#25).

Verified, not inferred:

```
var_os -> Some("")
joined  -> ".cache/flavor"
absolute? false
```

A genuinely *unset* `HOME` returns `None`, so the `LOCALAPPDATA` arm was reachable on a stock Windows box — but not under git-bash, which always sets `HOME`.

## Change

- An env variable set to the empty string is treated as unset, for all four inputs.
- The resolution order moves into `resolve_cache_dir(cache, xdg, home, local_app_data, temp)`, taking values as arguments.
- The `LOCALAPPDATA` arm is no longer `#[cfg]`-gated away on other platforms: nothing sets it there, so it costs one `None` check and stays exercised by the suite.

## The tests were testing a copy

`get_cache_dir_from_env` was defined **inside the `#[cfg(test)]` module** — a reimplementation of the production logic, not the production logic. The shipped ordering in `get_cache_dir` had no coverage, and the two could drift indefinitely without a failure. The tests now drive the real function; the duplicate is gone.

Red proven by neutralising the fix:

```
cache_dir_is_absolute_when_home_is_set_to_nothing ... FAILED
  empty HOME produced a relative cache directory: ".cache/flavor"
cache_dir_falls_back_to_local_app_data_when_home_is_empty ... FAILED
cache_dir_ignores_an_empty_override ... FAILED
```

Restored: 315 passed, `cargo fmt` clean, 0 clippy diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhi1SLuFiEseRhH9iLMv8Q